### PR TITLE
feat: implement system namespace and control-plane consensus (#13)

### DIFF
--- a/src/control_plane/consensus.rs
+++ b/src/control_plane/consensus.rs
@@ -1,0 +1,243 @@
+use std::collections::HashSet;
+
+use crate::error::CrdtError;
+use crate::placement::PlacementPolicy;
+use crate::types::NodeId;
+
+use super::system_namespace::{AuthorityDefinition, SystemNamespace};
+
+/// Simulates control-plane Authority consensus for system namespace updates.
+/// In MVP, this is a simple majority check (FR-009).
+pub struct ControlPlaneConsensus {
+    namespace: SystemNamespace,
+    authority_nodes: Vec<NodeId>,
+}
+
+impl ControlPlaneConsensus {
+    /// Creates a new consensus instance with the given authority nodes.
+    pub fn new(authority_nodes: Vec<NodeId>) -> Self {
+        Self {
+            namespace: SystemNamespace::new(),
+            authority_nodes,
+        }
+    }
+
+    /// Returns a reference to the managed system namespace.
+    pub fn namespace(&self) -> &SystemNamespace {
+        &self.namespace
+    }
+
+    /// Proposes a placement policy update. Applies only if a majority of
+    /// authority nodes have approved.
+    pub fn propose_policy_update(
+        &mut self,
+        policy: PlacementPolicy,
+        approvals: &[NodeId],
+    ) -> Result<(), CrdtError> {
+        if !self.has_majority(approvals) {
+            return Err(CrdtError::PolicyDenied(
+                "insufficient approvals for policy update".into(),
+            ));
+        }
+        self.namespace.set_placement_policy(policy);
+        Ok(())
+    }
+
+    /// Proposes an authority definition update. Applies only if a majority of
+    /// authority nodes have approved.
+    pub fn propose_authority_update(
+        &mut self,
+        def: AuthorityDefinition,
+        approvals: &[NodeId],
+    ) -> Result<(), CrdtError> {
+        if !self.has_majority(approvals) {
+            return Err(CrdtError::PolicyDenied(
+                "insufficient approvals for authority update".into(),
+            ));
+        }
+        self.namespace.set_authority_definition(def);
+        Ok(())
+    }
+
+    /// Returns `true` if the given approvals constitute a majority of the
+    /// authority nodes.
+    pub fn has_majority(&self, approvals: &[NodeId]) -> bool {
+        let authority_set: HashSet<&NodeId> = self.authority_nodes.iter().collect();
+        let valid_approvals = approvals
+            .iter()
+            .filter(|a| authority_set.contains(a))
+            .count();
+        let majority = self.authority_nodes.len() / 2 + 1;
+        valid_approvals >= majority
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::{KeyRange, PolicyVersion};
+
+    fn node_id(s: &str) -> NodeId {
+        NodeId(s.into())
+    }
+
+    fn key_range(prefix: &str) -> KeyRange {
+        KeyRange {
+            prefix: prefix.into(),
+        }
+    }
+
+    fn make_policy(prefix: &str) -> PlacementPolicy {
+        PlacementPolicy::new(PolicyVersion(1), key_range(prefix), 3)
+    }
+
+    fn make_authority_def(prefix: &str, nodes: &[&str]) -> AuthorityDefinition {
+        AuthorityDefinition {
+            key_range: key_range(prefix),
+            authority_nodes: nodes.iter().map(|s| node_id(s)).collect(),
+        }
+    }
+
+    fn three_node_consensus() -> ControlPlaneConsensus {
+        ControlPlaneConsensus::new(vec![node_id("n1"), node_id("n2"), node_id("n3")])
+    }
+
+    // --- has_majority ---
+
+    #[test]
+    fn has_majority_with_all_nodes() {
+        let c = three_node_consensus();
+        assert!(c.has_majority(&[node_id("n1"), node_id("n2"), node_id("n3")]));
+    }
+
+    #[test]
+    fn has_majority_with_exact_majority() {
+        let c = three_node_consensus();
+        assert!(c.has_majority(&[node_id("n1"), node_id("n2")]));
+    }
+
+    #[test]
+    fn no_majority_with_minority() {
+        let c = three_node_consensus();
+        assert!(!c.has_majority(&[node_id("n1")]));
+    }
+
+    #[test]
+    fn no_majority_with_empty_approvals() {
+        let c = three_node_consensus();
+        assert!(!c.has_majority(&[]));
+    }
+
+    #[test]
+    fn non_authority_nodes_ignored() {
+        let c = three_node_consensus();
+        // "n4" is not an authority node, so only "n1" counts
+        assert!(!c.has_majority(&[node_id("n1"), node_id("n4")]));
+    }
+
+    #[test]
+    fn has_majority_five_nodes() {
+        let c = ControlPlaneConsensus::new(vec![
+            node_id("n1"),
+            node_id("n2"),
+            node_id("n3"),
+            node_id("n4"),
+            node_id("n5"),
+        ]);
+        // majority of 5 is 3
+        assert!(c.has_majority(&[node_id("n1"), node_id("n2"), node_id("n3")]));
+        assert!(!c.has_majority(&[node_id("n1"), node_id("n2")]));
+    }
+
+    // --- propose_policy_update ---
+
+    #[test]
+    fn propose_policy_with_majority_succeeds() {
+        let mut c = three_node_consensus();
+        let result = c.propose_policy_update(make_policy("user/"), &[node_id("n1"), node_id("n2")]);
+        assert!(result.is_ok());
+        assert!(c.namespace().get_placement_policy("user/").is_some());
+    }
+
+    #[test]
+    fn propose_policy_without_majority_fails() {
+        let mut c = three_node_consensus();
+        let result = c.propose_policy_update(make_policy("user/"), &[node_id("n1")]);
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            CrdtError::PolicyDenied(msg) => {
+                assert!(msg.contains("insufficient approvals"));
+            }
+            other => panic!("unexpected error: {other}"),
+        }
+        assert!(c.namespace().get_placement_policy("user/").is_none());
+    }
+
+    #[test]
+    fn propose_policy_increments_version() {
+        let mut c = three_node_consensus();
+        let approvals = [node_id("n1"), node_id("n2")];
+        assert_eq!(*c.namespace().version(), PolicyVersion(1));
+
+        c.propose_policy_update(make_policy("user/"), &approvals)
+            .unwrap();
+        assert_eq!(*c.namespace().version(), PolicyVersion(2));
+
+        c.propose_policy_update(make_policy("order/"), &approvals)
+            .unwrap();
+        assert_eq!(*c.namespace().version(), PolicyVersion(3));
+    }
+
+    // --- propose_authority_update ---
+
+    #[test]
+    fn propose_authority_with_majority_succeeds() {
+        let mut c = three_node_consensus();
+        let result = c.propose_authority_update(
+            make_authority_def("user/", &["a1", "a2", "a3"]),
+            &[node_id("n1"), node_id("n2")],
+        );
+        assert!(result.is_ok());
+        let def = c.namespace().get_authority_definition("user/").unwrap();
+        assert_eq!(def.authority_nodes.len(), 3);
+    }
+
+    #[test]
+    fn propose_authority_without_majority_fails() {
+        let mut c = three_node_consensus();
+        let result =
+            c.propose_authority_update(make_authority_def("user/", &["a1"]), &[node_id("n1")]);
+        assert!(result.is_err());
+        assert!(c.namespace().get_authority_definition("user/").is_none());
+    }
+
+    // --- namespace access ---
+
+    #[test]
+    fn namespace_reflects_approved_changes() {
+        let mut c = three_node_consensus();
+        let approvals = [node_id("n1"), node_id("n2")];
+
+        c.propose_policy_update(make_policy("user/"), &approvals)
+            .unwrap();
+        c.propose_authority_update(make_authority_def("user/", &["a1", "a2"]), &approvals)
+            .unwrap();
+
+        assert_eq!(c.namespace().all_placement_policies().len(), 1);
+        assert_eq!(c.namespace().all_authority_definitions().len(), 1);
+        assert_eq!(*c.namespace().version(), PolicyVersion(3));
+    }
+
+    #[test]
+    fn failed_proposals_do_not_change_namespace() {
+        let mut c = three_node_consensus();
+        let insufficient = [node_id("n1")];
+
+        let _ = c.propose_policy_update(make_policy("user/"), &insufficient);
+        let _ = c.propose_authority_update(make_authority_def("user/", &["a1"]), &insufficient);
+
+        assert!(c.namespace().all_placement_policies().is_empty());
+        assert!(c.namespace().all_authority_definitions().is_empty());
+        assert_eq!(*c.namespace().version(), PolicyVersion(1));
+    }
+}

--- a/src/control_plane/mod.rs
+++ b/src/control_plane/mod.rs
@@ -1,0 +1,2 @@
+pub mod consensus;
+pub mod system_namespace;

--- a/src/control_plane/system_namespace.rs
+++ b/src/control_plane/system_namespace.rs
@@ -1,0 +1,367 @@
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+
+use crate::placement::PlacementPolicy;
+use crate::types::{KeyRange, NodeId, PolicyVersion};
+
+/// Defines which nodes are authorities for a key range.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AuthorityDefinition {
+    pub key_range: KeyRange,
+    pub authority_nodes: Vec<NodeId>,
+}
+
+/// The system namespace stores all control-plane configuration.
+/// Updates require control-plane Authority consensus (FR-009).
+#[derive(Debug, Clone)]
+pub struct SystemNamespace {
+    version: PolicyVersion,
+    placement_policies: HashMap<String, PlacementPolicy>,
+    authority_definitions: HashMap<String, AuthorityDefinition>,
+    /// History of policy versions for observability (NFR-004).
+    version_history: Vec<PolicyVersion>,
+}
+
+impl SystemNamespace {
+    /// Creates a new empty system namespace at version 1.
+    pub fn new() -> Self {
+        let initial_version = PolicyVersion(1);
+        Self {
+            version: initial_version,
+            placement_policies: HashMap::new(),
+            authority_definitions: HashMap::new(),
+            version_history: vec![initial_version],
+        }
+    }
+
+    /// Returns the current policy version.
+    pub fn version(&self) -> &PolicyVersion {
+        &self.version
+    }
+
+    /// Adds or updates a placement policy, keyed by its key range prefix.
+    /// Increments the namespace version.
+    pub fn set_placement_policy(&mut self, policy: PlacementPolicy) {
+        let prefix = policy.key_range.prefix.clone();
+        self.placement_policies.insert(prefix, policy);
+        self.bump_version();
+    }
+
+    /// Returns the placement policy for the given prefix, if any.
+    pub fn get_placement_policy(&self, prefix: &str) -> Option<&PlacementPolicy> {
+        self.placement_policies.get(prefix)
+    }
+
+    /// Removes and returns the placement policy for the given prefix.
+    /// Increments the namespace version if a policy was removed.
+    pub fn remove_placement_policy(&mut self, prefix: &str) -> Option<PlacementPolicy> {
+        let removed = self.placement_policies.remove(prefix);
+        if removed.is_some() {
+            self.bump_version();
+        }
+        removed
+    }
+
+    /// Returns all placement policies.
+    pub fn all_placement_policies(&self) -> Vec<&PlacementPolicy> {
+        self.placement_policies.values().collect()
+    }
+
+    /// Defines the authority set for a key range, keyed by its prefix.
+    /// Increments the namespace version.
+    pub fn set_authority_definition(&mut self, def: AuthorityDefinition) {
+        let prefix = def.key_range.prefix.clone();
+        self.authority_definitions.insert(prefix, def);
+        self.bump_version();
+    }
+
+    /// Returns the authority definition for the given prefix, if any.
+    pub fn get_authority_definition(&self, prefix: &str) -> Option<&AuthorityDefinition> {
+        self.authority_definitions.get(prefix)
+    }
+
+    /// Returns all authority definitions.
+    pub fn all_authority_definitions(&self) -> Vec<&AuthorityDefinition> {
+        self.authority_definitions.values().collect()
+    }
+
+    /// Returns the version history for observability (NFR-004).
+    pub fn version_history(&self) -> &[PolicyVersion] {
+        &self.version_history
+    }
+
+    /// Finds the authority definition whose key range prefix matches the given key.
+    /// Uses longest-prefix match.
+    pub fn get_authorities_for_key(&self, key: &str) -> Option<&AuthorityDefinition> {
+        self.authority_definitions
+            .iter()
+            .filter(|(prefix, _)| key.starts_with(prefix.as_str()))
+            .max_by_key(|(prefix, _)| prefix.len())
+            .map(|(_, def)| def)
+    }
+
+    fn bump_version(&mut self) {
+        self.version = PolicyVersion(self.version.0 + 1);
+        self.version_history.push(self.version);
+    }
+}
+
+impl Default for SystemNamespace {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn key_range(prefix: &str) -> KeyRange {
+        KeyRange {
+            prefix: prefix.into(),
+        }
+    }
+
+    fn make_policy(prefix: &str) -> PlacementPolicy {
+        PlacementPolicy::new(PolicyVersion(1), key_range(prefix), 3)
+    }
+
+    fn make_authority_def(prefix: &str, nodes: &[&str]) -> AuthorityDefinition {
+        AuthorityDefinition {
+            key_range: key_range(prefix),
+            authority_nodes: nodes.iter().map(|s| NodeId((*s).into())).collect(),
+        }
+    }
+
+    // --- SystemNamespace creation ---
+
+    #[test]
+    fn new_starts_at_version_1() {
+        let ns = SystemNamespace::new();
+        assert_eq!(*ns.version(), PolicyVersion(1));
+    }
+
+    #[test]
+    fn new_has_initial_version_history() {
+        let ns = SystemNamespace::new();
+        assert_eq!(ns.version_history(), &[PolicyVersion(1)]);
+    }
+
+    #[test]
+    fn new_has_no_policies() {
+        let ns = SystemNamespace::new();
+        assert!(ns.all_placement_policies().is_empty());
+    }
+
+    #[test]
+    fn new_has_no_authority_definitions() {
+        let ns = SystemNamespace::new();
+        assert!(ns.all_authority_definitions().is_empty());
+    }
+
+    // --- Placement policy CRUD ---
+
+    #[test]
+    fn set_and_get_placement_policy() {
+        let mut ns = SystemNamespace::new();
+        let policy = make_policy("user/");
+        ns.set_placement_policy(policy);
+
+        let got = ns.get_placement_policy("user/").unwrap();
+        assert_eq!(got.key_range.prefix, "user/");
+        assert_eq!(got.replica_count, 3);
+    }
+
+    #[test]
+    fn set_placement_policy_overwrites() {
+        let mut ns = SystemNamespace::new();
+        ns.set_placement_policy(make_policy("user/"));
+        let updated = PlacementPolicy::new(PolicyVersion(2), key_range("user/"), 5);
+        ns.set_placement_policy(updated);
+
+        let got = ns.get_placement_policy("user/").unwrap();
+        assert_eq!(got.replica_count, 5);
+    }
+
+    #[test]
+    fn get_nonexistent_policy_returns_none() {
+        let ns = SystemNamespace::new();
+        assert!(ns.get_placement_policy("missing/").is_none());
+    }
+
+    #[test]
+    fn remove_placement_policy() {
+        let mut ns = SystemNamespace::new();
+        ns.set_placement_policy(make_policy("user/"));
+
+        let removed = ns.remove_placement_policy("user/");
+        assert!(removed.is_some());
+        assert!(ns.get_placement_policy("user/").is_none());
+    }
+
+    #[test]
+    fn remove_nonexistent_policy_returns_none() {
+        let mut ns = SystemNamespace::new();
+        assert!(ns.remove_placement_policy("missing/").is_none());
+    }
+
+    #[test]
+    fn all_placement_policies_lists_all() {
+        let mut ns = SystemNamespace::new();
+        ns.set_placement_policy(make_policy("user/"));
+        ns.set_placement_policy(make_policy("order/"));
+
+        let all = ns.all_placement_policies();
+        assert_eq!(all.len(), 2);
+    }
+
+    // --- Version tracking ---
+
+    #[test]
+    fn version_increments_on_set_policy() {
+        let mut ns = SystemNamespace::new();
+        assert_eq!(*ns.version(), PolicyVersion(1));
+
+        ns.set_placement_policy(make_policy("user/"));
+        assert_eq!(*ns.version(), PolicyVersion(2));
+
+        ns.set_placement_policy(make_policy("order/"));
+        assert_eq!(*ns.version(), PolicyVersion(3));
+    }
+
+    #[test]
+    fn version_increments_on_remove_policy() {
+        let mut ns = SystemNamespace::new();
+        ns.set_placement_policy(make_policy("user/"));
+        let v_before = ns.version().0;
+        ns.remove_placement_policy("user/");
+        assert_eq!(ns.version().0, v_before + 1);
+    }
+
+    #[test]
+    fn version_does_not_increment_on_noop_remove() {
+        let mut ns = SystemNamespace::new();
+        let v_before = ns.version().0;
+        ns.remove_placement_policy("missing/");
+        assert_eq!(ns.version().0, v_before);
+    }
+
+    #[test]
+    fn version_increments_on_set_authority() {
+        let mut ns = SystemNamespace::new();
+        ns.set_authority_definition(make_authority_def("user/", &["n1", "n2", "n3"]));
+        assert_eq!(*ns.version(), PolicyVersion(2));
+    }
+
+    #[test]
+    fn version_history_tracks_all_changes() {
+        let mut ns = SystemNamespace::new();
+        ns.set_placement_policy(make_policy("user/"));
+        ns.set_authority_definition(make_authority_def("user/", &["n1"]));
+        ns.remove_placement_policy("user/");
+
+        assert_eq!(
+            ns.version_history(),
+            &[
+                PolicyVersion(1),
+                PolicyVersion(2),
+                PolicyVersion(3),
+                PolicyVersion(4),
+            ]
+        );
+    }
+
+    // --- Authority definition CRUD ---
+
+    #[test]
+    fn set_and_get_authority_definition() {
+        let mut ns = SystemNamespace::new();
+        let def = make_authority_def("user/", &["n1", "n2", "n3"]);
+        ns.set_authority_definition(def);
+
+        let got = ns.get_authority_definition("user/").unwrap();
+        assert_eq!(got.key_range.prefix, "user/");
+        assert_eq!(got.authority_nodes.len(), 3);
+    }
+
+    #[test]
+    fn get_nonexistent_authority_returns_none() {
+        let ns = SystemNamespace::new();
+        assert!(ns.get_authority_definition("missing/").is_none());
+    }
+
+    #[test]
+    fn all_authority_definitions_lists_all() {
+        let mut ns = SystemNamespace::new();
+        ns.set_authority_definition(make_authority_def("user/", &["n1"]));
+        ns.set_authority_definition(make_authority_def("order/", &["n2"]));
+
+        let all = ns.all_authority_definitions();
+        assert_eq!(all.len(), 2);
+    }
+
+    // --- get_authorities_for_key ---
+
+    #[test]
+    fn get_authorities_for_key_exact_prefix() {
+        let mut ns = SystemNamespace::new();
+        ns.set_authority_definition(make_authority_def("user/", &["n1", "n2", "n3"]));
+
+        let result = ns.get_authorities_for_key("user/alice");
+        assert!(result.is_some());
+        assert_eq!(result.unwrap().key_range.prefix, "user/");
+    }
+
+    #[test]
+    fn get_authorities_for_key_no_match() {
+        let mut ns = SystemNamespace::new();
+        ns.set_authority_definition(make_authority_def("user/", &["n1"]));
+
+        assert!(ns.get_authorities_for_key("order/123").is_none());
+    }
+
+    #[test]
+    fn get_authorities_for_key_longest_prefix_match() {
+        let mut ns = SystemNamespace::new();
+        ns.set_authority_definition(make_authority_def("user/", &["n1"]));
+        ns.set_authority_definition(make_authority_def("user/vip/", &["n2", "n3"]));
+
+        let result = ns.get_authorities_for_key("user/vip/alice");
+        assert!(result.is_some());
+        assert_eq!(result.unwrap().key_range.prefix, "user/vip/");
+        assert_eq!(result.unwrap().authority_nodes.len(), 2);
+    }
+
+    #[test]
+    fn get_authorities_for_key_falls_back_to_shorter_prefix() {
+        let mut ns = SystemNamespace::new();
+        ns.set_authority_definition(make_authority_def("user/", &["n1"]));
+        ns.set_authority_definition(make_authority_def("user/vip/", &["n2"]));
+
+        let result = ns.get_authorities_for_key("user/regular/bob");
+        assert!(result.is_some());
+        assert_eq!(result.unwrap().key_range.prefix, "user/");
+    }
+
+    // --- Default trait ---
+
+    #[test]
+    fn default_is_same_as_new() {
+        let ns = SystemNamespace::default();
+        assert_eq!(*ns.version(), PolicyVersion(1));
+        assert!(ns.all_placement_policies().is_empty());
+        assert!(ns.all_authority_definitions().is_empty());
+    }
+
+    // --- Serde for AuthorityDefinition ---
+
+    #[test]
+    fn serde_authority_definition_round_trip() {
+        let def = make_authority_def("user/", &["n1", "n2", "n3"]);
+        let json = serde_json::to_string(&def).unwrap();
+        let back: AuthorityDefinition = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.key_range.prefix, "user/");
+        assert_eq!(back.authority_nodes.len(), 3);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod authority;
+pub mod control_plane;
 pub mod crdt;
 pub mod error;
 pub mod hlc;


### PR DESCRIPTION
## Summary

- `SystemNamespace` を実装: 配置ポリシーと Authority 定義を格納する system namespace (FR-009)
- `ControlPlaneConsensus` を実装: system namespace の更新に Authority ノード群の過半数合意を要求
- longest-prefix match による `get_authorities_for_key` を実装
- version history tracking で NFR-004 observability に対応

## Details

### New files
- `src/control_plane/mod.rs` - module root
- `src/control_plane/system_namespace.rs` - SystemNamespace, AuthorityDefinition
- `src/control_plane/consensus.rs` - ControlPlaneConsensus with majority check

### Tests
- 30 new unit tests covering:
  - SystemNamespace CRUD (placement policies, authority definitions)
  - Version increment tracking and history
  - Longest-prefix key matching
  - Consensus majority check with valid/invalid approvals
  - Failed proposals leave namespace unchanged

Closes #13

## Test plan
- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test` passes (207 tests, all green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)