### PR TITLE
feat: make CertifiedApi certification range-aware (#40)

### DIFF
--- a/src/api/certified.rs
+++ b/src/api/certified.rs
@@ -1,8 +1,9 @@
 use crate::authority::ack_frontier::{AckFrontier, AckFrontierSet};
+use crate::control_plane::system_namespace::SystemNamespace;
 use crate::error::CrdtError;
 use crate::hlc::{Hlc, HlcTimestamp};
 use crate::store::kv::{CrdtValue, Store};
-use crate::types::{CertificationStatus, NodeId};
+use crate::types::{CertificationStatus, KeyRange, NodeId, PolicyVersion};
 
 /// What to do when `certified_write` cannot achieve consensus.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -35,6 +36,12 @@ pub struct PendingWrite {
     pub timestamp: HlcTimestamp,
     /// Current certification status.
     pub status: CertificationStatus,
+    /// The resolved key range for this write's authority scope.
+    pub key_range: KeyRange,
+    /// The policy version in effect when this write was issued.
+    pub policy_version: PolicyVersion,
+    /// The total number of authorities for this write's key range.
+    pub total_authorities: usize,
 }
 
 /// Configuration for retention and cleanup of pending writes.
@@ -67,23 +74,28 @@ impl Default for RetentionPolicy {
 ///
 /// Provides `get_certified` and `certified_write` operations that integrate
 /// with the Authority ack_frontier to track and report certification status.
+/// Authority resolution uses longest-prefix match via `SystemNamespace` to
+/// ensure certification decisions are scoped to the correct key range.
 pub struct CertifiedApi {
     store: Store,
     clock: Hlc,
     frontiers: AckFrontierSet,
-    total_authorities: usize,
+    namespace: SystemNamespace,
     pending_writes: Vec<PendingWrite>,
     retention: RetentionPolicy,
 }
 
 impl CertifiedApi {
     /// Create a new `CertifiedApi` for the given node.
-    pub fn new(node_id: NodeId, total_authorities: usize) -> Self {
+    ///
+    /// The `namespace` provides authority definitions for key-range-scoped
+    /// certification decisions via longest-prefix match.
+    pub fn new(node_id: NodeId, namespace: SystemNamespace) -> Self {
         Self {
             store: Store::new(),
             clock: Hlc::new(node_id.0),
             frontiers: AckFrontierSet::new(),
-            total_authorities,
+            namespace,
             pending_writes: Vec::new(),
             retention: RetentionPolicy::default(),
         }
@@ -92,29 +104,52 @@ impl CertifiedApi {
     /// Create a new `CertifiedApi` with a custom retention policy.
     pub fn with_retention(
         node_id: NodeId,
-        total_authorities: usize,
+        namespace: SystemNamespace,
         retention: RetentionPolicy,
     ) -> Self {
         Self {
             store: Store::new(),
             clock: Hlc::new(node_id.0),
             frontiers: AckFrontierSet::new(),
-            total_authorities,
+            namespace,
             pending_writes: Vec::new(),
             retention,
         }
     }
 
+    /// Resolve the authority scope for a given key.
+    ///
+    /// Uses longest-prefix match against authority definitions in the system
+    /// namespace. Returns the key range, current policy version, and total
+    /// authority count for that range.
+    fn resolve_scope(&self, key: &str) -> Result<(KeyRange, PolicyVersion, usize), CrdtError> {
+        let auth_def = self.namespace.get_authorities_for_key(key).ok_or_else(|| {
+            CrdtError::PolicyDenied(format!("no authority definition for key: {key}"))
+        })?;
+
+        let key_range = auth_def.key_range.clone();
+        let total = auth_def.authority_nodes.len();
+
+        let policy_version = self
+            .namespace
+            .get_placement_policy(&key_range.prefix)
+            .map(|p| p.version)
+            .unwrap_or(PolicyVersion(1));
+
+        Ok((key_range, policy_version, total))
+    }
+
     /// Read a key with certification status (FR-002).
     ///
     /// Returns the value (if present), its certification status based on
-    /// the latest pending write for that key, and the current majority frontier.
+    /// the latest pending write for that key, and the scoped majority frontier
+    /// for the key's authority range.
     pub fn get_certified(&self, key: &str) -> CertifiedRead<'_> {
         let value = self.store.get(key);
-        let frontier = self
-            .frontiers
-            .majority_frontier(self.total_authorities)
-            .cloned();
+
+        let frontier = self.resolve_scope(key).ok().and_then(|(kr, pv, total)| {
+            self.frontiers.majority_frontier_for_scope(&kr, &pv, total)
+        });
 
         let status = self
             .pending_writes
@@ -133,12 +168,17 @@ impl CertifiedApi {
 
     /// Write a value that requires Authority majority certification (FR-004).
     ///
-    /// The value is written to the local store immediately (eventual path).
-    /// A `PendingWrite` entry is created to track certification progress.
+    /// The key is resolved to an authority scope via longest-prefix match
+    /// in the system namespace. The value is written to the local store
+    /// immediately (eventual path). A `PendingWrite` entry is created to
+    /// track certification progress.
     ///
-    /// If the write is already certified at the current frontier, returns
-    /// `Ok(CertificationStatus::Certified)`. Otherwise, behaviour depends
-    /// on `on_timeout`:
+    /// Returns `Err(CrdtError::PolicyDenied)` if no authority definition
+    /// covers the key.
+    ///
+    /// If the write is already certified at the current scoped frontier,
+    /// returns `Ok(CertificationStatus::Certified)`. Otherwise, behaviour
+    /// depends on `on_timeout`:
     /// - `OnTimeout::Error` — returns `Err(CrdtError::Timeout)`.
     /// - `OnTimeout::Pending` — returns `Ok(CertificationStatus::Pending)`.
     ///
@@ -150,6 +190,8 @@ impl CertifiedApi {
         value: CrdtValue,
         on_timeout: OnTimeout,
     ) -> Result<CertificationStatus, CrdtError> {
+        let (key_range, policy_version, total_authorities) = self.resolve_scope(&key)?;
+
         // Auto-cleanup when capacity is exceeded.
         if self.pending_writes.len() >= self.retention.max_entries {
             self.cleanup_completed();
@@ -160,10 +202,13 @@ impl CertifiedApi {
         // Write to the local store (eventual consistency path).
         self.store.put(key.clone(), value.clone());
 
-        // Check if already certified at the current frontier.
-        let already_certified = self
-            .frontiers
-            .is_certified_at(&timestamp, self.total_authorities);
+        // Check if already certified at the current scoped frontier.
+        let already_certified = self.frontiers.is_certified_at_for_scope(
+            &timestamp,
+            &key_range,
+            &policy_version,
+            total_authorities,
+        );
 
         let status = if already_certified {
             CertificationStatus::Certified
@@ -176,6 +221,9 @@ impl CertifiedApi {
             value,
             timestamp,
             status,
+            key_range,
+            policy_version,
+            total_authorities,
         });
 
         if already_certified {
@@ -209,14 +257,18 @@ impl CertifiedApi {
 
     /// Re-evaluate all pending writes against the current frontiers.
     ///
-    /// Writes whose timestamps are at or below the majority frontier
-    /// are promoted to `Certified`.
+    /// Each write is checked against the scoped majority frontier for its
+    /// resolved key range. Writes whose timestamps are at or below the
+    /// scoped majority frontier are promoted to `Certified`.
     pub fn process_certifications(&mut self) {
         for pw in &mut self.pending_writes {
             if pw.status == CertificationStatus::Pending
-                && self
-                    .frontiers
-                    .is_certified_at(&pw.timestamp, self.total_authorities)
+                && self.frontiers.is_certified_at_for_scope(
+                    &pw.timestamp,
+                    &pw.key_range,
+                    &pw.policy_version,
+                    pw.total_authorities,
+                )
             {
                 pw.status = CertificationStatus::Certified;
             }
@@ -266,18 +318,31 @@ impl CertifiedApi {
     pub fn pending_writes(&self) -> &[PendingWrite] {
         &self.pending_writes
     }
+
+    /// Return a reference to the system namespace.
+    pub fn namespace(&self) -> &SystemNamespace {
+        &self.namespace
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::authority::ack_frontier::AckFrontier;
+    use crate::control_plane::system_namespace::AuthorityDefinition;
     use crate::crdt::pn_counter::PnCounter;
     use crate::hlc::HlcTimestamp;
+    use crate::placement::PlacementPolicy;
     use crate::types::{KeyRange, NodeId, PolicyVersion};
 
     fn node(name: &str) -> NodeId {
         NodeId(name.into())
+    }
+
+    fn kr(prefix: &str) -> KeyRange {
+        KeyRange {
+            prefix: prefix.into(),
+        }
     }
 
     fn make_frontier(authority: &str, physical: u64, logical: u32, prefix: &str) -> AckFrontier {
@@ -296,6 +361,28 @@ mod tests {
         }
     }
 
+    fn make_frontier_v(
+        authority: &str,
+        physical: u64,
+        logical: u32,
+        prefix: &str,
+        version: u64,
+    ) -> AckFrontier {
+        AckFrontier {
+            authority_id: NodeId(authority.into()),
+            frontier_hlc: HlcTimestamp {
+                physical,
+                logical,
+                node_id: authority.into(),
+            },
+            key_range: KeyRange {
+                prefix: prefix.into(),
+            },
+            policy_version: PolicyVersion(version),
+            digest_hash: format!("{authority}-{physical}-{logical}"),
+        }
+    }
+
     fn counter_value(n: i64) -> CrdtValue {
         let mut counter = PnCounter::new();
         for _ in 0..n {
@@ -304,13 +391,29 @@ mod tests {
         CrdtValue::Counter(counter)
     }
 
+    /// Create a namespace with a single catch-all authority definition (prefix "")
+    /// with 3 authorities. This preserves backward-compatible behaviour for
+    /// existing tests.
+    fn default_namespace() -> SystemNamespace {
+        make_namespace("", &["auth-1", "auth-2", "auth-3"])
+    }
+
+    fn make_namespace(prefix: &str, authorities: &[&str]) -> SystemNamespace {
+        let mut ns = SystemNamespace::new();
+        ns.set_authority_definition(AuthorityDefinition {
+            key_range: kr(prefix),
+            authority_nodes: authorities.iter().map(|a| node(a)).collect(),
+        });
+        ns
+    }
+
     // ---------------------------------------------------------------
     // get_certified with no data
     // ---------------------------------------------------------------
 
     #[test]
     fn get_certified_no_data() {
-        let api = CertifiedApi::new(node("node-1"), 3);
+        let api = CertifiedApi::new(node("node-1"), default_namespace());
         let result = api.get_certified("missing");
 
         assert!(result.value.is_none());
@@ -324,7 +427,7 @@ mod tests {
 
     #[test]
     fn certified_write_creates_pending_entry() {
-        let mut api = CertifiedApi::new(node("node-1"), 3);
+        let mut api = CertifiedApi::new(node("node-1"), default_namespace());
         let result = api.certified_write("key1".into(), counter_value(1), OnTimeout::Pending);
 
         assert_eq!(result.unwrap(), CertificationStatus::Pending);
@@ -339,7 +442,7 @@ mod tests {
 
     #[test]
     fn get_certification_status_pending_for_new_write() {
-        let mut api = CertifiedApi::new(node("node-1"), 3);
+        let mut api = CertifiedApi::new(node("node-1"), default_namespace());
         api.certified_write("key1".into(), counter_value(1), OnTimeout::Pending)
             .unwrap();
 
@@ -351,7 +454,7 @@ mod tests {
 
     #[test]
     fn get_certification_status_no_write_returns_pending() {
-        let api = CertifiedApi::new(node("node-1"), 3);
+        let api = CertifiedApi::new(node("node-1"), default_namespace());
         assert_eq!(
             api.get_certification_status("nonexistent"),
             CertificationStatus::Pending
@@ -364,7 +467,7 @@ mod tests {
 
     #[test]
     fn process_certifications_promotes_to_certified() {
-        let mut api = CertifiedApi::new(node("node-1"), 3);
+        let mut api = CertifiedApi::new(node("node-1"), default_namespace());
         api.certified_write("key1".into(), counter_value(1), OnTimeout::Pending)
             .unwrap();
 
@@ -384,7 +487,7 @@ mod tests {
 
     #[test]
     fn process_certifications_not_enough_authorities() {
-        let mut api = CertifiedApi::new(node("node-1"), 3);
+        let mut api = CertifiedApi::new(node("node-1"), default_namespace());
         api.certified_write("key1".into(), counter_value(1), OnTimeout::Pending)
             .unwrap();
 
@@ -404,7 +507,7 @@ mod tests {
 
     #[test]
     fn certified_write_on_timeout_error() {
-        let mut api = CertifiedApi::new(node("node-1"), 3);
+        let mut api = CertifiedApi::new(node("node-1"), default_namespace());
         let result = api.certified_write("key1".into(), counter_value(1), OnTimeout::Error);
 
         assert_eq!(result.unwrap_err(), CrdtError::Timeout);
@@ -419,7 +522,7 @@ mod tests {
 
     #[test]
     fn certified_write_on_timeout_pending() {
-        let mut api = CertifiedApi::new(node("node-1"), 3);
+        let mut api = CertifiedApi::new(node("node-1"), default_namespace());
         let result = api.certified_write("key1".into(), counter_value(1), OnTimeout::Pending);
 
         assert_eq!(result.unwrap(), CertificationStatus::Pending);
@@ -431,7 +534,7 @@ mod tests {
 
     #[test]
     fn get_certified_after_certification() {
-        let mut api = CertifiedApi::new(node("node-1"), 3);
+        let mut api = CertifiedApi::new(node("node-1"), default_namespace());
         api.certified_write("key1".into(), counter_value(5), OnTimeout::Pending)
             .unwrap();
 
@@ -455,7 +558,7 @@ mod tests {
 
     #[test]
     fn multiple_writes_selective_certification() {
-        let mut api = CertifiedApi::new(node("node-1"), 3);
+        let mut api = CertifiedApi::new(node("node-1"), default_namespace());
 
         api.certified_write("key1".into(), counter_value(1), OnTimeout::Pending)
             .unwrap();
@@ -489,7 +592,7 @@ mod tests {
 
     #[test]
     fn update_frontier_updates_tracking() {
-        let mut api = CertifiedApi::new(node("node-1"), 3);
+        let mut api = CertifiedApi::new(node("node-1"), default_namespace());
 
         api.update_frontier(make_frontier("auth-1", 100, 0, ""));
         api.update_frontier(make_frontier("auth-2", 200, 0, ""));
@@ -506,7 +609,7 @@ mod tests {
 
     #[test]
     fn certified_write_stores_value_locally() {
-        let mut api = CertifiedApi::new(node("node-1"), 3);
+        let mut api = CertifiedApi::new(node("node-1"), default_namespace());
         api.certified_write("key1".into(), counter_value(3), OnTimeout::Pending)
             .unwrap();
 
@@ -524,7 +627,7 @@ mod tests {
 
     #[test]
     fn retention_policy_defaults() {
-        let api = CertifiedApi::new(node("node-1"), 3);
+        let api = CertifiedApi::new(node("node-1"), default_namespace());
         let policy = api.retention_policy();
         assert_eq!(policy.max_age_ms, 60_000);
         assert_eq!(policy.max_entries, 10_000);
@@ -536,7 +639,7 @@ mod tests {
             max_age_ms: 5_000,
             max_entries: 100,
         };
-        let api = CertifiedApi::with_retention(node("node-1"), 3, policy);
+        let api = CertifiedApi::with_retention(node("node-1"), default_namespace(), policy);
         assert_eq!(api.retention_policy().max_age_ms, 5_000);
         assert_eq!(api.retention_policy().max_entries, 100);
     }
@@ -547,7 +650,7 @@ mod tests {
 
     #[test]
     fn cleanup_completed_removes_non_pending() {
-        let mut api = CertifiedApi::new(node("node-1"), 3);
+        let mut api = CertifiedApi::new(node("node-1"), default_namespace());
 
         // Write 3 entries.
         api.certified_write("key1".into(), counter_value(1), OnTimeout::Pending)
@@ -586,7 +689,7 @@ mod tests {
             max_age_ms: 5_000,
             max_entries: 10_000,
         };
-        let mut api = CertifiedApi::with_retention(node("node-1"), 3, policy);
+        let mut api = CertifiedApi::with_retention(node("node-1"), default_namespace(), policy);
 
         api.certified_write("key1".into(), counter_value(1), OnTimeout::Pending)
             .unwrap();
@@ -613,7 +716,7 @@ mod tests {
             max_age_ms: 10_000,
             max_entries: 10_000,
         };
-        let mut api = CertifiedApi::with_retention(node("node-1"), 3, policy);
+        let mut api = CertifiedApi::with_retention(node("node-1"), default_namespace(), policy);
 
         // Write entries at different times.
         api.certified_write("key1".into(), counter_value(1), OnTimeout::Pending)
@@ -647,7 +750,7 @@ mod tests {
             max_age_ms: 60_000,
             max_entries: 3,
         };
-        let mut api = CertifiedApi::with_retention(node("node-1"), 3, policy);
+        let mut api = CertifiedApi::with_retention(node("node-1"), default_namespace(), policy);
 
         // Write 3 entries (hits max_entries).
         api.certified_write("key1".into(), counter_value(1), OnTimeout::Pending)
@@ -689,7 +792,7 @@ mod tests {
             max_age_ms: 60_000,
             max_entries: 10,
         };
-        let mut api = CertifiedApi::with_retention(node("node-1"), 3, policy);
+        let mut api = CertifiedApi::with_retention(node("node-1"), default_namespace(), policy);
 
         // Simulate sustained writes with periodic certification.
         for i in 0..50u64 {
@@ -711,5 +814,220 @@ mod tests {
             "expected bounded growth, got {} entries",
             api.pending_writes().len()
         );
+    }
+
+    // ---------------------------------------------------------------
+    // Range-aware certification: cross-range contamination prevented
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn cross_range_certification_does_not_contaminate() {
+        // Two separate key ranges with distinct authority sets.
+        let mut ns = SystemNamespace::new();
+        ns.set_authority_definition(AuthorityDefinition {
+            key_range: kr("user/"),
+            authority_nodes: vec![node("auth-u1"), node("auth-u2"), node("auth-u3")],
+        });
+        ns.set_authority_definition(AuthorityDefinition {
+            key_range: kr("order/"),
+            authority_nodes: vec![node("auth-o1"), node("auth-o2"), node("auth-o3")],
+        });
+
+        let mut api = CertifiedApi::new(node("node-1"), ns);
+
+        // Write to both ranges.
+        api.certified_write("user/alice".into(), counter_value(1), OnTimeout::Pending)
+            .unwrap();
+        let user_ts = api.pending_writes()[0].timestamp.physical;
+
+        api.certified_write("order/123".into(), counter_value(2), OnTimeout::Pending)
+            .unwrap();
+        let order_ts = api.pending_writes()[1].timestamp.physical;
+
+        // Advance only order/ authorities past both timestamps.
+        api.update_frontier(make_frontier("auth-o1", order_ts + 100, 0, "order/"));
+        api.update_frontier(make_frontier("auth-o2", order_ts + 200, 0, "order/"));
+
+        api.process_certifications();
+
+        // order/123 should be certified (its authorities reached majority).
+        assert_eq!(
+            api.get_certification_status("order/123"),
+            CertificationStatus::Certified
+        );
+
+        // user/alice must NOT be certified — user/ authorities haven't reported.
+        assert_eq!(
+            api.get_certification_status("user/alice"),
+            CertificationStatus::Pending
+        );
+
+        // Now advance user/ authorities.
+        api.update_frontier(make_frontier("auth-u1", user_ts + 100, 0, "user/"));
+        api.update_frontier(make_frontier("auth-u2", user_ts + 200, 0, "user/"));
+
+        api.process_certifications();
+
+        // Now user/alice should be certified.
+        assert_eq!(
+            api.get_certification_status("user/alice"),
+            CertificationStatus::Certified
+        );
+    }
+
+    // ---------------------------------------------------------------
+    // Range-aware: scoped majority frontier in get_certified
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn get_certified_returns_scoped_frontier() {
+        let mut ns = SystemNamespace::new();
+        ns.set_authority_definition(AuthorityDefinition {
+            key_range: kr("user/"),
+            authority_nodes: vec![node("auth-u1"), node("auth-u2"), node("auth-u3")],
+        });
+        ns.set_authority_definition(AuthorityDefinition {
+            key_range: kr("order/"),
+            authority_nodes: vec![node("auth-o1"), node("auth-o2"), node("auth-o3")],
+        });
+
+        let mut api = CertifiedApi::new(node("node-1"), ns);
+
+        // Set different frontier levels for each range.
+        api.update_frontier(make_frontier("auth-u1", 100, 0, "user/"));
+        api.update_frontier(make_frontier("auth-u2", 200, 0, "user/"));
+        api.update_frontier(make_frontier("auth-u3", 150, 0, "user/"));
+
+        api.update_frontier(make_frontier("auth-o1", 1000, 0, "order/"));
+        api.update_frontier(make_frontier("auth-o2", 2000, 0, "order/"));
+        api.update_frontier(make_frontier("auth-o3", 1500, 0, "order/"));
+
+        // user/ majority frontier should be 150.
+        let user_read = api.get_certified("user/alice");
+        assert_eq!(user_read.frontier.unwrap().physical, 150);
+
+        // order/ majority frontier should be 1500.
+        let order_read = api.get_certified("order/123");
+        assert_eq!(order_read.frontier.unwrap().physical, 1500);
+    }
+
+    // ---------------------------------------------------------------
+    // Range-aware: policy version transition
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn policy_version_transition_independent_certification() {
+        let mut ns = SystemNamespace::new();
+        ns.set_authority_definition(AuthorityDefinition {
+            key_range: kr("data/"),
+            authority_nodes: vec![node("auth-1"), node("auth-2"), node("auth-3")],
+        });
+        // Set placement policy at version 2.
+        ns.set_placement_policy(
+            PlacementPolicy::new(PolicyVersion(2), kr("data/"), 3).with_certified(true),
+        );
+
+        let mut api = CertifiedApi::new(node("node-1"), ns);
+
+        // Write a key — should resolve to data/ with policy version 2.
+        api.certified_write("data/sensor".into(), counter_value(42), OnTimeout::Pending)
+            .unwrap();
+        let write_ts = api.pending_writes()[0].timestamp.physical;
+        assert_eq!(api.pending_writes()[0].policy_version, PolicyVersion(2));
+
+        // Frontiers at version 1 should NOT certify a write resolved at version 2.
+        api.update_frontier(make_frontier_v("auth-1", write_ts + 100, 0, "data/", 1));
+        api.update_frontier(make_frontier_v("auth-2", write_ts + 200, 0, "data/", 1));
+        api.process_certifications();
+
+        assert_eq!(
+            api.get_certification_status("data/sensor"),
+            CertificationStatus::Pending,
+            "v1 frontiers must not certify a v2 write"
+        );
+
+        // Frontiers at version 2 should certify the write.
+        api.update_frontier(make_frontier_v("auth-1", write_ts + 100, 0, "data/", 2));
+        api.update_frontier(make_frontier_v("auth-2", write_ts + 200, 0, "data/", 2));
+        api.process_certifications();
+
+        assert_eq!(
+            api.get_certification_status("data/sensor"),
+            CertificationStatus::Certified
+        );
+    }
+
+    // ---------------------------------------------------------------
+    // Range-aware: longest-prefix authority resolution
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn longest_prefix_authority_resolution() {
+        let mut ns = SystemNamespace::new();
+        // Broader authority set for user/
+        ns.set_authority_definition(AuthorityDefinition {
+            key_range: kr("user/"),
+            authority_nodes: vec![node("auth-1"), node("auth-2"), node("auth-3")],
+        });
+        // Narrower (higher-priority) authority set for user/vip/
+        ns.set_authority_definition(AuthorityDefinition {
+            key_range: kr("user/vip/"),
+            authority_nodes: vec![node("auth-v1"), node("auth-v2")],
+        });
+
+        let mut api = CertifiedApi::new(node("node-1"), ns);
+
+        // Write to user/vip/alice — should resolve to user/vip/ (2 authorities).
+        api.certified_write(
+            "user/vip/alice".into(),
+            counter_value(1),
+            OnTimeout::Pending,
+        )
+        .unwrap();
+        assert_eq!(api.pending_writes()[0].key_range, kr("user/vip/"));
+        assert_eq!(api.pending_writes()[0].total_authorities, 2);
+
+        // Write to user/regular/bob — should resolve to user/ (3 authorities).
+        api.certified_write(
+            "user/regular/bob".into(),
+            counter_value(2),
+            OnTimeout::Pending,
+        )
+        .unwrap();
+        assert_eq!(api.pending_writes()[1].key_range, kr("user/"));
+        assert_eq!(api.pending_writes()[1].total_authorities, 3);
+    }
+
+    // ---------------------------------------------------------------
+    // Range-aware: certified_write rejects key with no authority
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn certified_write_rejects_key_without_authority() {
+        // Namespace with only user/ defined.
+        let ns = make_namespace("user/", &["auth-1", "auth-2", "auth-3"]);
+        let mut api = CertifiedApi::new(node("node-1"), ns);
+
+        // order/ has no authority definition — should be PolicyDenied.
+        let result = api.certified_write("order/123".into(), counter_value(1), OnTimeout::Pending);
+        assert!(matches!(result, Err(CrdtError::PolicyDenied(_))));
+    }
+
+    // ---------------------------------------------------------------
+    // Range-aware: pending write stores resolved scope
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn pending_write_stores_resolved_scope() {
+        let ns = make_namespace("data/", &["auth-1", "auth-2", "auth-3"]);
+        let mut api = CertifiedApi::new(node("node-1"), ns);
+
+        api.certified_write("data/key1".into(), counter_value(1), OnTimeout::Pending)
+            .unwrap();
+
+        let pw = &api.pending_writes()[0];
+        assert_eq!(pw.key_range, kr("data/"));
+        assert_eq!(pw.policy_version, PolicyVersion(1));
+        assert_eq!(pw.total_authorities, 3);
     }
 }

--- a/tests/integration/authority_certified_flow.rs
+++ b/tests/integration/authority_certified_flow.rs
@@ -5,8 +5,10 @@ use asteroidb_poc::authority::certificate::{
     AuthoritySignature, EpochConfig, KeysetVersion, MajorityCertificate,
     create_certificate_message, sign_message,
 };
+use asteroidb_poc::control_plane::system_namespace::{AuthorityDefinition, SystemNamespace};
 use asteroidb_poc::crdt::pn_counter::PnCounter;
 use asteroidb_poc::hlc::{Hlc, HlcTimestamp};
+use asteroidb_poc::placement::PlacementPolicy;
 use asteroidb_poc::store::kv::CrdtValue;
 use asteroidb_poc::types::{CertificationStatus, KeyRange, NodeId, PolicyVersion};
 
@@ -41,6 +43,26 @@ fn make_frontier(authority: &str, physical: u64, logical: u32, prefix: &str) -> 
     }
 }
 
+fn make_frontier_v(
+    authority: &str,
+    physical: u64,
+    logical: u32,
+    prefix: &str,
+    version: u64,
+) -> AckFrontier {
+    AckFrontier {
+        authority_id: node(authority),
+        frontier_hlc: HlcTimestamp {
+            physical,
+            logical,
+            node_id: authority.into(),
+        },
+        key_range: key_range(prefix),
+        policy_version: PolicyVersion(version),
+        digest_hash: format!("{authority}-{physical}-{logical}"),
+    }
+}
+
 fn counter_value(n: i64) -> CrdtValue {
     let mut counter = PnCounter::new();
     let writer = node("writer");
@@ -54,6 +76,24 @@ fn make_key_pair() -> (SigningKey, ed25519_dalek::VerifyingKey) {
     let sk = SigningKey::generate(&mut OsRng);
     let vk = sk.verifying_key();
     (sk, vk)
+}
+
+/// Create a namespace with a catch-all authority definition (prefix "").
+fn default_namespace() -> SystemNamespace {
+    make_namespace("", &["auth-1", "auth-2", "auth-3"])
+}
+
+fn make_namespace(prefix: &str, authorities: &[&str]) -> SystemNamespace {
+    let mut ns = SystemNamespace::new();
+    ns.set_authority_definition(AuthorityDefinition {
+        key_range: key_range(prefix),
+        authority_nodes: authorities.iter().map(|a| node(a)).collect(),
+    });
+    ns
+}
+
+fn five_auth_namespace() -> SystemNamespace {
+    make_namespace("", &["auth-1", "auth-2", "auth-3", "auth-4", "auth-5"])
 }
 
 // ---------------------------------------------------------------------------
@@ -89,7 +129,7 @@ fn two_of_three_authorities_ack_updates_majority_frontier() {
 
 #[test]
 fn get_certified_returns_certified_after_majority_frontier_reached() {
-    let mut api = CertifiedApi::new(node("node-1"), 3);
+    let mut api = CertifiedApi::new(node("node-1"), default_namespace());
 
     // Write a value (pending because no frontiers yet)
     let status = api
@@ -125,7 +165,7 @@ fn get_certified_returns_certified_after_majority_frontier_reached() {
 
 #[test]
 fn pending_status_when_majority_not_reached() {
-    let mut api = CertifiedApi::new(node("node-1"), 3);
+    let mut api = CertifiedApi::new(node("node-1"), default_namespace());
 
     // Write a value
     api.certified_write("key1".into(), counter_value(5), OnTimeout::Pending)
@@ -155,7 +195,7 @@ fn pending_status_when_majority_not_reached() {
 
 #[test]
 fn certification_succeeds_with_one_authority_failure() {
-    let mut api = CertifiedApi::new(node("node-1"), 3);
+    let mut api = CertifiedApi::new(node("node-1"), default_namespace());
 
     // Write a value
     let status = api
@@ -243,8 +283,9 @@ fn end_to_end_certificate_signing_to_certified_api() {
     // Verify majority frontier is available
     assert!(frontier_set.majority_frontier(3).is_some());
 
-    // Step 5: Feed into CertifiedApi
-    let mut api = CertifiedApi::new(node("client-1"), 3);
+    // Step 5: Feed into CertifiedApi (namespace with user/ authority)
+    let ns = make_namespace("user/", &["auth-1", "auth-2", "auth-3"]);
+    let mut api = CertifiedApi::new(node("client-1"), ns);
 
     // Write a value with a timestamp that should be <= the certified frontier
     api.certified_write("user/data".into(), counter_value(100), OnTimeout::Pending)
@@ -276,7 +317,7 @@ fn end_to_end_certificate_signing_to_certified_api() {
 
 #[test]
 fn full_flow_write_frontier_certificate_read() {
-    let mut api = CertifiedApi::new(node("node-1"), 3);
+    let mut api = CertifiedApi::new(node("node-1"), default_namespace());
 
     // Phase 1: certified_write → Pending
     let status = api
@@ -353,7 +394,7 @@ fn certification_across_epoch_boundary() {
     let epoch_ms = epoch_config.duration_secs * 1000;
 
     // Epoch 1: Write occurs at the end of epoch 1
-    let mut api = CertifiedApi::new(node("node-1"), 3);
+    let mut api = CertifiedApi::new(node("node-1"), default_namespace());
     api.certified_write(
         "cross-epoch/data".into(),
         counter_value(1),
@@ -429,7 +470,7 @@ fn certification_across_epoch_boundary() {
 /// Multiple writes with progressive certification
 #[test]
 fn progressive_certification_of_multiple_writes() {
-    let mut api = CertifiedApi::new(node("node-1"), 3);
+    let mut api = CertifiedApi::new(node("node-1"), default_namespace());
 
     // Write three values at different times
     api.certified_write("key-a".into(), counter_value(1), OnTimeout::Pending)
@@ -497,7 +538,7 @@ fn progressive_certification_of_multiple_writes() {
 /// OnTimeout::Error returns error but write is still tracked
 #[test]
 fn on_timeout_error_still_tracks_write() {
-    let mut api = CertifiedApi::new(node("node-1"), 3);
+    let mut api = CertifiedApi::new(node("node-1"), default_namespace());
 
     let result = api.certified_write("key1".into(), counter_value(7), OnTimeout::Error);
     assert!(result.is_err());
@@ -580,7 +621,7 @@ fn certification_tracker_with_frontier_set() {
 /// Store write is visible immediately even before certification
 #[test]
 fn store_value_visible_before_certification() {
-    let mut api = CertifiedApi::new(node("node-1"), 3);
+    let mut api = CertifiedApi::new(node("node-1"), default_namespace());
 
     api.certified_write("immediate".into(), counter_value(99), OnTimeout::Pending)
         .unwrap();
@@ -599,7 +640,7 @@ fn store_value_visible_before_certification() {
 /// Frontier regression is prevented
 #[test]
 fn frontier_regression_prevented_in_certified_flow() {
-    let mut api = CertifiedApi::new(node("node-1"), 3);
+    let mut api = CertifiedApi::new(node("node-1"), default_namespace());
 
     api.certified_write("key1".into(), counter_value(1), OnTimeout::Pending)
         .unwrap();
@@ -675,7 +716,7 @@ fn invalid_signature_detected_in_certificate() {
 /// Five-authority cluster: need 3 for majority
 #[test]
 fn five_authority_majority_certification() {
-    let mut api = CertifiedApi::new(node("node-1"), 5);
+    let mut api = CertifiedApi::new(node("node-1"), five_auth_namespace());
 
     api.certified_write("five-auth".into(), counter_value(50), OnTimeout::Pending)
         .unwrap();
@@ -714,7 +755,7 @@ fn hlc_ordering_in_certification() {
     assert!(t2 < t3);
 
     // Use these in a certification flow
-    let mut api = CertifiedApi::new(node("node-1"), 3);
+    let mut api = CertifiedApi::new(node("node-1"), default_namespace());
 
     api.certified_write("ordered/first".into(), counter_value(1), OnTimeout::Pending)
         .unwrap();
@@ -799,7 +840,7 @@ fn certification_tracker_timeout_flow() {
 /// Overwriting a key and certifying the latest write
 #[test]
 fn overwrite_and_certify_latest() {
-    let mut api = CertifiedApi::new(node("node-1"), 3);
+    let mut api = CertifiedApi::new(node("node-1"), default_namespace());
 
     // Write first version
     api.certified_write("mutable".into(), counter_value(1), OnTimeout::Pending)
@@ -825,4 +866,186 @@ fn overwrite_and_certify_latest() {
     // get_certified returns status of the latest write for that key
     let read = api.get_certified("mutable");
     assert_eq!(read.status, CertificationStatus::Certified);
+}
+
+// ---------------------------------------------------------------------------
+// Issue #40: Cross-range certification contamination prevention
+// ---------------------------------------------------------------------------
+
+/// Proves that frontier updates for one key range do not affect certification
+/// in a different key range. This is the core acceptance criterion for #40.
+#[test]
+fn cross_range_certification_contamination_prevented() {
+    // Set up two separate key ranges with distinct authority sets.
+    let mut ns = SystemNamespace::new();
+    ns.set_authority_definition(AuthorityDefinition {
+        key_range: key_range("user/"),
+        authority_nodes: vec![node("auth-u1"), node("auth-u2"), node("auth-u3")],
+    });
+    ns.set_authority_definition(AuthorityDefinition {
+        key_range: key_range("order/"),
+        authority_nodes: vec![node("auth-o1"), node("auth-o2"), node("auth-o3")],
+    });
+
+    let mut api = CertifiedApi::new(node("node-1"), ns);
+
+    // Write to both ranges.
+    api.certified_write("user/alice".into(), counter_value(10), OnTimeout::Pending)
+        .unwrap();
+    api.certified_write("order/123".into(), counter_value(20), OnTimeout::Pending)
+        .unwrap();
+
+    let user_ts = api.pending_writes()[0].timestamp.physical;
+    let order_ts = api.pending_writes()[1].timestamp.physical;
+
+    // --- Phase 1: Only advance order/ authorities ---
+
+    api.update_frontier(make_frontier("auth-o1", order_ts + 100, 0, "order/"));
+    api.update_frontier(make_frontier("auth-o2", order_ts + 200, 0, "order/"));
+
+    api.process_certifications();
+
+    // order/123 should be certified.
+    assert_eq!(
+        api.get_certification_status("order/123"),
+        CertificationStatus::Certified,
+        "order/ write should be certified by order/ authorities"
+    );
+
+    // user/alice must NOT be certified — user/ authorities haven't reported.
+    assert_eq!(
+        api.get_certification_status("user/alice"),
+        CertificationStatus::Pending,
+        "user/ write must NOT be contaminated by order/ frontier"
+    );
+
+    // get_certified should reflect scoped frontiers.
+    let user_read = api.get_certified("user/alice");
+    assert!(
+        user_read.frontier.is_none(),
+        "user/ should have no majority frontier"
+    );
+
+    let order_read = api.get_certified("order/123");
+    assert!(
+        order_read.frontier.is_some(),
+        "order/ should have majority frontier"
+    );
+
+    // --- Phase 2: Advance user/ authorities ---
+
+    api.update_frontier(make_frontier("auth-u1", user_ts + 100, 0, "user/"));
+    api.update_frontier(make_frontier("auth-u2", user_ts + 200, 0, "user/"));
+
+    api.process_certifications();
+
+    // Now user/alice should also be certified.
+    assert_eq!(
+        api.get_certification_status("user/alice"),
+        CertificationStatus::Certified,
+        "user/ write should be certified after user/ authorities report"
+    );
+}
+
+/// Proves that policy version transitions produce independent certification.
+#[test]
+fn policy_version_transition_certification() {
+    let mut ns = SystemNamespace::new();
+    ns.set_authority_definition(AuthorityDefinition {
+        key_range: key_range("data/"),
+        authority_nodes: vec![node("auth-1"), node("auth-2"), node("auth-3")],
+    });
+    // Policy at version 2.
+    ns.set_placement_policy(
+        PlacementPolicy::new(PolicyVersion(2), key_range("data/"), 3).with_certified(true),
+    );
+
+    let mut api = CertifiedApi::new(node("node-1"), ns);
+
+    // Write resolves to data/ with policy version 2.
+    api.certified_write("data/sensor".into(), counter_value(42), OnTimeout::Pending)
+        .unwrap();
+    let write_ts = api.pending_writes()[0].timestamp.physical;
+
+    // Frontiers at v1 should NOT certify the v2 write.
+    api.update_frontier(make_frontier_v("auth-1", write_ts + 100, 0, "data/", 1));
+    api.update_frontier(make_frontier_v("auth-2", write_ts + 200, 0, "data/", 1));
+    api.process_certifications();
+
+    assert_eq!(
+        api.get_certification_status("data/sensor"),
+        CertificationStatus::Pending,
+        "v1 frontiers must not certify a v2 write"
+    );
+
+    // Frontiers at v2 certify the write.
+    api.update_frontier(make_frontier_v("auth-1", write_ts + 100, 0, "data/", 2));
+    api.update_frontier(make_frontier_v("auth-2", write_ts + 200, 0, "data/", 2));
+    api.process_certifications();
+
+    assert_eq!(
+        api.get_certification_status("data/sensor"),
+        CertificationStatus::Certified,
+        "v2 frontiers should certify a v2 write"
+    );
+}
+
+/// Longest-prefix match: narrower authority definition takes precedence.
+#[test]
+fn longest_prefix_authority_resolution_in_integration() {
+    let mut ns = SystemNamespace::new();
+    // Broad: 3 authorities for user/
+    ns.set_authority_definition(AuthorityDefinition {
+        key_range: key_range("user/"),
+        authority_nodes: vec![node("auth-1"), node("auth-2"), node("auth-3")],
+    });
+    // Narrow: 2 authorities for user/vip/ (only majority of 2 needed)
+    ns.set_authority_definition(AuthorityDefinition {
+        key_range: key_range("user/vip/"),
+        authority_nodes: vec![node("auth-v1"), node("auth-v2")],
+    });
+
+    let mut api = CertifiedApi::new(node("node-1"), ns);
+
+    // VIP key — resolves to user/vip/ with 2 authorities (majority = 2).
+    api.certified_write(
+        "user/vip/alice".into(),
+        counter_value(1),
+        OnTimeout::Pending,
+    )
+    .unwrap();
+    let vip_ts = api.pending_writes()[0].timestamp.physical;
+
+    // Regular key — resolves to user/ with 3 authorities (majority = 2).
+    api.certified_write(
+        "user/regular/bob".into(),
+        counter_value(2),
+        OnTimeout::Pending,
+    )
+    .unwrap();
+    let reg_ts = api.pending_writes()[1].timestamp.physical;
+
+    // Only the VIP authorities report — should certify VIP but not regular.
+    api.update_frontier(make_frontier("auth-v1", vip_ts + 100, 0, "user/vip/"));
+    api.update_frontier(make_frontier("auth-v2", vip_ts + 200, 0, "user/vip/"));
+    api.process_certifications();
+
+    assert_eq!(
+        api.get_certification_status("user/vip/alice"),
+        CertificationStatus::Certified
+    );
+    assert_eq!(
+        api.get_certification_status("user/regular/bob"),
+        CertificationStatus::Pending
+    );
+
+    // Now the regular authorities report.
+    api.update_frontier(make_frontier("auth-1", reg_ts + 100, 0, "user/"));
+    api.update_frontier(make_frontier("auth-2", reg_ts + 200, 0, "user/"));
+    api.process_certifications();
+
+    assert_eq!(
+        api.get_certification_status("user/regular/bob"),
+        CertificationStatus::Certified
+    );
 }

--- a/tests/integration/placement_authority.rs
+++ b/tests/integration/placement_authority.rs
@@ -505,7 +505,9 @@ fn frontier_tracks_policy_version_correctly() {
     frontier_set.update(f_v1);
 
     let scope_v1 = FrontierScope::new(
-        KeyRange { prefix: "user/".into() },
+        KeyRange {
+            prefix: "user/".into(),
+        },
         PolicyVersion(1),
         NodeId("auth-1".into()),
     );
@@ -515,7 +517,9 @@ fn frontier_tracks_policy_version_correctly() {
     // Update with newer policy version creates a separate scoped entry
     frontier_set.update(f_v2);
     let scope_v2 = FrontierScope::new(
-        KeyRange { prefix: "user/".into() },
+        KeyRange {
+            prefix: "user/".into(),
+        },
         PolicyVersion(2),
         NodeId("auth-1".into()),
     );

--- a/tests/partition_tolerance.rs
+++ b/tests/partition_tolerance.rs
@@ -12,6 +12,7 @@ use asteroidb_poc::api::certified::{CertifiedApi, OnTimeout};
 use asteroidb_poc::api::eventual::EventualApi;
 use asteroidb_poc::authority::ack_frontier::{AckFrontier, AckFrontierSet};
 use asteroidb_poc::compaction::{CompactionConfig, CompactionEngine};
+use asteroidb_poc::control_plane::system_namespace::{AuthorityDefinition, SystemNamespace};
 use asteroidb_poc::crdt::pn_counter::PnCounter;
 use asteroidb_poc::error::CrdtError;
 use asteroidb_poc::hlc::HlcTimestamp;
@@ -48,6 +49,16 @@ fn make_frontier(authority: &str, physical: u64, logical: u32, prefix: &str) -> 
         policy_version: PolicyVersion(1),
         digest_hash: format!("{authority}-{physical}-{logical}"),
     }
+}
+
+/// Create a namespace with a catch-all authority definition (prefix "").
+fn default_namespace() -> SystemNamespace {
+    let mut ns = SystemNamespace::new();
+    ns.set_authority_definition(AuthorityDefinition {
+        key_range: KeyRange { prefix: "".into() },
+        authority_nodes: vec![node("auth-1"), node("auth-2"), node("auth-3")],
+    });
+    ns
 }
 
 /// Bidirectional merge between two EventualApi nodes for a single key.
@@ -152,7 +163,7 @@ fn partition_eventual_write_succeeds_in_both_partitions() {
 fn partition_certified_write_fails_without_majority() {
     // During partition, {C} alone cannot reach majority (needs 2 of 3 authorities).
     // Auth-1 and Auth-2 are in partition {A,B}; Auth-3 is with {C}.
-    let mut cert_c = CertifiedApi::new(node("node-c"), 3);
+    let mut cert_c = CertifiedApi::new(node("node-c"), default_namespace());
 
     // Only auth-3 reports a frontier (1 of 3 — no majority).
     cert_c.update_frontier(make_frontier("auth-3", 1000, 0, ""));
@@ -166,7 +177,7 @@ fn partition_certified_write_fails_without_majority() {
 #[test]
 fn partition_certified_write_pending_without_majority() {
     // Same scenario with OnTimeout::Pending — should return Pending.
-    let mut cert_c = CertifiedApi::new(node("node-c"), 3);
+    let mut cert_c = CertifiedApi::new(node("node-c"), default_namespace());
     cert_c.update_frontier(make_frontier("auth-3", 1000, 0, ""));
 
     let counter = CrdtValue::Counter(PnCounter::new());
@@ -437,7 +448,7 @@ fn convergence_multiple_keys_across_partitions() {
 fn authority_majority_loss_and_recovery() {
     // With 3 authorities, losing 2 means no majority.
     // When they recover (report updated frontiers), certification resumes.
-    let mut cert = CertifiedApi::new(node("node-a"), 3);
+    let mut cert = CertifiedApi::new(node("node-a"), default_namespace());
 
     // Write while no authorities have reported.
     let counter = CrdtValue::Counter(PnCounter::new());
@@ -504,8 +515,8 @@ fn authority_ack_frontier_handoff_after_replacement() {
 fn authority_partition_different_certified_values() {
     // During partition, authorities in different partitions may advance their
     // frontiers at different rates, producing "split" certification states.
-    let mut cert_ab = CertifiedApi::new(node("node-a"), 3);
-    let mut cert_c = CertifiedApi::new(node("node-c"), 3);
+    let mut cert_ab = CertifiedApi::new(node("node-a"), default_namespace());
+    let mut cert_c = CertifiedApi::new(node("node-c"), default_namespace());
 
     // Partition {A,B} has auth-1 and auth-2.
     // Partition {C} has auth-3.
@@ -779,7 +790,7 @@ fn partition_map_concurrent_set_and_delete_add_wins() {
 fn certified_write_succeeds_with_full_authority_set() {
     // Baseline: when all 3 authorities report frontiers past the write,
     // writes are certified.
-    let mut cert = CertifiedApi::new(node("node-a"), 3);
+    let mut cert = CertifiedApi::new(node("node-a"), default_namespace());
 
     // First write (will be Pending since no authorities have reported).
     let counter = CrdtValue::Counter(PnCounter::new());
@@ -849,7 +860,7 @@ fn partition_asymmetric_load_convergence() {
 fn partition_certified_api_multiple_pending_writes_resolve_after_heal() {
     // Multiple pending writes should all be certified once authorities
     // catch up after partition heal.
-    let mut cert = CertifiedApi::new(node("node-a"), 3);
+    let mut cert = CertifiedApi::new(node("node-a"), default_namespace());
 
     // Write 3 values while no authorities are available.
     for i in 0..3 {


### PR DESCRIPTION
## Summary

- **CertifiedApi** now resolves authority definitions per key using longest-prefix match via `SystemNamespace`, ensuring certification decisions are scoped to the correct key range and policy version
- Replaces global `total_authorities` with per-key authority resolution using `is_certified_at_for_scope()` and `majority_frontier_for_scope()`
- Stores resolved scope (`key_range`, `policy_version`, `total_authorities`) in `PendingWrite` for efficient re-evaluation during `process_certifications()`

## Changes

### `src/api/certified.rs`
- `CertifiedApi` now takes `SystemNamespace` instead of `total_authorities: usize`
- Added `resolve_scope()` helper for longest-prefix authority resolution
- `get_certified()` returns scoped majority frontier per key range
- `certified_write()` resolves scope and uses scoped certification checks
- `process_certifications()` evaluates each pending write against its scoped frontier
- Returns `CrdtError::PolicyDenied` if no authority definition covers a key

### Tests
- Updated all existing unit tests (19) and integration tests (16) to use `SystemNamespace`
- Added 6 new unit tests for range-aware behavior
- Added 3 new integration tests for cross-range contamination prevention

### Acceptance Criteria
- [x] A key range's certification is NOT affected by another range's frontier updates
- [x] Policy version transitions produce independent certification
- [x] Cross-range contamination prevention integration tests pass
- [x] All 437 tests pass (320 unit + 65 integration + 25 partition + 27 store_crdt_hlc)

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)