### PR TITLE
fix: resolve clippy needless_range_loop warning (#53)

### DIFF
--- a/tests/integration/replication_convergence.rs
+++ b/tests/integration/replication_convergence.rs
@@ -297,13 +297,13 @@ fn five_node_concurrent_register_write_lww_wins() {
 
     // Each node writes to the same register with increasing timestamps.
     // Node 4 has the highest timestamp, so its value should win.
-    for i in 0..5 {
+    for (i, store) in stores.iter_mut().enumerate() {
         let mut reg = LwwRegister::new();
         reg.set(
             format!("value-{}", i),
             ts((i as u64 + 1) * 100, 0, &format!("node-{}", i)),
         );
-        stores[i].put("shared-reg".into(), CrdtValue::Register(reg));
+        store.put("shared-reg".into(), CrdtValue::Register(reg));
     }
 
     full_mesh_merge(&mut stores);


### PR DESCRIPTION
## Summary
- `tests/integration/replication_convergence.rs` の `for i in 0..5 { stores[i]... }` ループを `for (i, store) in stores.iter_mut().enumerate()` に書き換え
- clippy `needless_range_loop` 警告を解消
- 意味論（node index ベースの timestamp/value 生成）は完全に維持

## Test plan
- [x] `cargo clippy --all-targets --all-features -- -D warnings` がパス
- [x] `cargo test` 全テスト（320 unit + 116 integration + 27 replication = 463）がパス

Closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)