### PR TITLE
fix: scope compaction eligibility by key_range and policy_version (#51)

### DIFF
--- a/src/compaction/engine.rs
+++ b/src/compaction/engine.rs
@@ -153,8 +153,10 @@ impl CompactionEngine {
 
     /// Check whether data for a key range can be compacted.
     ///
-    /// Compaction is safe only when the majority of authorities have consumed
-    /// updates past the checkpoint's timestamp (FR-010).
+    /// Compaction is safe only when the majority of authorities **within the
+    /// same key_range and policy_version scope** have consumed updates past
+    /// the checkpoint's timestamp (FR-010).  Frontiers from other key ranges
+    /// or policy versions are excluded to prevent cross-scope contamination.
     pub fn is_compactable(
         &self,
         prefix: &str,
@@ -166,7 +168,12 @@ impl CompactionEngine {
             None => return false,
         };
 
-        frontiers.is_certified_at(&checkpoint.timestamp, total_authorities)
+        frontiers.is_certified_at_for_scope(
+            &checkpoint.timestamp,
+            &checkpoint.key_range,
+            &checkpoint.policy_version,
+            total_authorities,
+        )
     }
 
     /// Verify the digest hash for a key range against the stored checkpoint.
@@ -478,6 +485,118 @@ mod tests {
         assert_eq!(log.len(), 1);
         assert_eq!(log[0].1, RevalidationTrigger::Manual);
         assert_eq!(log[0].0.physical, 5000);
+    }
+
+    #[test]
+    fn is_compactable_not_affected_by_other_key_range() {
+        let mut engine = CompactionEngine::with_defaults();
+        let kr_user = make_key_range("user/");
+
+        // Checkpoint at t=100 for user/
+        engine.create_checkpoint(
+            kr_user.clone(),
+            make_ts(100, 0, "node-a"),
+            "hash".into(),
+            PolicyVersion(1),
+        );
+
+        // 3 authorities, but all frontiers are for order/ (different key range)
+        let mut frontiers = AckFrontierSet::new();
+        frontiers.update(make_frontier("auth-1", 200, "order/"));
+        frontiers.update(make_frontier("auth-2", 300, "order/"));
+        frontiers.update(make_frontier("auth-3", 400, "order/"));
+
+        // Should NOT be compactable: no user/ frontiers exist
+        assert!(!engine.is_compactable("user/", &frontiers, 3));
+    }
+
+    #[test]
+    fn is_compactable_not_affected_by_other_policy_version() {
+        let mut engine = CompactionEngine::with_defaults();
+        let kr = make_key_range("user/");
+
+        // Checkpoint at t=100 for user/ with policy_version=1
+        engine.create_checkpoint(
+            kr.clone(),
+            make_ts(100, 0, "node-a"),
+            "hash".into(),
+            PolicyVersion(1),
+        );
+
+        // 3 authorities, but all frontiers are for policy_version=2
+        let mut frontiers = AckFrontierSet::new();
+        frontiers.update(AckFrontier {
+            authority_id: NodeId("auth-1".into()),
+            frontier_hlc: make_ts(200, 0, "auth-1"),
+            key_range: make_key_range("user/"),
+            policy_version: PolicyVersion(2),
+            digest_hash: "auth-1-200".into(),
+        });
+        frontiers.update(AckFrontier {
+            authority_id: NodeId("auth-2".into()),
+            frontier_hlc: make_ts(300, 0, "auth-2"),
+            key_range: make_key_range("user/"),
+            policy_version: PolicyVersion(2),
+            digest_hash: "auth-2-300".into(),
+        });
+        frontiers.update(AckFrontier {
+            authority_id: NodeId("auth-3".into()),
+            frontier_hlc: make_ts(400, 0, "auth-3"),
+            key_range: make_key_range("user/"),
+            policy_version: PolicyVersion(2),
+            digest_hash: "auth-3-400".into(),
+        });
+
+        // Should NOT be compactable: no policy_version=1 frontiers
+        assert!(!engine.is_compactable("user/", &frontiers, 3));
+    }
+
+    #[test]
+    fn is_compactable_scoped_majority_only() {
+        let mut engine = CompactionEngine::with_defaults();
+        let kr = make_key_range("user/");
+
+        // Checkpoint at t=100 for user/
+        engine.create_checkpoint(
+            kr.clone(),
+            make_ts(100, 0, "node-a"),
+            "hash".into(),
+            PolicyVersion(1),
+        );
+
+        let mut frontiers = AckFrontierSet::new();
+        // 1 authority in user/ scope (insufficient for majority of 3)
+        frontiers.update(make_frontier("auth-1", 200, "user/"));
+        // 2 authorities in order/ scope (irrelevant)
+        frontiers.update(make_frontier("auth-2", 300, "order/"));
+        frontiers.update(make_frontier("auth-3", 400, "order/"));
+
+        // Should NOT be compactable: only 1 of 3 in user/ scope
+        assert!(!engine.is_compactable("user/", &frontiers, 3));
+    }
+
+    #[test]
+    fn is_compactable_with_matching_scope() {
+        let mut engine = CompactionEngine::with_defaults();
+        let kr = make_key_range("user/");
+
+        // Checkpoint at t=100 for user/ with policy_version=1
+        engine.create_checkpoint(
+            kr.clone(),
+            make_ts(100, 0, "node-a"),
+            "hash".into(),
+            PolicyVersion(1),
+        );
+
+        let mut frontiers = AckFrontierSet::new();
+        // 2 of 3 authorities in correct scope (user/, policy_version=1)
+        frontiers.update(make_frontier("auth-1", 200, "user/"));
+        frontiers.update(make_frontier("auth-2", 300, "user/"));
+        // 1 authority in wrong scope
+        frontiers.update(make_frontier("auth-3", 400, "order/"));
+
+        // Should be compactable: 2 of 3 in user/ scope past t=100
+        assert!(engine.is_compactable("user/", &frontiers, 3));
     }
 
     #[test]

--- a/tests/integration/quorum_safety_regression.rs
+++ b/tests/integration/quorum_safety_regression.rs
@@ -557,9 +557,10 @@ fn mixed_duplicate_and_unique_acks_counted_correctly() {
 // 4. Compaction eligibility checks under scoped frontiers (#39, FR-010)
 // ===========================================================================
 
-/// Compaction eligibility must use global (unscoped) majority frontier,
-/// so a checkpoint is only compactable when authorities in the *same scope*
-/// have consumed past it.
+/// Compaction eligibility uses scoped majority frontier (#51),
+/// so a checkpoint is only compactable when authorities in the *same
+/// key_range and policy_version scope* have consumed past it.
+/// Frontiers from other key ranges must NOT contribute.
 #[test]
 fn compaction_eligibility_uses_global_frontier() {
     let mut engine = CompactionEngine::new(CompactionConfig {
@@ -575,14 +576,12 @@ fn compaction_eligibility_uses_global_frontier() {
     frontiers.update(make_frontier("auth-1", 500, 0, "order/"));
     frontiers.update(make_frontier("auth-2", 600, 0, "order/"));
 
-    // is_compactable uses global is_certified_at which counts all entries.
-    // With 2 entries total and total_authorities=3, majority=2 → frontier index=0 → 500.
-    // Checkpoint at 100 ≤ 500, so technically it could pass with global queries.
-    // BUT: this demonstrates the need for scoped compaction in production.
-    // The current engine uses is_certified_at (global), so this DOES pass:
-    assert!(engine.is_compactable("user/", &frontiers, 3));
+    // is_compactable uses scoped is_certified_at_for_scope which only counts
+    // entries matching the checkpoint's key_range + policy_version.
+    // No "user/" frontiers exist, so this must NOT be compactable:
+    assert!(!engine.is_compactable("user/", &frontiers, 3));
 
-    // With only 1 frontier entry (below majority): NOT compactable
+    // With only 1 frontier entry (also wrong scope): still NOT compactable
     let mut frontiers_insufficient = AckFrontierSet::new();
     frontiers_insufficient.update(make_frontier("auth-1", 500, 0, "order/"));
     assert!(!engine.is_compactable("user/", &frontiers_insufficient, 3));


### PR DESCRIPTION
## Summary

- `CompactionEngine::is_compactable` を global `is_certified_at` から scoped `is_certified_at_for_scope` に変更
- Checkpoint の `key_range` と `policy_version` でスコープされた majority 判定のみ使用
- 他レンジや異なる policy version の frontier では compaction 不可になるよう修正
- 新規テスト4件追加 + 既存 regression テスト1件を scoped 判定に合わせて更新

Closes #51

## Test plan

- [x] 他レンジの frontier では compaction 可にならないことを検証 (`is_compactable_not_affected_by_other_key_range`)
- [x] 異なる policy_version の frontier では compaction 可にならないことを検証 (`is_compactable_not_affected_by_other_policy_version`)
- [x] 同一スコープの部分的 frontier では majority 不足で不可 (`is_compactable_scoped_majority_only`)
- [x] 正しいスコープの majority で compaction 可 (`is_compactable_with_matching_scope`)
- [x] 既存テスト 467 件 (ignored 2) 全パス
- [x] `cargo fmt --check && cargo clippy -- -D warnings && cargo test` 全パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)