### PR TITLE
feat: add AckFrontierSet and CertificationTracker persistence (#63)

### DIFF
--- a/src/api/status.rs
+++ b/src/api/status.rs
@@ -1,4 +1,6 @@
 use std::collections::{HashMap, HashSet};
+use std::io;
+use std::path::Path;
 
 use serde::{Deserialize, Serialize};
 
@@ -15,7 +17,7 @@ pub struct WriteId {
 }
 
 /// Entry tracking a single write's certification progress.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct StatusEntry {
     /// The write this entry tracks.
     pub write_id: WriteId,
@@ -37,9 +39,40 @@ pub struct StatusEntry {
 /// The tracker monitors acknowledgements from authority nodes and
 /// automatically promotes writes to `Certified` once the majority
 /// threshold is reached.
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CertificationTracker {
+    #[serde(with = "entries_map_serde")]
     entries: HashMap<WriteId, StatusEntry>,
     default_timeout_ms: u64,
+}
+
+/// Custom serde for `HashMap<WriteId, StatusEntry>`.
+///
+/// JSON only supports string keys, so we serialize the map as a
+/// `Vec<(WriteId, StatusEntry)>` instead.
+mod entries_map_serde {
+    use super::*;
+    use serde::de::Deserializer;
+    use serde::ser::Serializer;
+
+    pub fn serialize<S>(
+        map: &HashMap<WriteId, StatusEntry>,
+        serializer: S,
+    ) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let vec: Vec<(&WriteId, &StatusEntry)> = map.iter().collect();
+        vec.serialize(serializer)
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<HashMap<WriteId, StatusEntry>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let vec: Vec<(WriteId, StatusEntry)> = Vec::deserialize(deserializer)?;
+        Ok(vec.into_iter().collect())
+    }
 }
 
 impl CertificationTracker {
@@ -189,6 +222,60 @@ impl CertificationTracker {
     /// Returns the total number of tracked entries (all statuses).
     pub fn total_count(&self) -> usize {
         self.entries.len()
+    }
+
+    // ---------------------------------------------------------------
+    // Persistence
+    // ---------------------------------------------------------------
+
+    /// Serialize the tracker to a JSON string.
+    pub fn to_json(&self) -> Result<String, io::Error> {
+        serde_json::to_string_pretty(self)
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))
+    }
+
+    /// Deserialize a tracker from a JSON string.
+    ///
+    /// After deserialization, entry consistency is validated: each
+    /// `WriteId` key must match the `StatusEntry`'s `write_id` field.
+    pub fn from_json(json: &str) -> Result<Self, io::Error> {
+        let tracker: Self = serde_json::from_str(json)
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+        tracker.validate_entry_consistency()?;
+        Ok(tracker)
+    }
+
+    /// Save the tracker to a file as JSON.
+    pub fn save(&self, path: &Path) -> Result<(), io::Error> {
+        let json = self.to_json()?;
+        std::fs::write(path, json)
+    }
+
+    /// Load a tracker from a JSON file.
+    ///
+    /// Performs entry consistency validation after loading.
+    pub fn load(path: &Path) -> Result<Self, io::Error> {
+        let json = std::fs::read_to_string(path)?;
+        Self::from_json(&json)
+    }
+
+    /// Validate that every `WriteId` key matches its `StatusEntry`'s `write_id`.
+    ///
+    /// Returns an error if any key is inconsistent with the entry it maps to
+    /// (e.g., due to manual editing or data corruption).
+    fn validate_entry_consistency(&self) -> Result<(), io::Error> {
+        for (key, entry) in &self.entries {
+            if *key != entry.write_id {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!(
+                        "entry key mismatch: key {:?} does not match entry write_id {:?}",
+                        key, entry.write_id
+                    ),
+                ));
+            }
+        }
+        Ok(())
     }
 }
 
@@ -632,5 +719,189 @@ mod tests {
         tracker.cleanup(&ts(2000, 0, "node-a"), 500);
 
         assert_eq!(tracker.total_count(), 0);
+    }
+
+    // ---------------------------------------------------------------
+    // Persistence tests
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn serde_roundtrip_status_entry() {
+        let mut tracker = CertificationTracker::new();
+        let wid = write_id("key-1", 1000);
+        tracker.register_write(wid.clone(), 3, ts(1000, 0, "node-a"));
+        tracker.record_ack(&wid, auth("auth-1"), ts(1001, 0, "auth-1"));
+
+        let entry = tracker.get_entry(&wid).unwrap();
+        let json = serde_json::to_string(entry).expect("serialize");
+        let back: StatusEntry = serde_json::from_str(&json).expect("deserialize");
+
+        assert_eq!(back.write_id, wid);
+        assert_eq!(back.status, CertificationStatus::Pending);
+        assert_eq!(back.acked_by.len(), 1);
+        assert!(back.acked_by.contains(&auth("auth-1")));
+        assert_eq!(back.acks_required, 3);
+    }
+
+    #[test]
+    fn serde_roundtrip_certification_tracker() {
+        let mut tracker = CertificationTracker::with_timeout(5000);
+        let wid1 = write_id("key-1", 1000);
+        let wid2 = write_id("key-2", 2000);
+        let wid3 = write_id("key-3", 3000);
+
+        tracker.register_write(wid1.clone(), 3, ts(1000, 0, "node-a"));
+        tracker.register_write(wid2.clone(), 1, ts(2000, 0, "node-a"));
+        tracker.register_write(wid3.clone(), 2, ts(3000, 0, "node-a"));
+
+        // Certify wid2
+        tracker.record_ack(&wid2, auth("auth-1"), ts(2001, 0, "auth-1"));
+        // Partially ack wid1
+        tracker.record_ack(&wid1, auth("auth-1"), ts(1001, 0, "auth-1"));
+
+        let json = tracker.to_json().expect("serialize");
+        let restored = CertificationTracker::from_json(&json).expect("deserialize");
+
+        assert_eq!(restored.total_count(), 3);
+        assert_eq!(
+            restored.get_status(&wid1),
+            Some(CertificationStatus::Pending)
+        );
+        assert_eq!(
+            restored.get_status(&wid2),
+            Some(CertificationStatus::Certified)
+        );
+        assert_eq!(
+            restored.get_status(&wid3),
+            Some(CertificationStatus::Pending)
+        );
+
+        // Verify acks are preserved
+        let entry1 = restored.get_entry(&wid1).unwrap();
+        assert_eq!(entry1.acked_by.len(), 1);
+        assert!(entry1.acked_by.contains(&auth("auth-1")));
+    }
+
+    #[test]
+    fn serde_roundtrip_empty_tracker() {
+        let tracker = CertificationTracker::new();
+        let json = tracker.to_json().expect("serialize");
+        let restored = CertificationTracker::from_json(&json).expect("deserialize");
+        assert_eq!(restored.total_count(), 0);
+    }
+
+    #[test]
+    fn save_and_load_tracker() {
+        let mut tracker = CertificationTracker::with_timeout(10_000);
+        let wid1 = write_id("key-1", 1000);
+        let wid2 = write_id("key-2", 2000);
+
+        tracker.register_write(wid1.clone(), 2, ts(1000, 0, "node-a"));
+        tracker.register_write(wid2.clone(), 1, ts(2000, 0, "node-a"));
+        tracker.record_ack(&wid2, auth("auth-1"), ts(2001, 0, "auth-1"));
+
+        let dir = std::env::temp_dir().join("asteroidb_test_tracker_save");
+        let _ = std::fs::create_dir_all(&dir);
+        let path = dir.join("tracker.json");
+
+        tracker.save(&path).expect("save");
+        let restored = CertificationTracker::load(&path).expect("load");
+
+        assert_eq!(restored.total_count(), 2);
+        assert_eq!(restored.pending_count(), 1);
+        assert_eq!(
+            restored.get_status(&wid1),
+            Some(CertificationStatus::Pending)
+        );
+        assert_eq!(
+            restored.get_status(&wid2),
+            Some(CertificationStatus::Certified)
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn restored_tracker_continues_certification() {
+        let mut tracker = CertificationTracker::new();
+        let wid = write_id("key-1", 1000);
+        tracker.register_write(wid.clone(), 2, ts(1000, 0, "node-a"));
+        tracker.record_ack(&wid, auth("auth-1"), ts(1001, 0, "auth-1"));
+
+        // Save while partially acked
+        let json = tracker.to_json().expect("serialize");
+        let mut restored = CertificationTracker::from_json(&json).expect("deserialize");
+
+        // Continue certification on restored tracker
+        let status = restored.record_ack(&wid, auth("auth-2"), ts(1002, 0, "auth-2"));
+        assert_eq!(status, Some(CertificationStatus::Certified));
+    }
+
+    #[test]
+    fn restored_tracker_timeout_still_works() {
+        let mut tracker = CertificationTracker::with_timeout(5000);
+        let wid = write_id("key-1", 1000);
+        tracker.register_write(wid.clone(), 3, ts(1000, 0, "node-a"));
+
+        let json = tracker.to_json().expect("serialize");
+        let mut restored = CertificationTracker::from_json(&json).expect("deserialize");
+
+        // Timeout should work on restored tracker
+        restored.check_timeouts(&ts(7000, 0, "node-a"));
+        assert_eq!(
+            restored.get_status(&wid),
+            Some(CertificationStatus::Timeout)
+        );
+    }
+
+    #[test]
+    fn load_nonexistent_file_returns_error() {
+        let path = std::path::PathBuf::from("/tmp/asteroidb_nonexistent_tracker.json");
+        let result = CertificationTracker::load(&path);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn from_json_invalid_data_returns_error() {
+        let result = CertificationTracker::from_json("not valid json");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn save_and_load_preserves_all_statuses() {
+        let mut tracker = CertificationTracker::with_timeout(100);
+        let wid_pending = write_id("pending", 10000);
+        let wid_certified = write_id("certified", 2000);
+        let wid_rejected = write_id("rejected", 3000);
+        let wid_timeout = write_id("timeout", 4000);
+
+        tracker.register_write(wid_pending.clone(), 3, ts(10000, 0, "node-a"));
+        tracker.register_write(wid_certified.clone(), 1, ts(2000, 0, "node-a"));
+        tracker.register_write(wid_rejected.clone(), 3, ts(3000, 0, "node-a"));
+        tracker.register_write(wid_timeout.clone(), 3, ts(100, 0, "node-a"));
+
+        tracker.record_ack(&wid_certified, auth("auth-1"), ts(2001, 0, "auth-1"));
+        tracker.reject(&wid_rejected, ts(3001, 0, "auth-1"));
+        tracker.check_timeouts(&ts(10000, 0, "node-a"));
+
+        let json = tracker.to_json().expect("serialize");
+        let restored = CertificationTracker::from_json(&json).expect("deserialize");
+
+        assert_eq!(
+            restored.get_status(&wid_pending),
+            Some(CertificationStatus::Pending)
+        );
+        assert_eq!(
+            restored.get_status(&wid_certified),
+            Some(CertificationStatus::Certified)
+        );
+        assert_eq!(
+            restored.get_status(&wid_rejected),
+            Some(CertificationStatus::Rejected)
+        );
+        assert_eq!(
+            restored.get_status(&wid_timeout),
+            Some(CertificationStatus::Timeout)
+        );
     }
 }

--- a/src/authority/ack_frontier.rs
+++ b/src/authority/ack_frontier.rs
@@ -1,4 +1,6 @@
 use std::collections::HashMap;
+use std::io;
+use std::path::Path;
 
 use serde::{Deserialize, Serialize};
 
@@ -66,9 +68,41 @@ impl FrontierScope {
 /// eligibility (`majority_frontier`, `is_certified_at`).  Both unscoped
 /// (all entries) and scoped (filtered by key_range + policy_version)
 /// query variants are available.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AckFrontierSet {
+    #[serde(with = "frontier_map_serde")]
     frontiers: HashMap<FrontierScope, AckFrontier>,
+}
+
+/// Custom serde for `HashMap<FrontierScope, AckFrontier>`.
+///
+/// JSON only supports string keys, so we serialize the map as a
+/// `Vec<(FrontierScope, AckFrontier)>` instead.
+mod frontier_map_serde {
+    use super::*;
+    use serde::de::Deserializer;
+    use serde::ser::Serializer;
+
+    pub fn serialize<S>(
+        map: &HashMap<FrontierScope, AckFrontier>,
+        serializer: S,
+    ) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let vec: Vec<(&FrontierScope, &AckFrontier)> = map.iter().collect();
+        vec.serialize(serializer)
+    }
+
+    pub fn deserialize<'de, D>(
+        deserializer: D,
+    ) -> Result<HashMap<FrontierScope, AckFrontier>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let vec: Vec<(FrontierScope, AckFrontier)> = Vec::deserialize(deserializer)?;
+        Ok(vec.into_iter().collect())
+    }
 }
 
 impl AckFrontierSet {
@@ -223,6 +257,61 @@ impl AckFrontierSet {
             Some(ref mf) => timestamp <= mf,
             None => false,
         }
+    }
+
+    // ---------------------------------------------------------------
+    // Persistence
+    // ---------------------------------------------------------------
+
+    /// Serialize the frontier set to a JSON string.
+    pub fn to_json(&self) -> Result<String, io::Error> {
+        serde_json::to_string_pretty(self)
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))
+    }
+
+    /// Deserialize a frontier set from a JSON string.
+    ///
+    /// After deserialization, scope consistency is validated: each entry's
+    /// `FrontierScope` key must match the `AckFrontier` value it maps to.
+    pub fn from_json(json: &str) -> Result<Self, io::Error> {
+        let set: Self = serde_json::from_str(json)
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+        set.validate_scope_consistency()?;
+        Ok(set)
+    }
+
+    /// Save the frontier set to a file as JSON.
+    pub fn save(&self, path: &Path) -> Result<(), io::Error> {
+        let json = self.to_json()?;
+        std::fs::write(path, json)
+    }
+
+    /// Load a frontier set from a JSON file.
+    ///
+    /// Performs scope consistency validation after loading.
+    pub fn load(path: &Path) -> Result<Self, io::Error> {
+        let json = std::fs::read_to_string(path)?;
+        Self::from_json(&json)
+    }
+
+    /// Validate that every `FrontierScope` key matches its `AckFrontier` value.
+    ///
+    /// Returns an error if any scope key is inconsistent with the frontier
+    /// it maps to (e.g., due to manual editing or data corruption).
+    fn validate_scope_consistency(&self) -> Result<(), io::Error> {
+        for (scope, frontier) in &self.frontiers {
+            let expected = FrontierScope::from_frontier(frontier);
+            if *scope != expected {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!(
+                        "scope mismatch: key {:?} does not match frontier {:?}",
+                        scope, expected
+                    ),
+                ));
+            }
+        }
+        Ok(())
     }
 }
 
@@ -751,5 +840,159 @@ mod tests {
         // v1 entries not contaminated by v2
         assert!(set.is_certified_at_for_scope(&make_ts(100, 0, "c"), &kr("user/"), &pv(1), 3));
         assert!(!set.is_certified_at_for_scope(&make_ts(100, 0, "c"), &kr("user/"), &pv(2), 3));
+    }
+
+    // ---------------------------------------------------------------
+    // Persistence tests
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn serde_roundtrip_ack_frontier_set() {
+        let mut set = AckFrontierSet::new();
+        set.update(make_frontier("auth-1", 100, 0, "user/"));
+        set.update(make_frontier("auth-2", 200, 0, "user/"));
+        set.update(make_frontier("auth-1", 300, 0, "order/"));
+
+        let json = set.to_json().expect("serialize");
+        let restored = AckFrontierSet::from_json(&json).expect("deserialize");
+
+        assert_eq!(restored.all().len(), 3);
+
+        let scope_user_1 = FrontierScope::new(kr("user/"), pv(1), NodeId("auth-1".into()));
+        let scope_user_2 = FrontierScope::new(kr("user/"), pv(1), NodeId("auth-2".into()));
+        let scope_order = FrontierScope::new(kr("order/"), pv(1), NodeId("auth-1".into()));
+
+        assert_eq!(
+            restored
+                .get_scoped(&scope_user_1)
+                .unwrap()
+                .frontier_hlc
+                .physical,
+            100
+        );
+        assert_eq!(
+            restored
+                .get_scoped(&scope_user_2)
+                .unwrap()
+                .frontier_hlc
+                .physical,
+            200
+        );
+        assert_eq!(
+            restored
+                .get_scoped(&scope_order)
+                .unwrap()
+                .frontier_hlc
+                .physical,
+            300
+        );
+    }
+
+    #[test]
+    fn serde_roundtrip_empty_frontier_set() {
+        let set = AckFrontierSet::new();
+        let json = set.to_json().expect("serialize");
+        let restored = AckFrontierSet::from_json(&json).expect("deserialize");
+        assert!(restored.all().is_empty());
+    }
+
+    #[test]
+    fn save_and_load_frontier_set() {
+        let mut set = AckFrontierSet::new();
+        set.update(make_frontier("auth-1", 100, 0, "user/"));
+        set.update(make_frontier("auth-2", 200, 0, "user/"));
+        set.update(make_frontier_v("auth-1", 50, 0, "user/", 2));
+
+        let dir = std::env::temp_dir().join("asteroidb_test_frontier_save");
+        let _ = std::fs::create_dir_all(&dir);
+        let path = dir.join("frontier_set.json");
+
+        set.save(&path).expect("save");
+        let restored = AckFrontierSet::load(&path).expect("load");
+
+        assert_eq!(restored.all().len(), 3);
+
+        // Verify scoped queries work on restored data
+        let mf = restored
+            .majority_frontier_for_scope(&kr("user/"), &pv(1), 3)
+            .unwrap();
+        assert_eq!(mf.physical, 100);
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn save_and_load_preserves_scope_info() {
+        let mut set = AckFrontierSet::new();
+
+        // Multiple scopes: different key ranges and policy versions
+        set.update(make_frontier_v("auth-1", 100, 0, "user/", 1));
+        set.update(make_frontier_v("auth-2", 200, 0, "user/", 1));
+        set.update(make_frontier_v("auth-1", 50, 0, "order/", 1));
+        set.update(make_frontier_v("auth-1", 10, 0, "user/", 2));
+
+        let dir = std::env::temp_dir().join("asteroidb_test_frontier_scope");
+        let _ = std::fs::create_dir_all(&dir);
+        let path = dir.join("frontier_scoped.json");
+
+        set.save(&path).expect("save");
+        let restored = AckFrontierSet::load(&path).expect("load");
+
+        assert_eq!(restored.all().len(), 4);
+
+        // Verify each scope independently
+        assert_eq!(restored.all_for_scope(&kr("user/"), &pv(1)).len(), 2);
+        assert_eq!(restored.all_for_scope(&kr("order/"), &pv(1)).len(), 1);
+        assert_eq!(restored.all_for_scope(&kr("user/"), &pv(2)).len(), 1);
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn load_nonexistent_file_returns_error() {
+        let path = std::path::PathBuf::from("/tmp/asteroidb_nonexistent_frontier.json");
+        let result = AckFrontierSet::load(&path);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn from_json_invalid_data_returns_error() {
+        let result = AckFrontierSet::from_json("not valid json");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn scope_consistency_validated_on_load() {
+        // Build valid JSON then corrupt the scope key to create a mismatch.
+        // The serialized format is a Vec of (FrontierScope, AckFrontier) tuples.
+        // We corrupt the scope's authority_id so it no longer matches the frontier's.
+        let corrupted_json = r#"{
+            "frontiers": [
+                [
+                    {
+                        "key_range": {"prefix": "user/"},
+                        "policy_version": 1,
+                        "authority_id": "auth-WRONG"
+                    },
+                    {
+                        "authority_id": "auth-1",
+                        "frontier_hlc": {"physical": 100, "logical": 0, "node_id": "auth-1"},
+                        "key_range": {"prefix": "user/"},
+                        "policy_version": 1,
+                        "digest_hash": "auth-1-100-0"
+                    }
+                ]
+            ]
+        }"#;
+
+        let result = AckFrontierSet::from_json(corrupted_json);
+        assert!(result.is_err());
+
+        // Verify the error message mentions scope mismatch
+        let err_msg = result.unwrap_err().to_string();
+        assert!(
+            err_msg.contains("scope mismatch"),
+            "expected scope mismatch error, got: {err_msg}"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- `AckFrontierSet` に `Serialize`/`Deserialize` derive と `save`/`load`/`to_json`/`from_json` メソッドを追加
- `StatusEntry` と `CertificationTracker` に `Serialize`/`Deserialize` derive と `save`/`load`/`to_json`/`from_json` メソッドを追加
- 復元時のスコープ整合チェック（`validate_scope_consistency` / `validate_entry_consistency`）を実装
- HashMap の非文字列キー問題を Vec-of-tuples カスタム serde で解決

## Test plan

- [x] `AckFrontierSet` の JSON roundtrip テスト（空・複数スコープ）
- [x] `AckFrontierSet` のファイル save/load テスト
- [x] スコープ整合チェック: 不正な JSON でエラーを返すことを確認
- [x] `CertificationTracker` の JSON roundtrip テスト（空・複数ステータス）
- [x] `CertificationTracker` のファイル save/load テスト
- [x] 復元後に certification 継続可能であることを確認
- [x] 復元後に timeout 判定が機能することを確認
- [x] 全ステータス（Pending/Certified/Rejected/Timeout）が保存・復元されることを確認
- [x] 既存 470+ テストが全パス

Closes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)