### PR TITLE
feat: add HTTP API for eventual/certified/status (#59)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,9 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 ed25519-dalek = { version = "2", features = ["rand_core"] }
 rand = "0.8"
+tokio = { version = "1", features = ["full"] }
+axum = "0.8"
+
+[dev-dependencies]
+tower = { version = "0.5", features = ["util"] }
+http-body-util = "0.1"

--- a/src/http/handlers.rs
+++ b/src/http/handlers.rs
@@ -1,0 +1,292 @@
+use std::sync::Arc;
+
+use axum::Json;
+use axum::extract::{Path, State};
+use tokio::sync::Mutex;
+
+use crate::api::certified::{CertifiedApi, OnTimeout};
+use crate::api::eventual::EventualApi;
+use crate::crdt::pn_counter::PnCounter;
+use crate::error::CrdtError;
+use crate::store::kv::CrdtValue;
+
+use super::types::{
+    ApiError, CertifiedReadResponse, CertifiedWriteRequest, CertifiedWriteResponse, CrdtValueJson,
+    EventualReadResponse, EventualWriteRequest, FrontierJson, StatusResponse, WriteResponse,
+};
+
+/// Shared application state for HTTP handlers.
+pub struct AppState {
+    pub eventual: Mutex<EventualApi>,
+    pub certified: Mutex<CertifiedApi>,
+}
+
+// ---------------------------------------------------------------
+// Eventual handlers
+// ---------------------------------------------------------------
+
+/// `POST /api/eventual/write`
+///
+/// Accepts a typed CRDT operation and applies it to the eventual store.
+pub async fn eventual_write(
+    State(state): State<Arc<AppState>>,
+    Json(req): Json<EventualWriteRequest>,
+) -> Result<Json<WriteResponse>, ApiError> {
+    let mut api = state.eventual.lock().await;
+
+    match req {
+        EventualWriteRequest::CounterInc { key } => {
+            api.eventual_counter_inc(&key)?;
+        }
+        EventualWriteRequest::CounterDec { key } => {
+            api.eventual_counter_dec(&key)?;
+        }
+        EventualWriteRequest::SetAdd { key, element } => {
+            api.eventual_set_add(&key, element)?;
+        }
+        EventualWriteRequest::SetRemove { key, element } => {
+            api.eventual_set_remove(&key, &element)?;
+        }
+        EventualWriteRequest::MapSet {
+            key,
+            map_key,
+            map_value,
+        } => {
+            api.eventual_map_set(&key, map_key, map_value)?;
+        }
+        EventualWriteRequest::MapDelete { key, map_key } => {
+            api.eventual_map_delete(&key, &map_key)?;
+        }
+        EventualWriteRequest::RegisterSet { key, value } => {
+            api.eventual_register_set(&key, value)?;
+        }
+    }
+
+    Ok(Json(WriteResponse { ok: true }))
+}
+
+/// `GET /api/eventual/:key`
+///
+/// Returns the local CRDT value for the given key.
+pub async fn get_eventual(
+    State(state): State<Arc<AppState>>,
+    Path(key): Path<String>,
+) -> Json<EventualReadResponse> {
+    let api = state.eventual.lock().await;
+    let value = api.get_eventual(&key).map(CrdtValueJson::from_crdt_value);
+
+    Json(EventualReadResponse { key, value })
+}
+
+// ---------------------------------------------------------------
+// Certified handlers
+// ---------------------------------------------------------------
+
+/// `POST /api/certified/write`
+///
+/// Writes a value that requires Authority majority certification.
+pub async fn certified_write(
+    State(state): State<Arc<AppState>>,
+    Json(req): Json<CertifiedWriteRequest>,
+) -> Result<Json<CertifiedWriteResponse>, ApiError> {
+    let on_timeout = match req.on_timeout.as_str() {
+        "error" => OnTimeout::Error,
+        _ => OnTimeout::Pending,
+    };
+
+    let crdt_value = json_to_crdt_value(&req.value)?;
+
+    let mut api = state.certified.lock().await;
+    let status = api.certified_write(req.key, crdt_value, on_timeout)?;
+
+    Ok(Json(CertifiedWriteResponse { status }))
+}
+
+/// `GET /api/certified/:key`
+///
+/// Returns the value with certification status and frontier.
+pub async fn get_certified(
+    State(state): State<Arc<AppState>>,
+    Path(key): Path<String>,
+) -> Json<CertifiedReadResponse> {
+    let api = state.certified.lock().await;
+    let read = api.get_certified(&key);
+
+    let value = read.value.map(CrdtValueJson::from_crdt_value);
+    let frontier = read.frontier.map(|f| FrontierJson {
+        physical: f.physical,
+        logical: f.logical,
+        node_id: f.node_id,
+    });
+
+    Json(CertifiedReadResponse {
+        key,
+        value,
+        status: read.status,
+        frontier,
+    })
+}
+
+/// `GET /api/status/:key`
+///
+/// Returns the certification status of the latest write for the given key.
+pub async fn get_certification_status(
+    State(state): State<Arc<AppState>>,
+    Path(key): Path<String>,
+) -> Json<StatusResponse> {
+    let api = state.certified.lock().await;
+    let status = api.get_certification_status(&key);
+
+    Json(StatusResponse { key, status })
+}
+
+// ---------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------
+
+/// Convert a JSON CRDT value representation into an internal `CrdtValue`.
+///
+/// For Counter, creates a PnCounter with the specified value by incrementing
+/// a synthetic writer node. For Set/Map/Register, constructs the appropriate
+/// CRDT type from the provided data.
+fn json_to_crdt_value(json: &CrdtValueJson) -> Result<CrdtValue, CrdtError> {
+    use crate::crdt::lww_register::LwwRegister;
+    use crate::crdt::or_map::OrMap;
+    use crate::crdt::or_set::OrSet;
+    use crate::hlc::Hlc;
+    use crate::types::NodeId;
+
+    let writer = NodeId("http-writer".into());
+
+    match json {
+        CrdtValueJson::Counter { value } => {
+            let mut counter = PnCounter::new();
+            if *value >= 0 {
+                for _ in 0..*value {
+                    counter.increment(&writer);
+                }
+            } else {
+                for _ in 0..value.unsigned_abs() {
+                    counter.decrement(&writer);
+                }
+            }
+            Ok(CrdtValue::Counter(counter))
+        }
+        CrdtValueJson::Set { elements } => {
+            let mut set = OrSet::new();
+            for elem in elements {
+                set.add(elem.clone(), &writer);
+            }
+            Ok(CrdtValue::Set(set))
+        }
+        CrdtValueJson::Map { entries } => {
+            let mut map = OrMap::new();
+            let mut clock = Hlc::new("http-writer".into());
+            for (k, v) in entries {
+                let ts = clock.now();
+                map.set(k.clone(), v.clone(), ts, &writer);
+            }
+            Ok(CrdtValue::Map(map))
+        }
+        CrdtValueJson::Register { value } => {
+            let mut reg = LwwRegister::new();
+            if let Some(v) = value {
+                let mut clock = Hlc::new("http-writer".into());
+                let ts = clock.now();
+                reg.set(v.clone(), ts);
+            }
+            Ok(CrdtValue::Register(reg))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn json_to_crdt_counter_positive() {
+        let json = CrdtValueJson::Counter { value: 5 };
+        let val = json_to_crdt_value(&json).unwrap();
+        match val {
+            CrdtValue::Counter(c) => assert_eq!(c.value(), 5),
+            other => panic!("expected Counter, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn json_to_crdt_counter_negative() {
+        let json = CrdtValueJson::Counter { value: -3 };
+        let val = json_to_crdt_value(&json).unwrap();
+        match val {
+            CrdtValue::Counter(c) => assert_eq!(c.value(), -3),
+            other => panic!("expected Counter, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn json_to_crdt_counter_zero() {
+        let json = CrdtValueJson::Counter { value: 0 };
+        let val = json_to_crdt_value(&json).unwrap();
+        match val {
+            CrdtValue::Counter(c) => assert_eq!(c.value(), 0),
+            other => panic!("expected Counter, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn json_to_crdt_set() {
+        let json = CrdtValueJson::Set {
+            elements: vec!["a".into(), "b".into()],
+        };
+        let val = json_to_crdt_value(&json).unwrap();
+        match val {
+            CrdtValue::Set(s) => {
+                assert!(s.contains(&"a".to_string()));
+                assert!(s.contains(&"b".to_string()));
+                assert_eq!(s.len(), 2);
+            }
+            other => panic!("expected Set, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn json_to_crdt_map() {
+        let mut entries = std::collections::HashMap::new();
+        entries.insert("name".into(), "db".into());
+        let json = CrdtValueJson::Map { entries };
+        let val = json_to_crdt_value(&json).unwrap();
+        match val {
+            CrdtValue::Map(m) => {
+                assert_eq!(m.get(&"name".to_string()), Some(&"db".to_string()));
+            }
+            other => panic!("expected Map, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn json_to_crdt_register_with_value() {
+        let json = CrdtValueJson::Register {
+            value: Some("hello".into()),
+        };
+        let val = json_to_crdt_value(&json).unwrap();
+        match val {
+            CrdtValue::Register(r) => {
+                assert_eq!(r.get(), Some(&"hello".to_string()));
+            }
+            other => panic!("expected Register, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn json_to_crdt_register_empty() {
+        let json = CrdtValueJson::Register { value: None };
+        let val = json_to_crdt_value(&json).unwrap();
+        match val {
+            CrdtValue::Register(r) => {
+                assert_eq!(r.get(), None);
+            }
+            other => panic!("expected Register, got {other:?}"),
+        }
+    }
+}

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -1,0 +1,3 @@
+pub mod handlers;
+pub mod routes;
+pub mod types;

--- a/src/http/routes.rs
+++ b/src/http/routes.rs
@@ -1,0 +1,515 @@
+use std::sync::Arc;
+
+use axum::Router;
+use axum::routing::{get, post};
+
+use super::handlers::{
+    AppState, certified_write, eventual_write, get_certification_status, get_certified,
+    get_eventual,
+};
+
+/// Build the HTTP API router with all endpoints.
+pub fn router(state: Arc<AppState>) -> Router {
+    Router::new()
+        .route("/api/eventual/write", post(eventual_write))
+        .route("/api/eventual/{key}", get(get_eventual))
+        .route("/api/certified/write", post(certified_write))
+        .route("/api/certified/{key}", get(get_certified))
+        .route("/api/status/{key}", get(get_certification_status))
+        .with_state(state)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::api::certified::CertifiedApi;
+    use crate::api::eventual::EventualApi;
+    use crate::control_plane::system_namespace::{AuthorityDefinition, SystemNamespace};
+    use crate::http::types::{
+        CertifiedReadResponse, CertifiedWriteResponse, CrdtValueJson, EventualReadResponse,
+        StatusResponse, WriteResponse,
+    };
+    use crate::types::{CertificationStatus, KeyRange, NodeId};
+    use axum::body::Body;
+    use axum::http::{Request, StatusCode};
+    use http_body_util::BodyExt;
+    use tokio::sync::Mutex;
+    use tower::ServiceExt;
+
+    fn test_state() -> Arc<AppState> {
+        let node_id = NodeId("test-node".into());
+
+        let mut ns = SystemNamespace::new();
+        ns.set_authority_definition(AuthorityDefinition {
+            key_range: KeyRange {
+                prefix: String::new(),
+            },
+            authority_nodes: vec![
+                NodeId("auth-1".into()),
+                NodeId("auth-2".into()),
+                NodeId("auth-3".into()),
+            ],
+        });
+
+        Arc::new(AppState {
+            eventual: Mutex::new(EventualApi::new(node_id.clone())),
+            certified: Mutex::new(CertifiedApi::new(node_id, ns)),
+        })
+    }
+
+    async fn body_string(body: Body) -> String {
+        let bytes = body.collect().await.unwrap().to_bytes();
+        String::from_utf8(bytes.to_vec()).unwrap()
+    }
+
+    // ---------------------------------------------------------------
+    // Eventual write + read round-trip
+    // ---------------------------------------------------------------
+
+    #[tokio::test]
+    async fn eventual_counter_inc_and_read() {
+        let state = test_state();
+        let app = router(state);
+
+        // Increment counter
+        let req = Request::builder()
+            .method("POST")
+            .uri("/api/eventual/write")
+            .header("content-type", "application/json")
+            .body(Body::from(r#"{"type":"counter_inc","key":"hits"}"#))
+            .unwrap();
+
+        let resp = app.clone().oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let body = body_string(resp.into_body()).await;
+        let write_resp: WriteResponse = serde_json::from_str(&body).unwrap();
+        assert!(write_resp.ok);
+
+        // Read back
+        let req = Request::builder()
+            .uri("/api/eventual/hits")
+            .body(Body::empty())
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let body = body_string(resp.into_body()).await;
+        let read_resp: EventualReadResponse = serde_json::from_str(&body).unwrap();
+        assert_eq!(read_resp.key, "hits");
+        assert_eq!(read_resp.value, Some(CrdtValueJson::Counter { value: 1 }));
+    }
+
+    #[tokio::test]
+    async fn eventual_counter_dec() {
+        let state = test_state();
+        let app = router(state);
+
+        let req = Request::builder()
+            .method("POST")
+            .uri("/api/eventual/write")
+            .header("content-type", "application/json")
+            .body(Body::from(r#"{"type":"counter_dec","key":"balance"}"#))
+            .unwrap();
+
+        let resp = app.clone().oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let req = Request::builder()
+            .uri("/api/eventual/balance")
+            .body(Body::empty())
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        let body = body_string(resp.into_body()).await;
+        let read_resp: EventualReadResponse = serde_json::from_str(&body).unwrap();
+        assert_eq!(read_resp.value, Some(CrdtValueJson::Counter { value: -1 }));
+    }
+
+    #[tokio::test]
+    async fn eventual_set_add_and_read() {
+        let state = test_state();
+        let app = router(state);
+
+        let req = Request::builder()
+            .method("POST")
+            .uri("/api/eventual/write")
+            .header("content-type", "application/json")
+            .body(Body::from(
+                r#"{"type":"set_add","key":"users","element":"alice"}"#,
+            ))
+            .unwrap();
+
+        let resp = app.clone().oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let req = Request::builder()
+            .uri("/api/eventual/users")
+            .body(Body::empty())
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        let body = body_string(resp.into_body()).await;
+        let read_resp: EventualReadResponse = serde_json::from_str(&body).unwrap();
+        assert_eq!(
+            read_resp.value,
+            Some(CrdtValueJson::Set {
+                elements: vec!["alice".into()]
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn eventual_register_set_and_read() {
+        let state = test_state();
+        let app = router(state);
+
+        let req = Request::builder()
+            .method("POST")
+            .uri("/api/eventual/write")
+            .header("content-type", "application/json")
+            .body(Body::from(
+                r#"{"type":"register_set","key":"greeting","value":"hello"}"#,
+            ))
+            .unwrap();
+
+        let resp = app.clone().oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let req = Request::builder()
+            .uri("/api/eventual/greeting")
+            .body(Body::empty())
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        let body = body_string(resp.into_body()).await;
+        let read_resp: EventualReadResponse = serde_json::from_str(&body).unwrap();
+        assert_eq!(
+            read_resp.value,
+            Some(CrdtValueJson::Register {
+                value: Some("hello".into()),
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn eventual_map_set_and_read() {
+        let state = test_state();
+        let app = router(state);
+
+        let req = Request::builder()
+            .method("POST")
+            .uri("/api/eventual/write")
+            .header("content-type", "application/json")
+            .body(Body::from(
+                r#"{"type":"map_set","key":"config","map_key":"name","map_value":"AsteroidDB"}"#,
+            ))
+            .unwrap();
+
+        let resp = app.clone().oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let req = Request::builder()
+            .uri("/api/eventual/config")
+            .body(Body::empty())
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        let body = body_string(resp.into_body()).await;
+        let read_resp: EventualReadResponse = serde_json::from_str(&body).unwrap();
+        match &read_resp.value {
+            Some(CrdtValueJson::Map { entries }) => {
+                assert_eq!(entries.get("name"), Some(&"AsteroidDB".to_string()));
+            }
+            other => panic!("expected Map, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn eventual_read_nonexistent_key() {
+        let state = test_state();
+        let app = router(state);
+
+        let req = Request::builder()
+            .uri("/api/eventual/missing")
+            .body(Body::empty())
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let body = body_string(resp.into_body()).await;
+        let read_resp: EventualReadResponse = serde_json::from_str(&body).unwrap();
+        assert_eq!(read_resp.key, "missing");
+        assert!(read_resp.value.is_none());
+    }
+
+    // ---------------------------------------------------------------
+    // Error handling
+    // ---------------------------------------------------------------
+
+    #[tokio::test]
+    async fn eventual_type_mismatch_returns_conflict() {
+        let state = test_state();
+        let app = router(state);
+
+        // First, create a counter
+        let req = Request::builder()
+            .method("POST")
+            .uri("/api/eventual/write")
+            .header("content-type", "application/json")
+            .body(Body::from(r#"{"type":"counter_inc","key":"k"}"#))
+            .unwrap();
+        app.clone().oneshot(req).await.unwrap();
+
+        // Then try to add to it as a set → type mismatch
+        let req = Request::builder()
+            .method("POST")
+            .uri("/api/eventual/write")
+            .header("content-type", "application/json")
+            .body(Body::from(r#"{"type":"set_add","key":"k","element":"x"}"#))
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::CONFLICT);
+
+        let body = body_string(resp.into_body()).await;
+        assert!(body.contains("TYPE_MISMATCH"));
+    }
+
+    #[tokio::test]
+    async fn eventual_set_remove_key_not_found() {
+        let state = test_state();
+        let app = router(state);
+
+        let req = Request::builder()
+            .method("POST")
+            .uri("/api/eventual/write")
+            .header("content-type", "application/json")
+            .body(Body::from(
+                r#"{"type":"set_remove","key":"missing","element":"x"}"#,
+            ))
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+
+        let body = body_string(resp.into_body()).await;
+        assert!(body.contains("KEY_NOT_FOUND"));
+    }
+
+    // ---------------------------------------------------------------
+    // Certified write + read
+    // ---------------------------------------------------------------
+
+    #[tokio::test]
+    async fn certified_write_pending() {
+        let state = test_state();
+        let app = router(state);
+
+        let req = Request::builder()
+            .method("POST")
+            .uri("/api/certified/write")
+            .header("content-type", "application/json")
+            .body(Body::from(
+                r#"{"key":"sensor","value":{"type":"counter","value":5},"on_timeout":"pending"}"#,
+            ))
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let body = body_string(resp.into_body()).await;
+        let write_resp: CertifiedWriteResponse = serde_json::from_str(&body).unwrap();
+        assert_eq!(write_resp.status, CertificationStatus::Pending);
+    }
+
+    #[tokio::test]
+    async fn certified_write_on_timeout_error() {
+        let state = test_state();
+        let app = router(state);
+
+        let req = Request::builder()
+            .method("POST")
+            .uri("/api/certified/write")
+            .header("content-type", "application/json")
+            .body(Body::from(
+                r#"{"key":"sensor","value":{"type":"counter","value":1},"on_timeout":"error"}"#,
+            ))
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::GATEWAY_TIMEOUT);
+
+        let body = body_string(resp.into_body()).await;
+        assert!(body.contains("TIMEOUT"));
+    }
+
+    #[tokio::test]
+    async fn certified_read_returns_status() {
+        let state = test_state();
+        let app = router(state);
+
+        // Write a certified value
+        let req = Request::builder()
+            .method("POST")
+            .uri("/api/certified/write")
+            .header("content-type", "application/json")
+            .body(Body::from(
+                r#"{"key":"data","value":{"type":"register","value":"hello"}}"#,
+            ))
+            .unwrap();
+        app.clone().oneshot(req).await.unwrap();
+
+        // Read it back
+        let req = Request::builder()
+            .uri("/api/certified/data")
+            .body(Body::empty())
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let body = body_string(resp.into_body()).await;
+        let read_resp: CertifiedReadResponse = serde_json::from_str(&body).unwrap();
+        assert_eq!(read_resp.key, "data");
+        assert!(read_resp.value.is_some());
+        assert_eq!(read_resp.status, CertificationStatus::Pending);
+    }
+
+    // ---------------------------------------------------------------
+    // Status endpoint
+    // ---------------------------------------------------------------
+
+    #[tokio::test]
+    async fn status_endpoint_returns_pending() {
+        let state = test_state();
+        let app = router(state);
+
+        // Write first
+        let req = Request::builder()
+            .method("POST")
+            .uri("/api/certified/write")
+            .header("content-type", "application/json")
+            .body(Body::from(
+                r#"{"key":"k1","value":{"type":"counter","value":1}}"#,
+            ))
+            .unwrap();
+        app.clone().oneshot(req).await.unwrap();
+
+        // Check status
+        let req = Request::builder()
+            .uri("/api/status/k1")
+            .body(Body::empty())
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let body = body_string(resp.into_body()).await;
+        let status_resp: StatusResponse = serde_json::from_str(&body).unwrap();
+        assert_eq!(status_resp.key, "k1");
+        assert_eq!(status_resp.status, CertificationStatus::Pending);
+    }
+
+    #[tokio::test]
+    async fn status_endpoint_nonexistent_returns_pending() {
+        let state = test_state();
+        let app = router(state);
+
+        let req = Request::builder()
+            .uri("/api/status/nonexistent")
+            .body(Body::empty())
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let body = body_string(resp.into_body()).await;
+        let status_resp: StatusResponse = serde_json::from_str(&body).unwrap();
+        assert_eq!(status_resp.status, CertificationStatus::Pending);
+    }
+
+    // ---------------------------------------------------------------
+    // Invalid JSON returns 422
+    // ---------------------------------------------------------------
+
+    #[tokio::test]
+    async fn invalid_json_returns_unprocessable() {
+        let state = test_state();
+        let app = router(state);
+
+        let req = Request::builder()
+            .method("POST")
+            .uri("/api/eventual/write")
+            .header("content-type", "application/json")
+            .body(Body::from(r#"{"not":"valid"}"#))
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::UNPROCESSABLE_ENTITY);
+    }
+
+    // ---------------------------------------------------------------
+    // Multiple operations on same key
+    // ---------------------------------------------------------------
+
+    #[tokio::test]
+    async fn multiple_counter_increments() {
+        let state = test_state();
+        let app = router(state);
+
+        for _ in 0..3 {
+            let req = Request::builder()
+                .method("POST")
+                .uri("/api/eventual/write")
+                .header("content-type", "application/json")
+                .body(Body::from(r#"{"type":"counter_inc","key":"count"}"#))
+                .unwrap();
+            app.clone().oneshot(req).await.unwrap();
+        }
+
+        let req = Request::builder()
+            .uri("/api/eventual/count")
+            .body(Body::empty())
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        let body = body_string(resp.into_body()).await;
+        let read_resp: EventualReadResponse = serde_json::from_str(&body).unwrap();
+        assert_eq!(read_resp.value, Some(CrdtValueJson::Counter { value: 3 }));
+    }
+
+    // ---------------------------------------------------------------
+    // Certified write with set value
+    // ---------------------------------------------------------------
+
+    #[tokio::test]
+    async fn certified_write_set_value() {
+        let state = test_state();
+        let app = router(state);
+
+        let req = Request::builder()
+            .method("POST")
+            .uri("/api/certified/write")
+            .header("content-type", "application/json")
+            .body(Body::from(
+                r#"{"key":"tags","value":{"type":"set","elements":["a","b"]}}"#,
+            ))
+            .unwrap();
+
+        let resp = app.clone().oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let req = Request::builder()
+            .uri("/api/certified/tags")
+            .body(Body::empty())
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        let body = body_string(resp.into_body()).await;
+        let read_resp: CertifiedReadResponse = serde_json::from_str(&body).unwrap();
+        assert!(read_resp.value.is_some());
+    }
+}

--- a/src/http/types.rs
+++ b/src/http/types.rs
@@ -1,0 +1,332 @@
+use std::collections::HashMap;
+
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use serde::{Deserialize, Serialize};
+
+use crate::error::CrdtError;
+use crate::store::kv::CrdtValue;
+use crate::types::CertificationStatus;
+
+/// JSON-friendly representation of a CRDT value for API responses.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "type")]
+pub enum CrdtValueJson {
+    #[serde(rename = "counter")]
+    Counter { value: i64 },
+    #[serde(rename = "set")]
+    Set { elements: Vec<String> },
+    #[serde(rename = "map")]
+    Map { entries: HashMap<String, String> },
+    #[serde(rename = "register")]
+    Register { value: Option<String> },
+}
+
+impl CrdtValueJson {
+    /// Convert an internal `CrdtValue` to its JSON representation.
+    pub fn from_crdt_value(value: &CrdtValue) -> Self {
+        match value {
+            CrdtValue::Counter(c) => CrdtValueJson::Counter { value: c.value() },
+            CrdtValue::Set(s) => {
+                let mut elements: Vec<String> = s.elements().into_iter().cloned().collect();
+                elements.sort();
+                CrdtValueJson::Set { elements }
+            }
+            CrdtValue::Map(m) => {
+                let mut entries = HashMap::new();
+                for key in m.keys() {
+                    if let Some(val) = m.get(key) {
+                        entries.insert(key.clone(), val.clone());
+                    }
+                }
+                CrdtValueJson::Map { entries }
+            }
+            CrdtValue::Register(r) => CrdtValueJson::Register {
+                value: r.get().cloned(),
+            },
+        }
+    }
+}
+
+// ---------------------------------------------------------------
+// Request types
+// ---------------------------------------------------------------
+
+/// Request body for `POST /api/eventual/write`.
+#[derive(Debug, Deserialize)]
+#[serde(tag = "type")]
+pub enum EventualWriteRequest {
+    #[serde(rename = "counter_inc")]
+    CounterInc { key: String },
+    #[serde(rename = "counter_dec")]
+    CounterDec { key: String },
+    #[serde(rename = "set_add")]
+    SetAdd { key: String, element: String },
+    #[serde(rename = "set_remove")]
+    SetRemove { key: String, element: String },
+    #[serde(rename = "map_set")]
+    MapSet {
+        key: String,
+        map_key: String,
+        map_value: String,
+    },
+    #[serde(rename = "map_delete")]
+    MapDelete { key: String, map_key: String },
+    #[serde(rename = "register_set")]
+    RegisterSet { key: String, value: String },
+}
+
+/// Request body for `POST /api/certified/write`.
+#[derive(Debug, Deserialize)]
+pub struct CertifiedWriteRequest {
+    pub key: String,
+    pub value: CrdtValueJson,
+    #[serde(default = "default_on_timeout")]
+    pub on_timeout: String,
+}
+
+fn default_on_timeout() -> String {
+    "pending".to_string()
+}
+
+// ---------------------------------------------------------------
+// Response types
+// ---------------------------------------------------------------
+
+/// Response for `GET /api/eventual/:key`.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct EventualReadResponse {
+    pub key: String,
+    pub value: Option<CrdtValueJson>,
+}
+
+/// Response for a successful write.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct WriteResponse {
+    pub ok: bool,
+}
+
+/// Response for `GET /api/certified/:key`.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct CertifiedReadResponse {
+    pub key: String,
+    pub value: Option<CrdtValueJson>,
+    pub status: CertificationStatus,
+    pub frontier: Option<FrontierJson>,
+}
+
+/// JSON-friendly frontier representation.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct FrontierJson {
+    pub physical: u64,
+    pub logical: u32,
+    pub node_id: String,
+}
+
+/// Response for `POST /api/certified/write`.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct CertifiedWriteResponse {
+    pub status: CertificationStatus,
+}
+
+/// Response for `GET /api/status/:key`.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct StatusResponse {
+    pub key: String,
+    pub status: CertificationStatus,
+}
+
+// ---------------------------------------------------------------
+// Error response
+// ---------------------------------------------------------------
+
+/// Structured error body returned as JSON.
+#[derive(Debug, Serialize)]
+pub struct ErrorResponse {
+    pub error_code: String,
+    pub message: String,
+}
+
+/// Map `CrdtError` to HTTP status code + JSON body.
+impl IntoResponse for ApiError {
+    fn into_response(self) -> Response {
+        let (status, code, message) = match &self.0 {
+            CrdtError::InvalidArgument(msg) => {
+                (StatusCode::BAD_REQUEST, "INVALID_ARGUMENT", msg.clone())
+            }
+            CrdtError::InvalidOp => (
+                StatusCode::BAD_REQUEST,
+                "INVALID_OP",
+                "invalid operation for this CRDT type".to_string(),
+            ),
+            CrdtError::TypeMismatch { expected, actual } => (
+                StatusCode::CONFLICT,
+                "TYPE_MISMATCH",
+                format!("expected {expected}, got {actual}"),
+            ),
+            CrdtError::KeyNotFound(key) => (
+                StatusCode::NOT_FOUND,
+                "KEY_NOT_FOUND",
+                format!("key not found: {key}"),
+            ),
+            CrdtError::StaleVersion => (
+                StatusCode::CONFLICT,
+                "STALE_VERSION",
+                "stale version".to_string(),
+            ),
+            CrdtError::PolicyDenied(msg) => (StatusCode::FORBIDDEN, "POLICY_DENIED", msg.clone()),
+            CrdtError::Timeout => (
+                StatusCode::GATEWAY_TIMEOUT,
+                "TIMEOUT",
+                "timeout".to_string(),
+            ),
+            CrdtError::Internal(msg) => {
+                (StatusCode::INTERNAL_SERVER_ERROR, "INTERNAL", msg.clone())
+            }
+        };
+
+        let body = ErrorResponse {
+            error_code: code.to_string(),
+            message,
+        };
+
+        (status, axum::Json(body)).into_response()
+    }
+}
+
+/// Newtype wrapper for `CrdtError` to implement `IntoResponse`.
+#[derive(Debug)]
+pub struct ApiError(pub CrdtError);
+
+impl From<CrdtError> for ApiError {
+    fn from(err: CrdtError) -> Self {
+        ApiError(err)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::crdt::lww_register::LwwRegister;
+    use crate::crdt::or_map::OrMap;
+    use crate::crdt::or_set::OrSet;
+    use crate::crdt::pn_counter::PnCounter;
+    use crate::hlc::HlcTimestamp;
+    use crate::types::NodeId;
+
+    fn node(name: &str) -> NodeId {
+        NodeId(name.into())
+    }
+
+    fn ts(physical: u64, logical: u32, node: &str) -> HlcTimestamp {
+        HlcTimestamp {
+            physical,
+            logical,
+            node_id: node.into(),
+        }
+    }
+
+    #[test]
+    fn counter_to_json() {
+        let mut c = PnCounter::new();
+        c.increment(&node("a"));
+        c.increment(&node("a"));
+        c.decrement(&node("a"));
+
+        let json = CrdtValueJson::from_crdt_value(&CrdtValue::Counter(c));
+        assert_eq!(json, CrdtValueJson::Counter { value: 1 });
+    }
+
+    #[test]
+    fn set_to_json() {
+        let mut s = OrSet::new();
+        s.add("bob".to_string(), &node("a"));
+        s.add("alice".to_string(), &node("a"));
+
+        let json = CrdtValueJson::from_crdt_value(&CrdtValue::Set(s));
+        match json {
+            CrdtValueJson::Set { elements } => {
+                assert_eq!(elements, vec!["alice", "bob"]);
+            }
+            other => panic!("expected Set, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn map_to_json() {
+        let mut m = OrMap::new();
+        m.set(
+            "name".to_string(),
+            "AsteroidDB".to_string(),
+            ts(100, 0, "a"),
+            &node("a"),
+        );
+
+        let json = CrdtValueJson::from_crdt_value(&CrdtValue::Map(m));
+        match json {
+            CrdtValueJson::Map { entries } => {
+                assert_eq!(entries.get("name"), Some(&"AsteroidDB".to_string()));
+            }
+            other => panic!("expected Map, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn register_to_json() {
+        let mut r = LwwRegister::new();
+        r.set("hello".to_string(), ts(100, 0, "a"));
+
+        let json = CrdtValueJson::from_crdt_value(&CrdtValue::Register(r));
+        assert_eq!(
+            json,
+            CrdtValueJson::Register {
+                value: Some("hello".into()),
+            }
+        );
+    }
+
+    #[test]
+    fn empty_register_to_json() {
+        let r = LwwRegister::<String>::new();
+        let json = CrdtValueJson::from_crdt_value(&CrdtValue::Register(r));
+        assert_eq!(json, CrdtValueJson::Register { value: None });
+    }
+
+    #[test]
+    fn deserialize_eventual_write_counter_inc() {
+        let json = r#"{"type":"counter_inc","key":"hits"}"#;
+        let req: EventualWriteRequest = serde_json::from_str(json).unwrap();
+        match req {
+            EventualWriteRequest::CounterInc { key } => assert_eq!(key, "hits"),
+            other => panic!("expected CounterInc, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn deserialize_eventual_write_set_add() {
+        let json = r#"{"type":"set_add","key":"users","element":"alice"}"#;
+        let req: EventualWriteRequest = serde_json::from_str(json).unwrap();
+        match req {
+            EventualWriteRequest::SetAdd { key, element } => {
+                assert_eq!(key, "users");
+                assert_eq!(element, "alice");
+            }
+            other => panic!("expected SetAdd, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn deserialize_certified_write_request() {
+        let json = r#"{"key":"sensor","value":{"type":"counter","value":42},"on_timeout":"error"}"#;
+        let req: CertifiedWriteRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(req.key, "sensor");
+        assert_eq!(req.on_timeout, "error");
+    }
+
+    #[test]
+    fn deserialize_certified_write_request_default_timeout() {
+        let json = r#"{"key":"sensor","value":{"type":"counter","value":42}}"#;
+        let req: CertifiedWriteRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(req.on_timeout, "pending");
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ pub mod control_plane;
 pub mod crdt;
 pub mod error;
 pub mod hlc;
+pub mod http;
 pub mod node;
 pub mod placement;
 pub mod store;


### PR DESCRIPTION
## Summary

- axum + tokio ベースの HTTP API レイヤーを `src/http/` に追加
- Eventual / Certified / Status の全エンドポイントを実装
- CrdtError → HTTP ステータスコード + JSON エラーレスポンスのマッピング
- 20+ の axum ハンドラーテスト（全 CRDT 型の round-trip、エラーケース含む）

### Endpoints

| Method | Path | Description |
|--------|------|-------------|
| POST | `/api/eventual/write` | CRDT 操作 (counter_inc/dec, set_add/remove, map_set/delete, register_set) |
| GET | `/api/eventual/:key` | Eventual consistency read |
| POST | `/api/certified/write` | Certified write (on_timeout: error/pending) |
| GET | `/api/certified/:key` | Read with certification status + frontier |
| GET | `/api/status/:key` | Poll certification status |

### Error Code Mapping

| CrdtError | HTTP Status | Code |
|-----------|-------------|------|
| InvalidArgument | 400 | INVALID_ARGUMENT |
| InvalidOp | 400 | INVALID_OP |
| TypeMismatch | 409 | TYPE_MISMATCH |
| KeyNotFound | 404 | KEY_NOT_FOUND |
| StaleVersion | 409 | STALE_VERSION |
| PolicyDenied | 403 | POLICY_DENIED |
| Timeout | 504 | TIMEOUT |
| Internal | 500 | INTERNAL |

## Test plan

- [x] CI gate: `cargo fmt --check && cargo clippy -- -D warnings && cargo test`
- [x] 全 502 テストがパス（既存 470+ + 新規 HTTP テスト 20+）
- [x] Eventual write/read round-trip (counter, set, map, register)
- [x] Certified write/read with status tracking
- [x] Status endpoint for certification polling
- [x] Error handling (type mismatch → 409, key not found → 404, timeout → 504)
- [x] Invalid JSON → 422

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)