### PR TITLE
feat: add anti-entropy sync loop for eventual data convergence

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,9 +11,10 @@ ed25519-dalek = { version = "2", features = ["rand_core"] }
 rand = "0.8"
 tokio = { version = "1", features = ["full"] }
 axum = "0.8"
+reqwest = { version = "0.12", features = ["json"] }
+tracing = "0.1"
 
 [dev-dependencies]
 tempfile = "3"
 tower = { version = "0.5", features = ["util"] }
 http-body-util = "0.1"
-reqwest = { version = "0.12", features = ["json"] }

--- a/src/api/eventual.rs
+++ b/src/api/eventual.rs
@@ -236,6 +236,14 @@ impl EventualApi {
     pub fn keys_with_prefix(&self, prefix: &str) -> Vec<&String> {
         self.store.keys_with_prefix(prefix)
     }
+
+    /// Return a reference to the underlying store.
+    ///
+    /// Used by the anti-entropy sync layer to read all entries for
+    /// push-based replication.
+    pub fn store(&self) -> &Store {
+        &self.store
+    }
 }
 
 #[cfg(test)]

--- a/src/http/handlers.rs
+++ b/src/http/handlers.rs
@@ -10,6 +10,8 @@ use crate::crdt::pn_counter::PnCounter;
 use crate::error::CrdtError;
 use crate::store::kv::CrdtValue;
 
+use crate::network::sync::{KeyDumpResponse, SyncError, SyncRequest, SyncResponse};
+
 use super::types::{
     ApiError, CertifiedReadResponse, CertifiedWriteRequest, CertifiedWriteResponse, CrdtValueJson,
     EventualReadResponse, EventualWriteRequest, FrontierJson, StatusResponse, WriteResponse,
@@ -138,6 +140,56 @@ pub async fn get_certification_status(
     let status = api.get_certification_status(&key);
 
     Json(StatusResponse { key, status })
+}
+
+// ---------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------
+
+// ---------------------------------------------------------------
+// Internal sync handlers
+// ---------------------------------------------------------------
+
+/// `POST /api/internal/sync`
+///
+/// Receives CRDT values from a remote peer and merges them into the
+/// local eventual store using `merge_remote`.
+pub async fn internal_sync(
+    State(state): State<Arc<AppState>>,
+    Json(req): Json<SyncRequest>,
+) -> Json<SyncResponse> {
+    let mut api = state.eventual.lock().await;
+    let mut merged = 0;
+    let mut errors = Vec::new();
+
+    for (key, value) in &req.entries {
+        match api.merge_remote(key.clone(), value) {
+            Ok(()) => merged += 1,
+            Err(e) => {
+                errors.push(SyncError {
+                    key: key.clone(),
+                    error: e.to_string(),
+                });
+            }
+        }
+    }
+
+    Json(SyncResponse { merged, errors })
+}
+
+/// `GET /api/internal/keys`
+///
+/// Returns all key-value pairs from the eventual store. Used by
+/// remote peers for pull-based anti-entropy sync.
+pub async fn internal_keys(State(state): State<Arc<AppState>>) -> Json<KeyDumpResponse> {
+    let api = state.eventual.lock().await;
+    let entries = api
+        .store()
+        .all_entries()
+        .map(|(k, v)| (k.clone(), v.clone()))
+        .collect();
+
+    Json(KeyDumpResponse { entries })
 }
 
 // ---------------------------------------------------------------

--- a/src/http/routes.rs
+++ b/src/http/routes.rs
@@ -5,7 +5,7 @@ use axum::routing::{get, post};
 
 use super::handlers::{
     AppState, certified_write, eventual_write, get_certification_status, get_certified,
-    get_eventual,
+    get_eventual, internal_keys, internal_sync,
 };
 
 /// Build the HTTP API router with all endpoints.
@@ -16,6 +16,8 @@ pub fn router(state: Arc<AppState>) -> Router {
         .route("/api/certified/write", post(certified_write))
         .route("/api/certified/{key}", get(get_certified))
         .route("/api/status/{key}", get(get_certification_status))
+        .route("/api/internal/sync", post(internal_sync))
+        .route("/api/internal/keys", get(internal_keys))
         .with_state(state)
 }
 

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -1,3 +1,4 @@
 mod peer;
+pub mod sync;
 
 pub use peer::{NodeConfig, PeerConfig, PeerError, PeerRegistry, generate_cluster_configs};

--- a/src/network/sync.rs
+++ b/src/network/sync.rs
@@ -1,0 +1,310 @@
+use std::collections::HashMap;
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+
+use crate::network::peer::PeerRegistry;
+use crate::store::kv::CrdtValue;
+
+/// Bulk sync request payload sent to `POST /api/internal/sync`.
+///
+/// Contains a map of key -> serialised CRDT value that the receiving
+/// node should merge into its local eventual store.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SyncRequest {
+    /// The node ID of the sender, for logging/debugging.
+    pub sender: String,
+    /// Key-value pairs to merge. Values are JSON-serialised `CrdtValue`.
+    pub entries: HashMap<String, CrdtValue>,
+}
+
+/// Response from `POST /api/internal/sync`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SyncResponse {
+    /// Number of keys successfully merged.
+    pub merged: usize,
+    /// Keys that failed to merge (e.g. type mismatch), with error messages.
+    pub errors: Vec<SyncError>,
+}
+
+/// A single key-level sync error.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SyncError {
+    pub key: String,
+    pub error: String,
+}
+
+/// Response from `GET /api/internal/keys`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct KeyDumpResponse {
+    pub entries: HashMap<String, CrdtValue>,
+}
+
+/// Anti-entropy sync client.
+///
+/// Periodically pushes all local CRDT values to every known peer.
+/// Uses HTTP POST to `/api/internal/sync` on each peer.
+pub struct SyncClient {
+    peer_registry: PeerRegistry,
+    http_client: reqwest::Client,
+}
+
+impl SyncClient {
+    /// Create a new `SyncClient` for the given peer registry.
+    pub fn new(peer_registry: PeerRegistry) -> Self {
+        let http_client = reqwest::Client::builder()
+            .timeout(Duration::from_secs(5))
+            .build()
+            .expect("failed to build HTTP client");
+        Self {
+            peer_registry,
+            http_client,
+        }
+    }
+
+    /// Create a `SyncClient` with a custom reqwest client (for testing).
+    pub fn with_client(peer_registry: PeerRegistry, http_client: reqwest::Client) -> Self {
+        Self {
+            peer_registry,
+            http_client,
+        }
+    }
+
+    /// Push all key-value pairs from the local store to every peer.
+    ///
+    /// For each peer, sends a `POST /api/internal/sync` request with
+    /// the full set of local entries. Failures are logged and skipped;
+    /// the next sync cycle will retry.
+    ///
+    /// Returns the number of peers that were successfully synced.
+    pub async fn push_all_keys(
+        &self,
+        entries: HashMap<String, CrdtValue>,
+        sender_id: &str,
+    ) -> usize {
+        if entries.is_empty() {
+            return 0;
+        }
+
+        let request = SyncRequest {
+            sender: sender_id.to_string(),
+            entries,
+        };
+
+        let mut success_count = 0;
+
+        for peer in self.peer_registry.all_peers() {
+            let url = format!("http://{}/api/internal/sync", peer.addr);
+
+            match self.http_client.post(&url).json(&request).send().await {
+                Ok(resp) => {
+                    if resp.status().is_success() {
+                        success_count += 1;
+                        tracing::debug!(
+                            peer = %peer.node_id.0,
+                            "anti-entropy push succeeded"
+                        );
+                    } else {
+                        tracing::warn!(
+                            peer = %peer.node_id.0,
+                            status = %resp.status(),
+                            "anti-entropy push received non-success status"
+                        );
+                    }
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        peer = %peer.node_id.0,
+                        error = %e,
+                        "anti-entropy push failed"
+                    );
+                }
+            }
+        }
+
+        success_count
+    }
+
+    /// Pull all key-value pairs from a specific peer.
+    ///
+    /// Sends `GET /api/internal/keys` to the peer and returns the
+    /// entries map. Returns `None` on failure.
+    pub async fn pull_all_keys(
+        &self,
+        peer_addr: &std::net::SocketAddr,
+    ) -> Option<HashMap<String, CrdtValue>> {
+        let url = format!("http://{}/api/internal/keys", peer_addr);
+
+        match self.http_client.get(&url).send().await {
+            Ok(resp) => {
+                if resp.status().is_success() {
+                    match resp.json::<KeyDumpResponse>().await {
+                        Ok(dump) => Some(dump.entries),
+                        Err(e) => {
+                            tracing::warn!(
+                                error = %e,
+                                "failed to parse key dump response"
+                            );
+                            None
+                        }
+                    }
+                } else {
+                    tracing::warn!(
+                        status = %resp.status(),
+                        "pull_all_keys received non-success status"
+                    );
+                    None
+                }
+            }
+            Err(e) => {
+                tracing::warn!(
+                    error = %e,
+                    "pull_all_keys request failed"
+                );
+                None
+            }
+        }
+    }
+
+    /// Return a reference to the peer registry.
+    pub fn peer_registry(&self) -> &PeerRegistry {
+        &self.peer_registry
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::crdt::pn_counter::PnCounter;
+    use crate::network::peer::{PeerConfig, PeerRegistry};
+    use crate::types::NodeId;
+
+    fn nid(s: &str) -> NodeId {
+        NodeId(s.into())
+    }
+
+    #[test]
+    fn sync_request_serde_roundtrip() {
+        let mut entries = HashMap::new();
+        let mut counter = PnCounter::new();
+        counter.increment(&nid("node-1"));
+        entries.insert("key1".to_string(), CrdtValue::Counter(counter));
+
+        let req = SyncRequest {
+            sender: "node-1".to_string(),
+            entries,
+        };
+
+        let json = serde_json::to_string(&req).unwrap();
+        let deserialized: SyncRequest = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(deserialized.sender, "node-1");
+        assert!(deserialized.entries.contains_key("key1"));
+    }
+
+    #[test]
+    fn sync_response_serde_roundtrip() {
+        let resp = SyncResponse {
+            merged: 3,
+            errors: vec![SyncError {
+                key: "bad-key".into(),
+                error: "type mismatch".into(),
+            }],
+        };
+
+        let json = serde_json::to_string(&resp).unwrap();
+        let deserialized: SyncResponse = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(deserialized.merged, 3);
+        assert_eq!(deserialized.errors.len(), 1);
+        assert_eq!(deserialized.errors[0].key, "bad-key");
+    }
+
+    #[test]
+    fn key_dump_response_serde_roundtrip() {
+        let mut entries = HashMap::new();
+        let mut counter = PnCounter::new();
+        counter.increment(&nid("node-1"));
+        entries.insert("hits".to_string(), CrdtValue::Counter(counter));
+
+        let resp = KeyDumpResponse { entries };
+        let json = serde_json::to_string(&resp).unwrap();
+        let deserialized: KeyDumpResponse = serde_json::from_str(&json).unwrap();
+
+        assert!(deserialized.entries.contains_key("hits"));
+    }
+
+    #[test]
+    fn sync_client_creation() {
+        let registry = PeerRegistry::new(
+            nid("node-1"),
+            vec![PeerConfig {
+                node_id: nid("node-2"),
+                addr: "127.0.0.1:8001".parse().unwrap(),
+            }],
+        )
+        .unwrap();
+
+        let client = SyncClient::new(registry);
+        assert_eq!(client.peer_registry().peer_count(), 1);
+    }
+
+    #[tokio::test]
+    async fn push_all_keys_empty_entries_returns_zero() {
+        let registry = PeerRegistry::new(
+            nid("node-1"),
+            vec![PeerConfig {
+                node_id: nid("node-2"),
+                addr: "127.0.0.1:8001".parse().unwrap(),
+            }],
+        )
+        .unwrap();
+
+        let client = SyncClient::new(registry);
+        let result = client.push_all_keys(HashMap::new(), "node-1").await;
+        assert_eq!(result, 0);
+    }
+
+    #[tokio::test]
+    async fn push_all_keys_to_unreachable_peer_returns_zero() {
+        let registry = PeerRegistry::new(
+            nid("node-1"),
+            vec![PeerConfig {
+                node_id: nid("node-2"),
+                // Unreachable address.
+                addr: "127.0.0.1:1".parse().unwrap(),
+            }],
+        )
+        .unwrap();
+
+        // Use a short timeout to speed up the test.
+        let http_client = reqwest::Client::builder()
+            .timeout(Duration::from_millis(100))
+            .build()
+            .unwrap();
+        let client = SyncClient::with_client(registry, http_client);
+
+        let mut entries = HashMap::new();
+        let mut counter = PnCounter::new();
+        counter.increment(&nid("node-1"));
+        entries.insert("key1".to_string(), CrdtValue::Counter(counter));
+
+        let result = client.push_all_keys(entries, "node-1").await;
+        assert_eq!(result, 0);
+    }
+
+    #[tokio::test]
+    async fn pull_all_keys_from_unreachable_peer_returns_none() {
+        let registry = PeerRegistry::new(nid("node-1"), vec![]).unwrap();
+
+        let http_client = reqwest::Client::builder()
+            .timeout(Duration::from_millis(100))
+            .build()
+            .unwrap();
+        let client = SyncClient::with_client(registry, http_client);
+
+        let addr: std::net::SocketAddr = "127.0.0.1:1".parse().unwrap();
+        let result = client.pull_all_keys(&addr).await;
+        assert!(result.is_none());
+    }
+}

--- a/src/runtime/node_runner.rs
+++ b/src/runtime/node_runner.rs
@@ -1,10 +1,13 @@
+use std::sync::Arc;
 use std::time::Duration;
 
-use tokio::sync::watch;
+use tokio::sync::{Mutex, watch};
 
 use crate::api::certified::CertifiedApi;
+use crate::api::eventual::EventualApi;
 use crate::compaction::CompactionEngine;
 use crate::hlc::Hlc;
+use crate::network::sync::SyncClient;
 use crate::types::NodeId;
 
 /// Configuration for the background processing intervals of [`NodeRunner`].
@@ -16,6 +19,9 @@ pub struct NodeRunnerConfig {
     pub cleanup_interval: Duration,
     /// How often to check compaction eligibility and create checkpoints.
     pub compaction_check_interval: Duration,
+    /// How often to run anti-entropy sync with peers.
+    /// Set to `None` to disable sync (e.g. when no peers are configured).
+    pub sync_interval: Option<Duration>,
 }
 
 impl Default for NodeRunnerConfig {
@@ -24,6 +30,7 @@ impl Default for NodeRunnerConfig {
             certification_interval: Duration::from_secs(1),
             cleanup_interval: Duration::from_secs(5),
             compaction_check_interval: Duration::from_secs(10),
+            sync_interval: Some(Duration::from_secs(2)),
         }
     }
 }
@@ -44,6 +51,10 @@ pub struct NodeRunner {
     config: NodeRunnerConfig,
     shutdown_tx: watch::Sender<bool>,
     shutdown_rx: watch::Receiver<bool>,
+    /// Optional sync client for anti-entropy replication.
+    sync_client: Option<SyncClient>,
+    /// Shared reference to the eventual API for reading store state during sync.
+    eventual_api: Option<Arc<Mutex<EventualApi>>>,
 }
 
 /// Counters returned after the run loop exits, useful for testing and observability.
@@ -55,10 +66,12 @@ pub struct RunLoopStats {
     pub cleanup_ticks: u64,
     /// Number of compaction check ticks executed.
     pub compaction_check_ticks: u64,
+    /// Number of anti-entropy sync ticks executed.
+    pub sync_ticks: u64,
 }
 
 impl NodeRunner {
-    /// Create a new `NodeRunner`.
+    /// Create a new `NodeRunner` without anti-entropy sync.
     pub fn new(
         node_id: NodeId,
         certified_api: CertifiedApi,
@@ -74,6 +87,34 @@ impl NodeRunner {
             config,
             shutdown_tx,
             shutdown_rx,
+            sync_client: None,
+            eventual_api: None,
+        }
+    }
+
+    /// Create a new `NodeRunner` with anti-entropy sync enabled.
+    ///
+    /// The `eventual_api` must be the same `Arc<Mutex<EventualApi>>` shared
+    /// with the HTTP handlers so that sync reads the latest store state.
+    pub fn with_sync(
+        node_id: NodeId,
+        certified_api: CertifiedApi,
+        compaction_engine: CompactionEngine,
+        config: NodeRunnerConfig,
+        sync_client: SyncClient,
+        eventual_api: Arc<Mutex<EventualApi>>,
+    ) -> Self {
+        let (shutdown_tx, shutdown_rx) = watch::channel(false);
+        Self {
+            clock: Hlc::new(node_id.0.clone()),
+            node_id,
+            certified_api,
+            compaction_engine,
+            config,
+            shutdown_tx,
+            shutdown_rx,
+            sync_client: Some(sync_client),
+            eventual_api: Some(eventual_api),
         }
     }
 
@@ -139,6 +180,16 @@ impl NodeRunner {
             self.config.compaction_check_interval,
         );
 
+        // Sync interval: only create if sync is configured.
+        let sync_duration = self
+            .config
+            .sync_interval
+            .unwrap_or(Duration::from_secs(3600));
+        let sync_enabled = self.config.sync_interval.is_some()
+            && self.sync_client.is_some()
+            && self.eventual_api.is_some();
+        let mut sync_interval = tokio::time::interval_at(start + sync_duration, sync_duration);
+
         let mut stats = RunLoopStats::default();
         let mut shutdown_rx = self.shutdown_rx.clone();
 
@@ -160,6 +211,10 @@ impl NodeRunner {
                 _ = compaction_interval.tick() => {
                     self.check_compaction();
                     stats.compaction_check_ticks += 1;
+                }
+                _ = sync_interval.tick(), if sync_enabled => {
+                    self.run_sync().await;
+                    stats.sync_ticks += 1;
                 }
             }
         }
@@ -190,6 +245,36 @@ impl NodeRunner {
     fn run_cleanup(&mut self) {
         let now_ms = self.clock.now().physical;
         self.certified_api.cleanup(now_ms);
+    }
+
+    /// Run one cycle of anti-entropy push sync.
+    ///
+    /// Reads all entries from the eventual store and pushes them
+    /// to every known peer. Failures are logged and skipped.
+    async fn run_sync(&self) {
+        let Some(sync_client) = &self.sync_client else {
+            return;
+        };
+        let Some(eventual_api) = &self.eventual_api else {
+            return;
+        };
+
+        // Snapshot the current store state while holding the lock briefly.
+        let entries = {
+            let api = eventual_api.lock().await;
+            api.store()
+                .all_entries()
+                .map(|(k, v)| (k.clone(), v.clone()))
+                .collect()
+        };
+
+        let synced = sync_client.push_all_keys(entries, &self.node_id.0).await;
+
+        tracing::debug!(
+            node = %self.node_id.0,
+            peers_synced = synced,
+            "anti-entropy sync cycle completed"
+        );
     }
 
     fn check_compaction(&mut self) {
@@ -291,6 +376,7 @@ mod tests {
             certification_interval: Duration::from_millis(10),
             cleanup_interval: Duration::from_millis(50),
             compaction_check_interval: Duration::from_millis(100),
+            sync_interval: None,
         };
 
         let mut runner = NodeRunner::new(node_id("node-1"), api, engine, config);
@@ -335,6 +421,7 @@ mod tests {
             certification_interval: Duration::from_millis(10),
             cleanup_interval: Duration::from_secs(60),
             compaction_check_interval: Duration::from_secs(60),
+            sync_interval: None,
         };
 
         let mut runner = NodeRunner::new(node_id("node-1"), api, engine, config);
@@ -375,6 +462,7 @@ mod tests {
             certification_interval: Duration::from_secs(60),
             cleanup_interval: Duration::from_millis(10),
             compaction_check_interval: Duration::from_secs(60),
+            sync_interval: None,
         };
 
         let mut runner = NodeRunner::new(node_id("node-1"), api, engine, config);
@@ -418,6 +506,7 @@ mod tests {
             certification_interval: Duration::from_secs(60),
             cleanup_interval: Duration::from_secs(60),
             compaction_check_interval: Duration::from_millis(10),
+            sync_interval: None,
         };
 
         let mut runner = NodeRunner::new(node_id("node-1"), api, engine, config);
@@ -457,6 +546,7 @@ mod tests {
         assert_eq!(config.certification_interval, Duration::from_secs(1));
         assert_eq!(config.cleanup_interval, Duration::from_secs(5));
         assert_eq!(config.compaction_check_interval, Duration::from_secs(10));
+        assert_eq!(config.sync_interval, Some(Duration::from_secs(2)));
     }
 
     #[tokio::test]
@@ -486,6 +576,7 @@ mod tests {
             certification_interval: Duration::from_secs(60),
             cleanup_interval: Duration::from_secs(60),
             compaction_check_interval: Duration::from_secs(60),
+            sync_interval: None,
         };
 
         let mut runner = NodeRunner::new(node_id("node-1"), api, engine, config);

--- a/src/store/kv.rs
+++ b/src/store/kv.rs
@@ -96,6 +96,11 @@ impl Store {
         self.data.is_empty()
     }
 
+    /// Return all key-value pairs as an iterator.
+    pub fn all_entries(&self) -> impl Iterator<Item = (&String, &CrdtValue)> {
+        self.data.iter()
+    }
+
     /// Save the store as a JSON snapshot to the given path.
     pub fn save_snapshot(&self, path: &Path) -> io::Result<()> {
         let json = serde_json::to_string(self)

--- a/tests/anti_entropy_convergence.rs
+++ b/tests/anti_entropy_convergence.rs
@@ -1,0 +1,497 @@
+//! Anti-entropy sync convergence integration tests (Issue #78).
+//!
+//! Validates that eventual data converges across nodes without manual merge,
+//! using the anti-entropy sync loop (push-based replication via HTTP).
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use asteroidb_poc::api::certified::CertifiedApi;
+use asteroidb_poc::api::eventual::EventualApi;
+use asteroidb_poc::control_plane::system_namespace::{AuthorityDefinition, SystemNamespace};
+use asteroidb_poc::crdt::pn_counter::PnCounter;
+use asteroidb_poc::http::handlers::AppState;
+use asteroidb_poc::http::routes::router;
+use asteroidb_poc::network::sync::SyncClient;
+use asteroidb_poc::network::{PeerConfig, PeerRegistry};
+use asteroidb_poc::store::kv::CrdtValue;
+use asteroidb_poc::types::{KeyRange, NodeId};
+
+use tokio::sync::Mutex;
+
+fn node_id(s: &str) -> NodeId {
+    NodeId(s.into())
+}
+
+fn default_namespace() -> SystemNamespace {
+    let mut ns = SystemNamespace::new();
+    ns.set_authority_definition(AuthorityDefinition {
+        key_range: KeyRange {
+            prefix: String::new(),
+        },
+        authority_nodes: vec![node_id("auth-1"), node_id("auth-2"), node_id("auth-3")],
+    });
+    ns
+}
+
+/// Spin up two HTTP servers with eventual stores, write data to each,
+/// run anti-entropy sync, and verify convergence.
+#[tokio::test]
+async fn two_node_anti_entropy_convergence() {
+    // Start two HTTP servers on ephemeral ports.
+    let listener1 = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr1 = listener1.local_addr().unwrap();
+
+    let listener2 = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr2 = listener2.local_addr().unwrap();
+
+    // Build state for node 1.
+    let state1 = Arc::new(AppState {
+        eventual: Mutex::new(EventualApi::new(node_id("node-1"))),
+        certified: Mutex::new(CertifiedApi::new(node_id("node-1"), default_namespace())),
+    });
+
+    // Build state for node 2.
+    let state2 = Arc::new(AppState {
+        eventual: Mutex::new(EventualApi::new(node_id("node-2"))),
+        certified: Mutex::new(CertifiedApi::new(node_id("node-2"), default_namespace())),
+    });
+
+    // Write some data to node 1.
+    {
+        let mut api = state1.eventual.lock().await;
+        api.eventual_counter_inc("visits").unwrap();
+        api.eventual_counter_inc("visits").unwrap();
+        api.eventual_counter_inc("visits").unwrap();
+        api.eventual_set_add("users", "alice".into()).unwrap();
+        api.eventual_register_set("status", "online".into())
+            .unwrap();
+    }
+
+    // Write different data to node 2.
+    {
+        let mut api = state2.eventual.lock().await;
+        api.eventual_counter_inc("visits").unwrap();
+        api.eventual_counter_inc("visits").unwrap();
+        api.eventual_set_add("users", "bob".into()).unwrap();
+        api.eventual_register_set("config", "production".into())
+            .unwrap();
+    }
+
+    // Start HTTP servers.
+    let app1 = router(state1.clone());
+    let app2 = router(state2.clone());
+
+    let server1 = tokio::spawn(async move {
+        axum::serve(listener1, app1).await.unwrap();
+    });
+    let server2 = tokio::spawn(async move {
+        axum::serve(listener2, app2).await.unwrap();
+    });
+
+    // Give servers a moment to start.
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    // --- Sync node 1 -> node 2 ---
+    let registry1 = PeerRegistry::new(
+        node_id("node-1"),
+        vec![PeerConfig {
+            node_id: node_id("node-2"),
+            addr: addr2,
+        }],
+    )
+    .unwrap();
+    let sync_client1 = SyncClient::new(registry1);
+
+    // Snapshot node 1's store and push to node 2.
+    let entries1: HashMap<String, CrdtValue> = {
+        let api = state1.eventual.lock().await;
+        api.store()
+            .all_entries()
+            .map(|(k, v)| (k.clone(), v.clone()))
+            .collect()
+    };
+    let synced = sync_client1.push_all_keys(entries1, "node-1").await;
+    assert_eq!(synced, 1, "should have synced to 1 peer");
+
+    // --- Sync node 2 -> node 1 ---
+    let registry2 = PeerRegistry::new(
+        node_id("node-2"),
+        vec![PeerConfig {
+            node_id: node_id("node-1"),
+            addr: addr1,
+        }],
+    )
+    .unwrap();
+    let sync_client2 = SyncClient::new(registry2);
+
+    let entries2: HashMap<String, CrdtValue> = {
+        let api = state2.eventual.lock().await;
+        api.store()
+            .all_entries()
+            .map(|(k, v)| (k.clone(), v.clone()))
+            .collect()
+    };
+    let synced = sync_client2.push_all_keys(entries2, "node-2").await;
+    assert_eq!(synced, 1, "should have synced to 1 peer");
+
+    // --- Verify convergence ---
+    // Both nodes should now have the same view of the data.
+
+    // Check node 1's state (should have merged node 2's data).
+    {
+        let api = state1.eventual.lock().await;
+
+        // visits: 3 (node-1) + 2 (node-2) = 5
+        match api.get_eventual("visits") {
+            Some(CrdtValue::Counter(c)) => {
+                assert_eq!(c.value(), 5, "node-1 visits should be 5 after sync");
+            }
+            other => panic!("node-1: expected Counter for visits, got {:?}", other),
+        }
+
+        // users: {"alice", "bob"}
+        match api.get_eventual("users") {
+            Some(CrdtValue::Set(s)) => {
+                assert!(s.contains(&"alice".to_string()), "node-1 should have alice");
+                assert!(s.contains(&"bob".to_string()), "node-1 should have bob");
+                assert_eq!(s.len(), 2);
+            }
+            other => panic!("node-1: expected Set for users, got {:?}", other),
+        }
+
+        // status: "online" (from node-1)
+        assert!(
+            api.get_eventual("status").is_some(),
+            "node-1 should still have status"
+        );
+
+        // config: "production" (from node-2, merged in)
+        match api.get_eventual("config") {
+            Some(CrdtValue::Register(r)) => {
+                assert_eq!(r.get(), Some(&"production".to_string()));
+            }
+            other => panic!("node-1: expected Register for config, got {:?}", other),
+        }
+    }
+
+    // Check node 2's state (should have merged node 1's data).
+    {
+        let api = state2.eventual.lock().await;
+
+        // visits: 3 (node-1) + 2 (node-2) = 5
+        match api.get_eventual("visits") {
+            Some(CrdtValue::Counter(c)) => {
+                assert_eq!(c.value(), 5, "node-2 visits should be 5 after sync");
+            }
+            other => panic!("node-2: expected Counter for visits, got {:?}", other),
+        }
+
+        // users: {"alice", "bob"}
+        match api.get_eventual("users") {
+            Some(CrdtValue::Set(s)) => {
+                assert!(s.contains(&"alice".to_string()), "node-2 should have alice");
+                assert!(s.contains(&"bob".to_string()), "node-2 should have bob");
+                assert_eq!(s.len(), 2);
+            }
+            other => panic!("node-2: expected Set for users, got {:?}", other),
+        }
+
+        // status: "online" (from node-1, merged in)
+        match api.get_eventual("status") {
+            Some(CrdtValue::Register(r)) => {
+                assert_eq!(r.get(), Some(&"online".to_string()));
+            }
+            other => panic!("node-2: expected Register for status, got {:?}", other),
+        }
+
+        // config: "production" (from node-2)
+        assert!(
+            api.get_eventual("config").is_some(),
+            "node-2 should still have config"
+        );
+    }
+
+    // Clean up.
+    server1.abort();
+    server2.abort();
+}
+
+/// Test the pull-based sync: node pulls all keys from a peer.
+#[tokio::test]
+async fn pull_based_sync() {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    // Build state with some data.
+    let state = Arc::new(AppState {
+        eventual: Mutex::new(EventualApi::new(node_id("source"))),
+        certified: Mutex::new(CertifiedApi::new(node_id("source"), default_namespace())),
+    });
+
+    {
+        let mut api = state.eventual.lock().await;
+        api.eventual_counter_inc("counter1").unwrap();
+        api.eventual_counter_inc("counter1").unwrap();
+        api.eventual_set_add("set1", "elem-a".into()).unwrap();
+    }
+
+    let app = router(state.clone());
+    let server = tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    // Pull from the source node.
+    let registry = PeerRegistry::new(node_id("puller"), vec![]).unwrap();
+    let sync_client = SyncClient::new(registry);
+
+    let pulled = sync_client.pull_all_keys(&addr).await;
+    assert!(pulled.is_some(), "pull should succeed");
+
+    let entries = pulled.unwrap();
+    assert_eq!(entries.len(), 2, "should have 2 keys");
+    assert!(entries.contains_key("counter1"));
+    assert!(entries.contains_key("set1"));
+
+    // Verify the pulled counter value.
+    match entries.get("counter1") {
+        Some(CrdtValue::Counter(c)) => assert_eq!(c.value(), 2),
+        other => panic!("expected Counter, got {:?}", other),
+    }
+
+    server.abort();
+}
+
+/// Test that the internal sync endpoint correctly handles type mismatches
+/// (logs errors but merges the rest).
+#[tokio::test]
+async fn sync_endpoint_partial_failure() {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    let state = Arc::new(AppState {
+        eventual: Mutex::new(EventualApi::new(node_id("target"))),
+        certified: Mutex::new(CertifiedApi::new(node_id("target"), default_namespace())),
+    });
+
+    // Pre-populate with a counter at "k".
+    {
+        let mut api = state.eventual.lock().await;
+        api.eventual_counter_inc("k").unwrap();
+    }
+
+    let app = router(state.clone());
+    let server = tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    // Send a sync request that has:
+    // - "k" as a Set (type mismatch with existing Counter)
+    // - "new_key" as a Counter (should succeed)
+    let client = reqwest::Client::new();
+    let mut entries = HashMap::new();
+
+    use asteroidb_poc::crdt::or_set::OrSet;
+    let mut set = OrSet::new();
+    set.add("x".to_string(), &node_id("sender"));
+    entries.insert("k".to_string(), CrdtValue::Set(set));
+
+    let mut counter = PnCounter::new();
+    counter.increment(&node_id("sender"));
+    entries.insert("new_key".to_string(), CrdtValue::Counter(counter));
+
+    let sync_req = asteroidb_poc::network::sync::SyncRequest {
+        sender: "sender".to_string(),
+        entries,
+    };
+
+    let resp = client
+        .post(format!("http://{}/api/internal/sync", addr))
+        .json(&sync_req)
+        .send()
+        .await
+        .unwrap();
+
+    assert!(resp.status().is_success());
+
+    let sync_resp: asteroidb_poc::network::sync::SyncResponse = resp.json().await.unwrap();
+    assert_eq!(sync_resp.merged, 1, "should merge 1 key successfully");
+    assert_eq!(sync_resp.errors.len(), 1, "should have 1 error");
+    assert_eq!(sync_resp.errors[0].key, "k");
+
+    // Verify the successful merge.
+    {
+        let api = state.eventual.lock().await;
+        assert!(api.get_eventual("new_key").is_some());
+        match api.get_eventual("new_key") {
+            Some(CrdtValue::Counter(c)) => assert_eq!(c.value(), 1),
+            other => panic!("expected Counter, got {:?}", other),
+        }
+
+        // Original "k" should be unchanged (still a counter).
+        match api.get_eventual("k") {
+            Some(CrdtValue::Counter(c)) => assert_eq!(c.value(), 1),
+            other => panic!("expected Counter for k, got {:?}", other),
+        }
+    }
+
+    server.abort();
+}
+
+/// Test three-node convergence through sequential sync rounds.
+#[tokio::test]
+async fn three_node_convergence_via_sync() {
+    // Start 3 HTTP servers.
+    let mut listeners = Vec::new();
+    let mut addrs = Vec::new();
+    for _ in 0..3 {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        addrs.push(addr);
+        listeners.push(listener);
+    }
+
+    let mut states = Vec::new();
+    for i in 0..3 {
+        let nid = node_id(&format!("node-{}", i + 1));
+        let state = Arc::new(AppState {
+            eventual: Mutex::new(EventualApi::new(nid.clone())),
+            certified: Mutex::new(CertifiedApi::new(nid, default_namespace())),
+        });
+        states.push(state);
+    }
+
+    // Write distinct data to each node.
+    {
+        let mut api = states[0].eventual.lock().await;
+        let mut c = PnCounter::new();
+        c.increment(&node_id("node-1"));
+        c.increment(&node_id("node-1"));
+        api.eventual_write("score".into(), CrdtValue::Counter(c));
+    }
+    {
+        let mut api = states[1].eventual.lock().await;
+        let mut c = PnCounter::new();
+        c.increment(&node_id("node-2"));
+        c.increment(&node_id("node-2"));
+        c.increment(&node_id("node-2"));
+        api.eventual_write("score".into(), CrdtValue::Counter(c));
+    }
+    {
+        let mut api = states[2].eventual.lock().await;
+        let mut c = PnCounter::new();
+        c.increment(&node_id("node-3"));
+        api.eventual_write("score".into(), CrdtValue::Counter(c));
+    }
+
+    // Start servers.
+    let mut servers = Vec::new();
+    for _ in 0..3 {
+        let state = states[servers.len()].clone();
+        let listener = listeners.remove(0);
+        let app = router(state);
+        servers.push(tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        }));
+    }
+
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    // Run 2 rounds of full-mesh sync (push from each node to all others).
+    for _round in 0..2 {
+        for i in 0..3 {
+            let self_id = node_id(&format!("node-{}", i + 1));
+            let peers: Vec<PeerConfig> = (0..3)
+                .filter(|&j| j != i)
+                .map(|j| PeerConfig {
+                    node_id: node_id(&format!("node-{}", j + 1)),
+                    addr: addrs[j],
+                })
+                .collect();
+
+            let registry = PeerRegistry::new(self_id, peers).unwrap();
+            let sync_client = SyncClient::new(registry);
+
+            let entries: HashMap<String, CrdtValue> = {
+                let api = states[i].eventual.lock().await;
+                api.store()
+                    .all_entries()
+                    .map(|(k, v)| (k.clone(), v.clone()))
+                    .collect()
+            };
+
+            sync_client
+                .push_all_keys(entries, &format!("node-{}", i + 1))
+                .await;
+        }
+    }
+
+    // Verify all nodes converge to score = 2 + 3 + 1 = 6.
+    for i in 0..3 {
+        let api = states[i].eventual.lock().await;
+        match api.get_eventual("score") {
+            Some(CrdtValue::Counter(c)) => {
+                assert_eq!(
+                    c.value(),
+                    6,
+                    "node-{} should see score=6 after sync, got {}",
+                    i + 1,
+                    c.value()
+                );
+            }
+            other => panic!("node-{}: expected Counter, got {:?}", i + 1, other),
+        }
+    }
+
+    for s in servers {
+        s.abort();
+    }
+}
+
+/// Test that the internal /api/internal/keys endpoint returns all entries.
+#[tokio::test]
+async fn internal_keys_endpoint() {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    let state = Arc::new(AppState {
+        eventual: Mutex::new(EventualApi::new(node_id("node-1"))),
+        certified: Mutex::new(CertifiedApi::new(node_id("node-1"), default_namespace())),
+    });
+
+    {
+        let mut api = state.eventual.lock().await;
+        api.eventual_counter_inc("a").unwrap();
+        api.eventual_counter_inc("b").unwrap();
+        api.eventual_counter_inc("c").unwrap();
+    }
+
+    let app = router(state);
+    let server = tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    let client = reqwest::Client::new();
+    let resp = client
+        .get(format!("http://{}/api/internal/keys", addr))
+        .send()
+        .await
+        .unwrap();
+
+    assert!(resp.status().is_success());
+
+    let dump: asteroidb_poc::network::sync::KeyDumpResponse = resp.json().await.unwrap();
+    assert_eq!(dump.entries.len(), 3);
+    assert!(dump.entries.contains_key("a"));
+    assert!(dump.entries.contains_key("b"));
+    assert!(dump.entries.contains_key("c"));
+
+    server.abort();
+}


### PR DESCRIPTION
## Summary
- Add `SyncClient` (`src/network/sync.rs`) with push-based and pull-based anti-entropy replication via HTTP
- Add internal sync endpoints: `POST /api/internal/sync` (bulk CRDT merge) and `GET /api/internal/keys` (full key dump)
- Integrate sync loop into `NodeRunner` with configurable `sync_interval` (default 2s)
- Add `Store::all_entries()` and `EventualApi::store()` accessors for sync layer to read store state
- Add `reqwest` and `tracing` as runtime dependencies for HTTP sync client and structured logging
- 5 integration tests covering 2-node convergence, 3-node convergence, pull-based sync, partial failure handling, and internal keys endpoint

## Test plan
- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] All 431 existing unit tests pass (no regressions)
- [x] 5 new integration tests in `tests/anti_entropy_convergence.rs`:
  - `two_node_anti_entropy_convergence`: Two nodes with disjoint data converge after push sync
  - `three_node_convergence_via_sync`: Three nodes converge to correct CRDT state after 2 sync rounds
  - `pull_based_sync`: Pull endpoint returns correct CRDT values
  - `sync_endpoint_partial_failure`: Type mismatch errors are reported but valid keys still merge
  - `internal_keys_endpoint`: GET endpoint returns all stored entries
- [x] Sync unit tests in `src/network/sync.rs` (serde round-trips, unreachable peer handling)

Closes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)