### PR TITLE
feat: add local 3-node cluster environment with Docker Compose

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+target/
+.git/
+.claude/
+.gitignore
+docker-compose.yml
+Dockerfile
+configs/
+scripts/
+docs/
+tests/
+*.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM rust:1.85 AS builder
+WORKDIR /app
+COPY . .
+RUN cargo build --release
+
+FROM debian:bookworm-slim
+COPY --from=builder /app/target/release/asteroidb-poc /usr/local/bin/
+ENTRYPOINT ["asteroidb-poc"]

--- a/configs/node-1.json
+++ b/configs/node-1.json
@@ -1,0 +1,21 @@
+{
+  "node": {
+    "id": "node-1",
+    "mode": "Both",
+    "tags": []
+  },
+  "bind_addr": "0.0.0.0:3000",
+  "peers": {
+    "self_id": "node-1",
+    "peers": {
+      "node-2": {
+        "node_id": "node-2",
+        "addr": "asteroidb-node-2:3000"
+      },
+      "node-3": {
+        "node_id": "node-3",
+        "addr": "asteroidb-node-3:3000"
+      }
+    }
+  }
+}

--- a/configs/node-2.json
+++ b/configs/node-2.json
@@ -1,0 +1,21 @@
+{
+  "node": {
+    "id": "node-2",
+    "mode": "Both",
+    "tags": []
+  },
+  "bind_addr": "0.0.0.0:3000",
+  "peers": {
+    "self_id": "node-2",
+    "peers": {
+      "node-1": {
+        "node_id": "node-1",
+        "addr": "asteroidb-node-1:3000"
+      },
+      "node-3": {
+        "node_id": "node-3",
+        "addr": "asteroidb-node-3:3000"
+      }
+    }
+  }
+}

--- a/configs/node-3.json
+++ b/configs/node-3.json
@@ -1,0 +1,21 @@
+{
+  "node": {
+    "id": "node-3",
+    "mode": "Both",
+    "tags": []
+  },
+  "bind_addr": "0.0.0.0:3000",
+  "peers": {
+    "self_id": "node-3",
+    "peers": {
+      "node-1": {
+        "node_id": "node-1",
+        "addr": "asteroidb-node-1:3000"
+      },
+      "node-2": {
+        "node_id": "node-2",
+        "addr": "asteroidb-node-2:3000"
+      }
+    }
+  }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,37 @@
+services:
+  node-1:
+    build: .
+    container_name: asteroidb-node-1
+    ports:
+      - "3001:3000"
+    environment:
+      ASTEROIDB_BIND_ADDR: "0.0.0.0:3000"
+      ASTEROIDB_NODE_ID: "node-1"
+    networks:
+      - asteroidb
+
+  node-2:
+    build: .
+    container_name: asteroidb-node-2
+    ports:
+      - "3002:3000"
+    environment:
+      ASTEROIDB_BIND_ADDR: "0.0.0.0:3000"
+      ASTEROIDB_NODE_ID: "node-2"
+    networks:
+      - asteroidb
+
+  node-3:
+    build: .
+    container_name: asteroidb-node-3
+    ports:
+      - "3003:3000"
+    environment:
+      ASTEROIDB_BIND_ADDR: "0.0.0.0:3000"
+      ASTEROIDB_NODE_ID: "node-3"
+    networks:
+      - asteroidb
+
+networks:
+  asteroidb:
+    driver: bridge

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -355,7 +355,105 @@ cargo test eventual_counter_inc
 - **統合テスト**: Authority 認証フロー、配置連携、CRDT 収束、クォーラム安全性
 - **分断耐性テスト**: ネットワーク分断後の収束、Certified write の挙動
 
-## 5. デモシナリオ
+## 5. Docker Compose による 3 ノードクラスタ
+
+Docker Compose を使って、ローカル環境で 3 ノードのクラスタを起動できます。
+
+### 前提条件
+
+| 項目 | 要件 |
+|------|------|
+| **Docker** | 20.10 以降 |
+| **Docker Compose** | V2 (docker compose コマンド) |
+
+### クラスタの起動
+
+```bash
+# 補助スクリプトで起動 (ビルド + バックグラウンド起動)
+./scripts/cluster-up.sh
+
+# または直接 docker compose を実行
+docker compose up -d --build
+```
+
+起動後、各ノードは以下のポートで HTTP API を公開します:
+
+| ノード | ホスト側ポート | コンテナ内ポート |
+|--------|--------------|----------------|
+| node-1 | `localhost:3001` | `0.0.0.0:3000` |
+| node-2 | `localhost:3002` | `0.0.0.0:3000` |
+| node-3 | `localhost:3003` | `0.0.0.0:3000` |
+
+### ヘルスチェック
+
+```bash
+./scripts/cluster-status.sh
+```
+
+出力例:
+
+```
+AsteroidDB Cluster Status
+=========================
+
+  node-1 (localhost:3001): UP
+  node-2 (localhost:3002): UP
+  node-3 (localhost:3003): UP
+
+All nodes are healthy.
+```
+
+### クラスタへの操作
+
+各ノードに対して個別に HTTP API を呼び出せます:
+
+```bash
+# node-1 に書き込み
+curl -X POST http://localhost:3001/api/eventual/write \
+  -H "Content-Type: application/json" \
+  -d '{"type":"counter_inc","key":"hits"}'
+
+# node-2 から読み取り
+curl http://localhost:3002/api/eventual/hits
+
+# node-3 に書き込み
+curl -X POST http://localhost:3003/api/eventual/write \
+  -H "Content-Type: application/json" \
+  -d '{"type":"set_add","key":"users","element":"alice"}'
+```
+
+> **注**: 現時点ではノード間のデータ同期 (レプリケーション) は docker compose 構成では未接続です。各ノードは独立した HTTP API サーバとして動作します。ノード間通信の統合は今後の Issue で対応予定です。
+
+### クラスタの停止
+
+```bash
+./scripts/cluster-down.sh
+
+# または直接
+docker compose down
+```
+
+### ログの確認
+
+```bash
+# 全ノードのログを表示
+docker compose logs
+
+# 特定ノードのログをフォロー
+docker compose logs -f node-1
+```
+
+### 設定ファイル
+
+各ノードの設定例は `configs/` ディレクトリに格納されています:
+
+- `configs/node-1.json` - node-1 の NodeConfig
+- `configs/node-2.json` - node-2 の NodeConfig
+- `configs/node-3.json` - node-3 の NodeConfig
+
+これらは `NodeConfig::load()` で読み込み可能な JSON 形式です。将来的にノード起動時に設定ファイルを指定する機能が追加される予定です。
+
+## 6. デモシナリオ
 
 ### ノード起動とバックグラウンド処理
 
@@ -397,7 +495,7 @@ cargo test --test partition_tolerance -- --nocapture
 
 > 注: `demo_partition_recovery` example は今後追加予定です。現時点では上記のテストスイートで分断耐性を検証できます。
 
-## 6. トラブルシューティング
+## 7. トラブルシューティング
 
 ### ビルドエラー
 

--- a/scripts/cluster-down.sh
+++ b/scripts/cluster-down.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+echo "Stopping AsteroidDB cluster..."
+docker compose -f "$PROJECT_DIR/docker-compose.yml" down
+
+echo "Cluster stopped."

--- a/scripts/cluster-status.sh
+++ b/scripts/cluster-status.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+NODES=("localhost:3001" "localhost:3002" "localhost:3003")
+NODE_NAMES=("node-1" "node-2" "node-3")
+
+echo "AsteroidDB Cluster Status"
+echo "========================="
+echo ""
+
+all_ok=true
+
+for i in "${!NODES[@]}"; do
+    addr="${NODES[$i]}"
+    name="${NODE_NAMES[$i]}"
+
+    if curl -sf --max-time 3 "http://${addr}/api/eventual/__health_check" > /dev/null 2>&1; then
+        # The endpoint returns 200 with null value for non-existent keys,
+        # which means the HTTP server is up and responding.
+        echo "  ${name} (${addr}): UP"
+    else
+        # Even a 200 with {"key":"__health_check","value":null} counts as UP.
+        # Try again and check HTTP status code.
+        status=$(curl -s -o /dev/null -w "%{http_code}" --max-time 3 "http://${addr}/api/eventual/__health_check" 2>/dev/null || echo "000")
+        if [ "$status" = "200" ]; then
+            echo "  ${name} (${addr}): UP"
+        else
+            echo "  ${name} (${addr}): DOWN (HTTP ${status})"
+            all_ok=false
+        fi
+    fi
+done
+
+echo ""
+if $all_ok; then
+    echo "All nodes are healthy."
+else
+    echo "Some nodes are not responding. Check 'docker compose logs' for details."
+fi

--- a/scripts/cluster-up.sh
+++ b/scripts/cluster-up.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+echo "Starting AsteroidDB 3-node cluster..."
+docker compose -f "$PROJECT_DIR/docker-compose.yml" up -d --build
+
+echo ""
+echo "Cluster started. Nodes:"
+echo "  node-1: http://localhost:3001"
+echo "  node-2: http://localhost:3002"
+echo "  node-3: http://localhost:3003"
+echo ""
+echo "Run 'scripts/cluster-status.sh' to check health."
+echo "Run 'scripts/cluster-down.sh' to stop."

--- a/src/http/routes.rs
+++ b/src/http/routes.rs
@@ -5,8 +5,7 @@ use axum::routing::{get, post};
 
 use super::handlers::{
     AppState, certified_write, eventual_write, get_certification_status, get_certified,
-    get_eventual, get_internal_frontiers, internal_keys, internal_sync,
-    post_internal_frontiers,
+    get_eventual, get_internal_frontiers, internal_keys, internal_sync, post_internal_frontiers,
 };
 
 /// Build the HTTP API router with all endpoints.

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,9 +16,11 @@ async fn main() {
     let bind_addr =
         std::env::var("ASTEROIDB_BIND_ADDR").unwrap_or_else(|_| "127.0.0.1:3000".into());
 
-    println!("AsteroidDB starting...");
+    let node_id_str = std::env::var("ASTEROIDB_NODE_ID").unwrap_or_else(|_| "node-1".into());
 
-    let node_id = NodeId("node-1".into());
+    println!("AsteroidDB starting... (node_id={node_id_str})");
+
+    let node_id = NodeId(node_id_str);
 
     let mut ns = SystemNamespace::new();
     ns.set_authority_definition(AuthorityDefinition {


### PR DESCRIPTION
## Summary

- Add `Dockerfile` and `docker-compose.yml` for 3-node local cluster (node-1:3001, node-2:3002, node-3:3003)
- Add `configs/node-{1,2,3}.json` with NodeConfig examples including peer registry
- Add `scripts/cluster-up.sh`, `scripts/cluster-down.sh`, `scripts/cluster-status.sh` helper scripts
- Support `ASTEROIDB_NODE_ID` environment variable in `main.rs` for per-node identity
- Update `docs/getting-started.md` with Docker Compose cluster setup instructions
- Fix `cargo fmt` issue in `src/http/routes.rs`

Closes #81

## Test plan

- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test` passes (all 555+ tests)
- [ ] Run `./scripts/cluster-up.sh` and verify 3 containers start
- [ ] Run `./scripts/cluster-status.sh` and verify all nodes report UP
- [ ] Execute curl commands from docs against each node
- [ ] Run `./scripts/cluster-down.sh` and verify clean shutdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)