### PR TITLE
feat: add certified_write auto-certification worker

### DIFF
--- a/src/api/certified.rs
+++ b/src/api/certified.rs
@@ -308,6 +308,54 @@ impl CertifiedApi {
         }
     }
 
+    /// Re-evaluate pending writes and detect timeouts in a single pass.
+    ///
+    /// Combines the logic of [`process_certifications`](Self::process_certifications)
+    /// and timeout detection: pending writes whose timestamps are at or below
+    /// the scoped majority frontier are promoted to `Certified`, while those
+    /// older than `max_age_ms` are marked as `Timeout`.
+    ///
+    /// Returns the number of writes that transitioned (certified + timed out).
+    pub fn process_certifications_with_timeout(&mut self, now_physical_ms: u64) -> usize {
+        let mut transitions = 0;
+        for pw in &mut self.pending_writes {
+            if pw.status != CertificationStatus::Pending {
+                continue;
+            }
+            if self.frontiers.is_certified_at_for_scope(
+                &pw.timestamp,
+                &pw.key_range,
+                &pw.policy_version,
+                pw.total_authorities,
+            ) {
+                pw.status = CertificationStatus::Certified;
+                transitions += 1;
+            } else if now_physical_ms.saturating_sub(pw.timestamp.physical)
+                >= self.retention.max_age_ms
+            {
+                pw.status = CertificationStatus::Timeout;
+                transitions += 1;
+            }
+        }
+        transitions
+    }
+
+    /// Reject a pending write by key.
+    ///
+    /// Marks the most recent `Pending` write for the given key as `Rejected`.
+    /// Returns `true` if a write was found and rejected, `false` otherwise.
+    /// Only `Pending` writes can be rejected; already-resolved writes are
+    /// left unchanged.
+    pub fn reject_write(&mut self, key: &str) -> bool {
+        for pw in self.pending_writes.iter_mut().rev() {
+            if pw.key == key && pw.status == CertificationStatus::Pending {
+                pw.status = CertificationStatus::Rejected;
+                return true;
+            }
+        }
+        false
+    }
+
     /// Remove all writes whose status is not `Pending`.
     ///
     /// This removes `Certified`, `Rejected`, and `Timeout` entries,
@@ -1185,5 +1233,181 @@ mod tests {
         assert_eq!(pw.key_range, kr("data/"));
         assert_eq!(pw.policy_version, PolicyVersion(1));
         assert_eq!(pw.total_authorities, 3);
+    }
+
+    // ---------------------------------------------------------------
+    // process_certifications_with_timeout tests
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn process_with_timeout_certifies_and_detects_timeout() {
+        // Use two separate key ranges so we can certify one without the other.
+        let mut ns = SystemNamespace::new();
+        ns.set_authority_definition(AuthorityDefinition {
+            key_range: kr("cert/"),
+            authority_nodes: vec![node("auth-1"), node("auth-2"), node("auth-3")],
+        });
+        ns.set_authority_definition(AuthorityDefinition {
+            key_range: kr("stale/"),
+            authority_nodes: vec![node("auth-s1"), node("auth-s2"), node("auth-s3")],
+        });
+
+        let policy = RetentionPolicy {
+            max_age_ms: 5_000,
+            max_entries: 10_000,
+        };
+        let mut api = CertifiedApi::with_retention(node("node-1"), ns, policy);
+
+        // Write to cert/ range (will be certified).
+        api.certified_write("cert/key1".into(), counter_value(1), OnTimeout::Pending)
+            .unwrap();
+        let ts1 = api.pending_writes()[0].timestamp.physical;
+
+        // Write to stale/ range (will time out because its authorities never report).
+        api.certified_write("stale/key2".into(), counter_value(2), OnTimeout::Pending)
+            .unwrap();
+
+        // Advance cert/ authorities past the write timestamp.
+        api.update_frontier(make_frontier_v("auth-1", ts1 + 100, 0, "cert/", 1));
+        api.update_frontier(make_frontier_v("auth-2", ts1 + 200, 0, "cert/", 1));
+
+        // Process with a time far in the future to trigger timeout on stale/key2.
+        let transitions = api.process_certifications_with_timeout(ts1 + 10_000);
+
+        // cert/key1 should be certified (its authorities reached majority).
+        assert_eq!(
+            api.get_certification_status("cert/key1"),
+            CertificationStatus::Certified
+        );
+        // stale/key2 should time out (its authorities never reported).
+        assert_eq!(
+            api.get_certification_status("stale/key2"),
+            CertificationStatus::Timeout
+        );
+        assert_eq!(transitions, 2);
+    }
+
+    #[test]
+    fn process_with_timeout_no_timeout_when_young() {
+        let policy = RetentionPolicy {
+            max_age_ms: 60_000,
+            max_entries: 10_000,
+        };
+        let mut api = CertifiedApi::with_retention(node("node-1"), default_namespace(), policy);
+
+        api.certified_write("key1".into(), counter_value(1), OnTimeout::Pending)
+            .unwrap();
+        let ts1 = api.pending_writes()[0].timestamp.physical;
+
+        // Process with a time only slightly ahead (below max_age_ms).
+        let transitions = api.process_certifications_with_timeout(ts1 + 1_000);
+
+        // Still pending — no timeout.
+        assert_eq!(
+            api.get_certification_status("key1"),
+            CertificationStatus::Pending
+        );
+        assert_eq!(transitions, 0);
+    }
+
+    #[test]
+    fn process_with_timeout_returns_transition_count() {
+        let mut api = CertifiedApi::new(node("node-1"), default_namespace());
+
+        api.certified_write("key1".into(), counter_value(1), OnTimeout::Pending)
+            .unwrap();
+        api.certified_write("key2".into(), counter_value(2), OnTimeout::Pending)
+            .unwrap();
+
+        let ts = api.pending_writes()[1].timestamp.physical;
+
+        // Certify both.
+        api.update_frontier(make_frontier("auth-1", ts + 100, 0, ""));
+        api.update_frontier(make_frontier("auth-2", ts + 200, 0, ""));
+
+        let transitions = api.process_certifications_with_timeout(ts + 100);
+        assert_eq!(transitions, 2);
+
+        // Calling again should yield 0 (already certified).
+        let transitions2 = api.process_certifications_with_timeout(ts + 200);
+        assert_eq!(transitions2, 0);
+    }
+
+    // ---------------------------------------------------------------
+    // reject_write tests
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn reject_write_marks_pending_as_rejected() {
+        let mut api = CertifiedApi::new(node("node-1"), default_namespace());
+
+        api.certified_write("key1".into(), counter_value(1), OnTimeout::Pending)
+            .unwrap();
+        assert_eq!(
+            api.get_certification_status("key1"),
+            CertificationStatus::Pending
+        );
+
+        assert!(api.reject_write("key1"));
+        assert_eq!(
+            api.get_certification_status("key1"),
+            CertificationStatus::Rejected
+        );
+    }
+
+    #[test]
+    fn reject_write_returns_false_for_nonexistent_key() {
+        let mut api = CertifiedApi::new(node("node-1"), default_namespace());
+        assert!(!api.reject_write("no-such-key"));
+    }
+
+    #[test]
+    fn reject_write_does_not_affect_certified() {
+        let mut api = CertifiedApi::new(node("node-1"), default_namespace());
+
+        api.certified_write("key1".into(), counter_value(1), OnTimeout::Pending)
+            .unwrap();
+        let ts = api.pending_writes()[0].timestamp.physical;
+
+        // Certify it.
+        api.update_frontier(make_frontier("auth-1", ts + 100, 0, ""));
+        api.update_frontier(make_frontier("auth-2", ts + 200, 0, ""));
+        api.process_certifications();
+
+        assert_eq!(
+            api.get_certification_status("key1"),
+            CertificationStatus::Certified
+        );
+
+        // Reject should be a no-op on certified writes.
+        assert!(!api.reject_write("key1"));
+        assert_eq!(
+            api.get_certification_status("key1"),
+            CertificationStatus::Certified
+        );
+    }
+
+    #[test]
+    fn reject_write_targets_latest_pending() {
+        let mut api = CertifiedApi::new(node("node-1"), default_namespace());
+
+        // Write same key twice.
+        api.certified_write("key1".into(), counter_value(1), OnTimeout::Pending)
+            .unwrap();
+        api.certified_write("key1".into(), counter_value(2), OnTimeout::Pending)
+            .unwrap();
+
+        // Reject targets the latest (most recent) pending write.
+        assert!(api.reject_write("key1"));
+
+        // The latest should be rejected.
+        let writes: Vec<_> = api
+            .pending_writes()
+            .iter()
+            .filter(|pw| pw.key == "key1")
+            .collect();
+        assert_eq!(writes.len(), 2);
+        assert_eq!(writes[0].status, CertificationStatus::Pending);
+        assert_eq!(writes[1].status, CertificationStatus::Rejected);
     }
 }

--- a/src/http/routes.rs
+++ b/src/http/routes.rs
@@ -5,8 +5,7 @@ use axum::routing::{get, post};
 
 use super::handlers::{
     AppState, certified_write, eventual_write, get_certification_status, get_certified,
-    get_eventual, get_internal_frontiers, internal_keys, internal_sync,
-    post_internal_frontiers,
+    get_eventual, get_internal_frontiers, internal_keys, internal_sync, post_internal_frontiers,
 };
 
 /// Build the HTTP API router with all endpoints.

--- a/src/runtime/node_runner.rs
+++ b/src/runtime/node_runner.rs
@@ -291,7 +291,9 @@ impl NodeRunner {
     }
 
     fn process_certifications(&mut self) {
-        self.certified_api.process_certifications();
+        let now_ms = self.clock.now().physical;
+        self.certified_api
+            .process_certifications_with_timeout(now_ms);
     }
 
     fn run_cleanup(&mut self) {

--- a/tests/certification_worker.rs
+++ b/tests/certification_worker.rs
@@ -1,0 +1,667 @@
+//! Certification worker E2E tests (Issue #80).
+//!
+//! Validates that the automatic certification pipeline in [`NodeRunner`]
+//! drives pending writes to completion without manual intervention:
+//!
+//! 1. **3-Authority auto-certification**: a `certified_write` on an authority
+//!    node is automatically certified by the frontier auto-report pipeline.
+//! 2. **Timeout detection**: stale pending writes are promoted to `Timeout`
+//!    during the certification tick.
+//! 3. **Rejected transition**: writes can be explicitly rejected and the
+//!    status is observable.
+//! 4. **Status tracking**: certification status transitions are observable
+//!    through the `CertifiedApi` and `CertificationTracker` APIs.
+
+use std::time::Duration;
+
+use asteroidb_poc::api::certified::{CertifiedApi, OnTimeout, RetentionPolicy};
+use asteroidb_poc::api::status::{CertificationTracker, WriteId};
+use asteroidb_poc::authority::ack_frontier::AckFrontier;
+use asteroidb_poc::authority::frontier_reporter::FrontierReporter;
+use asteroidb_poc::compaction::CompactionEngine;
+use asteroidb_poc::control_plane::system_namespace::{AuthorityDefinition, SystemNamespace};
+use asteroidb_poc::crdt::pn_counter::PnCounter;
+use asteroidb_poc::hlc::HlcTimestamp;
+use asteroidb_poc::runtime::{NodeRunner, NodeRunnerConfig};
+use asteroidb_poc::store::kv::CrdtValue;
+use asteroidb_poc::types::{CertificationStatus, KeyRange, NodeId, PolicyVersion};
+
+fn node_id(s: &str) -> NodeId {
+    NodeId(s.into())
+}
+
+fn kr(prefix: &str) -> KeyRange {
+    KeyRange {
+        prefix: prefix.into(),
+    }
+}
+
+fn counter_value(n: i64) -> CrdtValue {
+    let mut counter = PnCounter::new();
+    for _ in 0..n {
+        counter.increment(&node_id("writer"));
+    }
+    CrdtValue::Counter(counter)
+}
+
+fn make_frontier(authority: &str, physical: u64, prefix: &str) -> AckFrontier {
+    AckFrontier {
+        authority_id: NodeId(authority.into()),
+        frontier_hlc: HlcTimestamp {
+            physical,
+            logical: 0,
+            node_id: authority.into(),
+        },
+        key_range: KeyRange {
+            prefix: prefix.into(),
+        },
+        policy_version: PolicyVersion(1),
+        digest_hash: format!("{authority}-{physical}"),
+    }
+}
+
+/// Build a 3-authority namespace with a catch-all key range.
+fn three_authority_namespace() -> SystemNamespace {
+    let mut ns = SystemNamespace::new();
+    ns.set_authority_definition(AuthorityDefinition {
+        key_range: kr(""),
+        authority_nodes: vec![node_id("auth-1"), node_id("auth-2"), node_id("auth-3")],
+    });
+    ns
+}
+
+/// Fast runner config with short intervals for testing.
+fn fast_config() -> NodeRunnerConfig {
+    NodeRunnerConfig {
+        certification_interval: Duration::from_millis(10),
+        cleanup_interval: Duration::from_secs(60),
+        compaction_check_interval: Duration::from_secs(60),
+        frontier_report_interval: Duration::from_millis(10),
+        sync_interval: None,
+    }
+}
+
+// ---------------------------------------------------------------
+// Test 1: 3 Authority auto-certification E2E
+// ---------------------------------------------------------------
+
+/// In a 3-authority system, a `certified_write` should reach `Certified`
+/// once a majority (2 of 3) of authority frontier reporters advance past
+/// the write timestamp. This test simulates 3 authorities generating
+/// frontier reports via `FrontierReporter`, feeds them to a client node
+/// holding the pending write, and verifies automatic certification.
+#[tokio::test]
+async fn three_authority_auto_certification() {
+    let ns = three_authority_namespace();
+
+    // Create frontier reporters for all 3 authorities.
+    let reporter1 = FrontierReporter::new(node_id("auth-1"), &ns);
+    let reporter2 = FrontierReporter::new(node_id("auth-2"), &ns);
+    let reporter3 = FrontierReporter::new(node_id("auth-3"), &ns);
+
+    assert!(reporter1.is_authority());
+    assert!(reporter2.is_authority());
+    assert!(reporter3.is_authority());
+
+    // Client node: writes a pending entry.
+    let mut client_api = CertifiedApi::new(node_id("client"), ns);
+    client_api
+        .certified_write("sensor/temp".into(), counter_value(42), OnTimeout::Pending)
+        .unwrap();
+    assert_eq!(
+        client_api.get_certification_status("sensor/temp"),
+        CertificationStatus::Pending
+    );
+
+    let write_ts = &client_api.pending_writes()[0].timestamp;
+
+    // Each authority generates a frontier report at a timestamp guaranteed
+    // to be after the write. We use the write timestamp + 100ms to ensure
+    // the frontier strictly covers the write.
+    let frontier_ts = HlcTimestamp {
+        physical: write_ts.physical + 100,
+        logical: 0,
+        node_id: "frontier-gen".into(),
+    };
+
+    let frontiers1 = reporter1.report_frontiers_at(&frontier_ts);
+    let frontiers2 = reporter2.report_frontiers_at(&frontier_ts);
+    let frontiers3 = reporter3.report_frontiers_at(&frontier_ts);
+
+    // Apply frontiers from all 3 authorities to the client.
+    for f in frontiers1 {
+        client_api.update_frontier(f);
+    }
+    for f in frontiers2 {
+        client_api.update_frontier(f);
+    }
+    for f in frontiers3 {
+        client_api.update_frontier(f);
+    }
+
+    // Process certifications on the client side.
+    client_api.process_certifications();
+
+    // The write should now be certified because all 3 authorities
+    // have reported frontiers past the write timestamp.
+    assert_eq!(
+        client_api.get_certification_status("sensor/temp"),
+        CertificationStatus::Certified,
+        "certified_write should auto-certify when 3-authority frontiers have advanced"
+    );
+}
+
+/// Full NodeRunner-based E2E: an authority node running a NodeRunner
+/// with its own frontier reporter auto-certifies a pending write.
+/// Uses 3-authority namespace but only one authority node runs locally.
+/// The other 2 authorities' frontiers are injected manually to simulate
+/// the network sync that would deliver them.
+#[tokio::test]
+async fn three_authority_node_runner_certification() {
+    let ns = three_authority_namespace();
+
+    // auth-1 is an authority node that also has the pending write.
+    let mut api = CertifiedApi::new(node_id("auth-1"), ns);
+    api.certified_write("data/val".into(), counter_value(5), OnTimeout::Pending)
+        .unwrap();
+    let write_ts = api.pending_writes()[0].timestamp.physical;
+
+    // Inject frontiers for auth-2 and auth-3 (simulating network sync).
+    // These are past the write timestamp.
+    api.update_frontier(make_frontier("auth-2", write_ts + 500, ""));
+    api.update_frontier(make_frontier("auth-3", write_ts + 600, ""));
+
+    // auth-1's own frontier will be auto-reported by the NodeRunner.
+    let engine = CompactionEngine::with_defaults();
+    let mut runner = NodeRunner::new(node_id("auth-1"), api, engine, fast_config());
+    assert!(runner.is_authority());
+
+    let handle = runner.shutdown_handle();
+
+    tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        let _ = handle.send(true);
+    });
+
+    runner.run().await;
+
+    // auth-1 frontier should have been auto-reported, giving 3/3 authorities.
+    // But only 2/3 are needed for majority. The write should be certified.
+    assert_eq!(
+        runner.certified_api().pending_writes()[0].status,
+        CertificationStatus::Certified,
+        "write should auto-certify in 3-authority NodeRunner setup"
+    );
+}
+
+// ---------------------------------------------------------------
+// Test 2: Single authority node auto-certifies its own write
+// ---------------------------------------------------------------
+
+/// When an authority node writes locally and runs its own frontier
+/// reporter, the write should auto-certify without external intervention.
+/// This uses a 1-authority setup for simplicity.
+#[tokio::test]
+async fn single_authority_self_certification() {
+    let mut ns = SystemNamespace::new();
+    ns.set_authority_definition(AuthorityDefinition {
+        key_range: kr(""),
+        authority_nodes: vec![node_id("auth-1")],
+    });
+
+    let mut api = CertifiedApi::new(node_id("auth-1"), ns);
+    api.certified_write("key1".into(), counter_value(10), OnTimeout::Pending)
+        .unwrap();
+    assert_eq!(
+        api.get_certification_status("key1"),
+        CertificationStatus::Pending
+    );
+
+    let engine = CompactionEngine::with_defaults();
+    let mut runner = NodeRunner::new(node_id("auth-1"), api, engine, fast_config());
+    let handle = runner.shutdown_handle();
+
+    tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        let _ = handle.send(true);
+    });
+
+    let stats = runner.run().await;
+
+    assert!(
+        stats.frontier_report_ticks >= 1,
+        "authority should have reported frontiers"
+    );
+    assert!(
+        stats.certification_ticks >= 1,
+        "certification ticks should have fired"
+    );
+
+    assert_eq!(
+        runner.certified_api().pending_writes()[0].status,
+        CertificationStatus::Certified,
+        "write should auto-certify on authority node"
+    );
+}
+
+// ---------------------------------------------------------------
+// Test 3: Timeout auto-detection during certification tick
+// ---------------------------------------------------------------
+
+/// Pending writes that exceed the retention policy's `max_age_ms` should
+/// be automatically marked as `Timeout` during the certification tick.
+#[tokio::test]
+async fn timeout_auto_detection() {
+    let retention = RetentionPolicy {
+        max_age_ms: 10, // Very short TTL for test.
+        max_entries: 10_000,
+    };
+    let ns = three_authority_namespace();
+    let mut api = CertifiedApi::with_retention(node_id("node-1"), ns, retention);
+
+    api.certified_write("key1".into(), counter_value(1), OnTimeout::Pending)
+        .unwrap();
+    assert_eq!(
+        api.get_certification_status("key1"),
+        CertificationStatus::Pending
+    );
+
+    let engine = CompactionEngine::with_defaults();
+    let config = NodeRunnerConfig {
+        certification_interval: Duration::from_millis(10),
+        cleanup_interval: Duration::from_secs(60),
+        compaction_check_interval: Duration::from_secs(60),
+        frontier_report_interval: Duration::from_secs(60),
+        sync_interval: None,
+    };
+
+    let mut runner = NodeRunner::new(node_id("node-1"), api, engine, config);
+    let handle = runner.shutdown_handle();
+
+    // Run long enough for the write to age past max_age_ms (10ms).
+    tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_millis(80)).await;
+        let _ = handle.send(true);
+    });
+
+    runner.run().await;
+
+    // The write should be marked as Timeout because the certification tick
+    // detected that it exceeded max_age_ms.
+    assert_eq!(
+        runner.certified_api().pending_writes()[0].status,
+        CertificationStatus::Timeout,
+        "stale write should auto-transition to Timeout"
+    );
+}
+
+// ---------------------------------------------------------------
+// Test 4: Rejected transition
+// ---------------------------------------------------------------
+
+/// Writes can be explicitly rejected via `reject_write`, and this
+/// status is observable through the API.
+#[tokio::test]
+async fn rejected_transition_observable() {
+    let ns = three_authority_namespace();
+    let mut api = CertifiedApi::new(node_id("node-1"), ns);
+
+    api.certified_write("key1".into(), counter_value(1), OnTimeout::Pending)
+        .unwrap();
+    assert_eq!(
+        api.get_certification_status("key1"),
+        CertificationStatus::Pending
+    );
+
+    // Reject the write.
+    let rejected = api.reject_write("key1");
+    assert!(
+        rejected,
+        "reject_write should return true for pending write"
+    );
+
+    assert_eq!(
+        api.get_certification_status("key1"),
+        CertificationStatus::Rejected,
+        "write status should be Rejected after reject_write"
+    );
+
+    // Reject on already-rejected write should be a no-op.
+    let rejected_again = api.reject_write("key1");
+    assert!(
+        !rejected_again,
+        "reject_write on non-pending should return false"
+    );
+}
+
+// ---------------------------------------------------------------
+// Test 5: Status API tracks transitions via CertificationTracker
+// ---------------------------------------------------------------
+
+/// The `CertificationTracker` mirrors the certification flow and
+/// transitions are observable: Pending -> Certified, Pending -> Timeout,
+/// Pending -> Rejected.
+#[tokio::test]
+async fn status_tracker_mirrors_certification_flow() {
+    let mut tracker = CertificationTracker::with_timeout(100); // 100ms timeout
+
+    // Register a write.
+    let wid1 = WriteId {
+        key: "key1".into(),
+        timestamp: HlcTimestamp {
+            physical: 1000,
+            logical: 0,
+            node_id: "node-1".into(),
+        },
+    };
+    tracker.register_write(wid1.clone(), 2, wid1.timestamp.clone());
+
+    // Initially pending.
+    assert_eq!(
+        tracker.get_status(&wid1),
+        Some(CertificationStatus::Pending)
+    );
+    assert_eq!(tracker.pending_count(), 1);
+
+    // Record ack from auth-1.
+    tracker.record_ack(
+        &wid1,
+        node_id("auth-1"),
+        HlcTimestamp {
+            physical: 1001,
+            logical: 0,
+            node_id: "auth-1".into(),
+        },
+    );
+    assert_eq!(
+        tracker.get_status(&wid1),
+        Some(CertificationStatus::Pending),
+        "1 ack out of 2 required: still pending"
+    );
+
+    // Record ack from auth-2 -> certified.
+    tracker.record_ack(
+        &wid1,
+        node_id("auth-2"),
+        HlcTimestamp {
+            physical: 1002,
+            logical: 0,
+            node_id: "auth-2".into(),
+        },
+    );
+    assert_eq!(
+        tracker.get_status(&wid1),
+        Some(CertificationStatus::Certified),
+        "2 acks out of 2 required: certified"
+    );
+
+    // Register a second write that will time out.
+    let wid2 = WriteId {
+        key: "key2".into(),
+        timestamp: HlcTimestamp {
+            physical: 2000,
+            logical: 0,
+            node_id: "node-1".into(),
+        },
+    };
+    tracker.register_write(wid2.clone(), 3, wid2.timestamp.clone());
+
+    // Check timeouts at a time > created_at + 100ms.
+    tracker.check_timeouts(&HlcTimestamp {
+        physical: 2200,
+        logical: 0,
+        node_id: "node-1".into(),
+    });
+    assert_eq!(
+        tracker.get_status(&wid2),
+        Some(CertificationStatus::Timeout),
+        "write should time out after 100ms"
+    );
+
+    // Register a third write that will be rejected.
+    let wid3 = WriteId {
+        key: "key3".into(),
+        timestamp: HlcTimestamp {
+            physical: 3000,
+            logical: 0,
+            node_id: "node-1".into(),
+        },
+    };
+    tracker.register_write(wid3.clone(), 2, wid3.timestamp.clone());
+    tracker.reject(
+        &wid3,
+        HlcTimestamp {
+            physical: 3001,
+            logical: 0,
+            node_id: "node-1".into(),
+        },
+    );
+    assert_eq!(
+        tracker.get_status(&wid3),
+        Some(CertificationStatus::Rejected),
+        "write should be rejected"
+    );
+}
+
+// ---------------------------------------------------------------
+// Test 6: 3-Authority with manual frontier injection
+// ---------------------------------------------------------------
+
+/// Simulates the full flow without NodeRunner: write -> inject 2/3
+/// authority frontiers -> process_certifications -> Certified.
+/// Verifies the majority condition precisely.
+#[tokio::test]
+async fn majority_certification_requires_two_of_three() {
+    let ns = three_authority_namespace();
+    let mut api = CertifiedApi::new(node_id("node-1"), ns);
+
+    api.certified_write("data/x".into(), counter_value(1), OnTimeout::Pending)
+        .unwrap();
+    let write_ts = api.pending_writes()[0].timestamp.physical;
+
+    // 1 of 3: not enough.
+    api.update_frontier(make_frontier("auth-1", write_ts + 100, ""));
+    api.process_certifications();
+    assert_eq!(
+        api.get_certification_status("data/x"),
+        CertificationStatus::Pending,
+        "1/3 authorities: should stay pending"
+    );
+
+    // 2 of 3: majority reached.
+    api.update_frontier(make_frontier("auth-2", write_ts + 200, ""));
+    api.process_certifications();
+    assert_eq!(
+        api.get_certification_status("data/x"),
+        CertificationStatus::Certified,
+        "2/3 authorities: should be certified"
+    );
+}
+
+// ---------------------------------------------------------------
+// Test 7: Multiple writes with mixed outcomes
+// ---------------------------------------------------------------
+
+/// Multiple writes in flight: one gets certified, one times out,
+/// one gets rejected. All transitions are observable.
+/// Uses separate key ranges so that frontier advancement for one range
+/// does not inadvertently certify writes in another range.
+#[tokio::test]
+async fn mixed_outcomes_all_observable() {
+    let mut ns = SystemNamespace::new();
+    ns.set_authority_definition(AuthorityDefinition {
+        key_range: kr("cert/"),
+        authority_nodes: vec![node_id("auth-1"), node_id("auth-2"), node_id("auth-3")],
+    });
+    ns.set_authority_definition(AuthorityDefinition {
+        key_range: kr("stale/"),
+        authority_nodes: vec![node_id("auth-s1"), node_id("auth-s2"), node_id("auth-s3")],
+    });
+    ns.set_authority_definition(AuthorityDefinition {
+        key_range: kr("rej/"),
+        authority_nodes: vec![node_id("auth-r1"), node_id("auth-r2"), node_id("auth-r3")],
+    });
+
+    let retention = RetentionPolicy {
+        max_age_ms: 5_000,
+        max_entries: 10_000,
+    };
+    let mut api = CertifiedApi::with_retention(node_id("node-1"), ns, retention);
+
+    // Write 3 keys to different ranges.
+    api.certified_write("cert/key".into(), counter_value(1), OnTimeout::Pending)
+        .unwrap();
+    let ts_cert = api.pending_writes()[0].timestamp.physical;
+
+    api.certified_write("stale/key".into(), counter_value(2), OnTimeout::Pending)
+        .unwrap();
+
+    api.certified_write("rej/key".into(), counter_value(3), OnTimeout::Pending)
+        .unwrap();
+
+    // Certify cert/key via frontier advancement (cert/ range authorities).
+    api.update_frontier(make_frontier("auth-1", ts_cert + 100, "cert/"));
+    api.update_frontier(make_frontier("auth-2", ts_cert + 200, "cert/"));
+
+    // Reject rej/key explicitly.
+    api.reject_write("rej/key");
+
+    // Process with a timestamp far enough for stale/key to expire.
+    api.process_certifications_with_timeout(ts_cert + 10_000);
+
+    assert_eq!(
+        api.get_certification_status("cert/key"),
+        CertificationStatus::Certified
+    );
+    assert_eq!(
+        api.get_certification_status("stale/key"),
+        CertificationStatus::Timeout
+    );
+    assert_eq!(
+        api.get_certification_status("rej/key"),
+        CertificationStatus::Rejected
+    );
+}
+
+// ---------------------------------------------------------------
+// Test 8: Cleanup removes completed entries after certification
+// ---------------------------------------------------------------
+
+/// After auto-certification, cleanup should remove resolved entries
+/// and leave only pending ones.
+/// Uses separate key ranges so that frontier advancement for one range
+/// does not certify writes in the other.
+#[tokio::test]
+async fn cleanup_after_auto_certification() {
+    let mut ns = SystemNamespace::new();
+    ns.set_authority_definition(AuthorityDefinition {
+        key_range: kr("a/"),
+        authority_nodes: vec![node_id("auth-1"), node_id("auth-2"), node_id("auth-3")],
+    });
+    ns.set_authority_definition(AuthorityDefinition {
+        key_range: kr("b/"),
+        authority_nodes: vec![node_id("auth-b1"), node_id("auth-b2"), node_id("auth-b3")],
+    });
+
+    let mut api = CertifiedApi::new(node_id("node-1"), ns);
+
+    api.certified_write("a/key1".into(), counter_value(1), OnTimeout::Pending)
+        .unwrap();
+    api.certified_write("b/key2".into(), counter_value(2), OnTimeout::Pending)
+        .unwrap();
+
+    let ts = api.pending_writes()[0].timestamp.physical;
+
+    // Certify a/key1 only (advance a/ range authorities).
+    api.update_frontier(make_frontier("auth-1", ts + 100, "a/"));
+    api.update_frontier(make_frontier("auth-2", ts + 100, "a/"));
+    api.process_certifications();
+
+    assert_eq!(api.pending_writes().len(), 2);
+    assert_eq!(
+        api.get_certification_status("a/key1"),
+        CertificationStatus::Certified
+    );
+    assert_eq!(
+        api.get_certification_status("b/key2"),
+        CertificationStatus::Pending
+    );
+
+    // Full cleanup removes certified entries.
+    api.cleanup(ts + 100);
+
+    // Only b/key2 (still pending) should remain.
+    let remaining: Vec<&str> = api
+        .pending_writes()
+        .iter()
+        .map(|pw| pw.key.as_str())
+        .collect();
+    assert!(
+        remaining.contains(&"b/key2"),
+        "b/key2 should still be pending"
+    );
+    assert!(
+        !remaining.contains(&"a/key1"),
+        "a/key1 should have been cleaned up"
+    );
+}
+
+// ---------------------------------------------------------------
+// Test 9: Status tracker persistence across certification
+// ---------------------------------------------------------------
+
+/// The CertificationTracker can be serialized/deserialized while
+/// certification is in progress, and the restored tracker continues
+/// correctly.
+#[tokio::test]
+async fn tracker_persistence_during_certification() {
+    let mut tracker = CertificationTracker::new();
+
+    let wid = WriteId {
+        key: "persistent-key".into(),
+        timestamp: HlcTimestamp {
+            physical: 5000,
+            logical: 0,
+            node_id: "node-1".into(),
+        },
+    };
+    tracker.register_write(wid.clone(), 2, wid.timestamp.clone());
+
+    // Partial ack.
+    tracker.record_ack(
+        &wid,
+        node_id("auth-1"),
+        HlcTimestamp {
+            physical: 5001,
+            logical: 0,
+            node_id: "auth-1".into(),
+        },
+    );
+    assert_eq!(tracker.get_status(&wid), Some(CertificationStatus::Pending));
+
+    // Serialize.
+    let json = tracker.to_json().expect("serialize");
+
+    // Restore.
+    let mut restored = CertificationTracker::from_json(&json).expect("deserialize");
+
+    // Verify state survived.
+    assert_eq!(
+        restored.get_status(&wid),
+        Some(CertificationStatus::Pending)
+    );
+    let entry = restored.get_entry(&wid).unwrap();
+    assert_eq!(entry.acked_by.len(), 1);
+
+    // Complete certification on restored tracker.
+    let status = restored.record_ack(
+        &wid,
+        node_id("auth-2"),
+        HlcTimestamp {
+            physical: 5002,
+            logical: 0,
+            node_id: "auth-2".into(),
+        },
+    );
+    assert_eq!(status, Some(CertificationStatus::Certified));
+}


### PR DESCRIPTION
## Summary
- Add `process_certifications_with_timeout()` to `CertifiedApi` that evaluates pending writes against frontiers and detects timeouts in a single pass
- Add `reject_write()` to `CertifiedApi` for explicit `Rejected` transitions
- Update `NodeRunner::process_certifications` to use the new combined method, enabling automatic timeout detection during certification ticks
- Add 10 E2E integration tests covering 3-authority auto-certification, timeout detection, rejected transitions, status API observability, and tracker persistence

## Test plan
- [x] 3-authority auto-certification via FrontierReporter (E2E)
- [x] 3-authority NodeRunner-based certification with injected peer frontiers (E2E)
- [x] Single authority self-certification via NodeRunner (E2E)
- [x] Timeout auto-detection during certification tick (E2E)
- [x] Rejected transition observable via status API (E2E)
- [x] CertificationTracker mirrors all transition states (E2E)
- [x] Majority condition requires 2/3 authorities (E2E)
- [x] Mixed outcomes (certified + timeout + rejected) all observable (E2E)
- [x] Cleanup removes resolved entries after certification (E2E)
- [x] Tracker persistence survives serialization during certification (E2E)
- [x] Unit tests for `process_certifications_with_timeout` and `reject_write`
- [x] CI gate: `cargo fmt --check && cargo clippy -- -D warnings && cargo test` all pass

Closes #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)