### PR TITLE
feat: add benchmark suite and metrics collection

### DIFF
--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -1,0 +1,156 @@
+# AsteroidDB Benchmark Guide
+
+## Overview
+
+AsteroidDB benchmarks measure three key performance indicators that characterize
+the system's behaviour under normal operation and failure recovery:
+
+| # | Metric | What it measures |
+|---|--------|------------------|
+| 1 | **Eventual write latency** | Time to accept a single `eventual_counter_inc` operation locally |
+| 2 | **Certified confirmation time** | End-to-end time from `certified_write` to `Certified` status via majority frontier advancement |
+| 3 | **Recovery convergence time** | Time for 3 divergent nodes to reach identical state via CRDT merge after partition recovery |
+
+## Running the Benchmark
+
+### Prerequisites
+
+- Rust toolchain (edition 2024)
+- Repository cloned and dependencies resolved (`cargo build`)
+
+### Execution
+
+```bash
+# Run the benchmark (human-readable progress on stderr, JSON on stdout)
+cargo run --example benchmark
+
+# Save JSON results to a file
+cargo run --example benchmark > results.json
+
+# Release mode for more representative numbers
+cargo run --release --example benchmark > results.json
+```
+
+### Output
+
+The benchmark prints progress and CSV summary to **stderr** and a JSON array of
+results to **stdout**.
+
+JSON schema per entry:
+
+```json
+{
+  "name": "eventual_write_latency",
+  "iterations": 1000,
+  "mean_us": 1.23,
+  "p50_us": 1.10,
+  "p95_us": 2.50,
+  "p99_us": 4.00,
+  "min_us": 0.80,
+  "max_us": 15.00
+}
+```
+
+## Metric Details
+
+### 1. Eventual Write Latency
+
+- **Operation**: `EventualApi::eventual_counter_inc` on distinct keys
+- **Iterations**: 1000
+- **Measures**: Wall-clock time of a single local CRDT write (no network)
+- **Relevance**: FR-002/FR-004 -- baseline cost of the eventual consistency path
+
+### 2. Certified Confirmation Time
+
+- **Operation**: `CertifiedApi::certified_write` followed by 2-of-3 authority
+  frontier updates and `process_certifications`
+- **Iterations**: 100
+- **Measures**: Full certification round-trip (write + frontier sync + status check)
+- **Relevance**: FR-003/FR-004 -- time to achieve majority consensus confirmation
+
+### 3. Recovery Convergence Time
+
+- **Operation**: 3-node partition scenario with divergent PN-Counter state,
+  then full CRDT merge propagation
+- **Iterations**: 100
+- **Measures**: Wall-clock time from start of merge propagation to all 3 nodes
+  holding identical state
+- **Relevance**: FR-002/NFR -- demonstrates CRDT convergence guarantee after
+  network partition
+
+## Result Recording Template
+
+Copy the table below and fill in the measured values. Include the commit hash
+and hardware description for reproducibility.
+
+```
+## Benchmark Results
+
+**Date**: YYYY-MM-DD
+**Commit**: <hash>
+**Hardware**: <CPU / RAM / OS>
+**Build mode**: release | debug
+
+| Metric                      | Iterations | Mean (us) | P50 (us) | P95 (us) | P99 (us) | Min (us) | Max (us) |
+|-----------------------------|------------|-----------|----------|----------|----------|----------|----------|
+| eventual_write_latency      |            |           |          |          |          |          |          |
+| certified_confirmation_time |            |           |          |          |          |          |          |
+| recovery_convergence_time   |            |           |          |          |          |          |          |
+
+### Notes
+
+- (describe any anomalies, environment specifics, etc.)
+```
+
+## Reproducing Results
+
+1. Check out the target commit:
+   ```bash
+   git checkout <commit-hash>
+   ```
+
+2. Build in release mode:
+   ```bash
+   cargo build --release --example benchmark
+   ```
+
+3. Run the benchmark and save results:
+   ```bash
+   cargo run --release --example benchmark > results.json 2> benchmark.log
+   ```
+
+4. Extract CSV from the log:
+   ```bash
+   grep -A4 "Results (CSV)" benchmark.log
+   ```
+
+5. Compare with previous runs using the JSON output:
+   ```bash
+   # Example: compare mean latencies with jq
+   jq '.[].mean_us' results.json
+   ```
+
+## Programmatic Access
+
+The metrics module (`src/ops/metrics.rs`) exposes:
+
+- `BenchmarkResult` -- serializable struct with all statistics
+- `collect_latencies(name, &[Duration]) -> BenchmarkResult` -- compute stats from raw durations
+- `to_csv_row(&BenchmarkResult) -> String` -- CSV formatting
+- `csv_header() -> &str` -- matching CSV header
+
+These can be used in integration tests or custom benchmarks:
+
+```rust
+use std::time::{Duration, Instant};
+use asteroidb_poc::ops::metrics::{collect_latencies, BenchmarkResult};
+
+let mut durations = Vec::new();
+for _ in 0..100 {
+    let start = Instant::now();
+    // ... operation to measure ...
+    durations.push(start.elapsed());
+}
+let result: BenchmarkResult = collect_latencies("my_benchmark", &durations);
+println!("{}", serde_json::to_string_pretty(&result).unwrap());
+```

--- a/examples/benchmark.rs
+++ b/examples/benchmark.rs
@@ -1,0 +1,276 @@
+/// AsteroidDB Benchmark Suite
+///
+/// Measures three key performance indicators:
+/// 1. Eventual write latency (PN-Counter increment)
+/// 2. Certified write confirmation time (write -> certified via majority)
+/// 3. Partition recovery convergence time (divergent -> converged via CRDT merge)
+///
+/// Run: `cargo run --example benchmark`
+/// JSON output: `cargo run --example benchmark 2>/dev/null`
+use std::time::Instant;
+
+use asteroidb_poc::api::certified::{CertifiedApi, OnTimeout};
+use asteroidb_poc::api::eventual::EventualApi;
+use asteroidb_poc::authority::ack_frontier::AckFrontier;
+use asteroidb_poc::control_plane::system_namespace::{AuthorityDefinition, SystemNamespace};
+use asteroidb_poc::crdt::pn_counter::PnCounter;
+use asteroidb_poc::hlc::HlcTimestamp;
+use asteroidb_poc::ops::metrics::{BenchmarkResult, collect_latencies, csv_header, to_csv_row};
+use asteroidb_poc::store::kv::CrdtValue;
+use asteroidb_poc::types::{CertificationStatus, KeyRange, NodeId, PolicyVersion};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn node(name: &str) -> NodeId {
+    NodeId(name.into())
+}
+
+fn kr(prefix: &str) -> KeyRange {
+    KeyRange {
+        prefix: prefix.into(),
+    }
+}
+
+fn make_frontier(authority: &str, physical: u64, prefix: &str) -> AckFrontier {
+    AckFrontier {
+        authority_id: NodeId(authority.into()),
+        frontier_hlc: HlcTimestamp {
+            physical,
+            logical: 0,
+            node_id: authority.into(),
+        },
+        key_range: KeyRange {
+            prefix: prefix.into(),
+        },
+        policy_version: PolicyVersion(1),
+        digest_hash: format!("{authority}-{physical}"),
+    }
+}
+
+fn default_namespace() -> SystemNamespace {
+    let mut ns = SystemNamespace::new();
+    ns.set_authority_definition(AuthorityDefinition {
+        key_range: kr(""),
+        authority_nodes: vec![node("auth-1"), node("auth-2"), node("auth-3")],
+    });
+    ns
+}
+
+fn counter_value(n: i64) -> CrdtValue {
+    let mut counter = PnCounter::new();
+    for _ in 0..n {
+        counter.increment(&node("writer"));
+    }
+    CrdtValue::Counter(counter)
+}
+
+// ---------------------------------------------------------------------------
+// Benchmark 1: Eventual write latency
+// ---------------------------------------------------------------------------
+
+fn bench_eventual_write_latency(iterations: usize) -> BenchmarkResult {
+    eprintln!("[1/3] Measuring eventual write latency ({iterations} iterations)...");
+
+    let mut api = EventualApi::new(node("bench-node"));
+    let mut durations = Vec::with_capacity(iterations);
+
+    for i in 0..iterations {
+        let key = format!("bench/counter/{i}");
+        let start = Instant::now();
+        api.eventual_counter_inc(&key).unwrap();
+        durations.push(start.elapsed());
+    }
+
+    let result = collect_latencies("eventual_write_latency", &durations);
+    eprintln!(
+        "       mean={:.2}us  p50={:.2}us  p95={:.2}us  p99={:.2}us",
+        result.mean_us, result.p50_us, result.p95_us, result.p99_us
+    );
+    result
+}
+
+// ---------------------------------------------------------------------------
+// Benchmark 2: Certified write -> certified confirmation time
+// ---------------------------------------------------------------------------
+
+fn bench_certified_confirmation_time(iterations: usize) -> BenchmarkResult {
+    eprintln!("[2/3] Measuring certified confirmation time ({iterations} iterations)...");
+
+    let mut durations = Vec::with_capacity(iterations);
+
+    for i in 0..iterations {
+        let mut api = CertifiedApi::new(node("bench-node"), default_namespace());
+
+        let key = format!("bench/cert/{i}");
+
+        // Start timing: certified_write + frontier updates + process_certifications
+        let start = Instant::now();
+
+        api.certified_write(key.clone(), counter_value(1), OnTimeout::Pending)
+            .unwrap();
+
+        let write_ts = api.pending_writes()[0].timestamp.physical;
+
+        // Simulate majority of authorities acknowledging the write.
+        api.update_frontier(make_frontier("auth-1", write_ts + 100, ""));
+        api.update_frontier(make_frontier("auth-2", write_ts + 200, ""));
+
+        api.process_certifications();
+
+        let elapsed = start.elapsed();
+
+        // Verify certification succeeded.
+        assert_eq!(
+            api.get_certification_status(&key),
+            CertificationStatus::Certified,
+            "write should be certified after majority frontier advancement"
+        );
+
+        durations.push(elapsed);
+    }
+
+    let result = collect_latencies("certified_confirmation_time", &durations);
+    eprintln!(
+        "       mean={:.2}us  p50={:.2}us  p95={:.2}us  p99={:.2}us",
+        result.mean_us, result.p50_us, result.p95_us, result.p99_us
+    );
+    result
+}
+
+// ---------------------------------------------------------------------------
+// Benchmark 3: Partition recovery convergence time
+// ---------------------------------------------------------------------------
+
+fn bench_recovery_convergence_time(iterations: usize) -> BenchmarkResult {
+    eprintln!("[3/3] Measuring partition recovery convergence time ({iterations} iterations)...");
+
+    let mut durations = Vec::with_capacity(iterations);
+
+    for _ in 0..iterations {
+        let node_a = node("node-A");
+        let node_b = node("node-B");
+        let node_c = node("node-C");
+
+        let mut api_a = EventualApi::new(node_a);
+        let mut api_b = EventualApi::new(node_b);
+        let mut api_c = EventualApi::new(node_c);
+
+        let key = "bench/recovery";
+
+        // Phase 1: Pre-partition writes and full replication.
+        for _ in 0..10 {
+            api_a.eventual_counter_inc(key).unwrap();
+        }
+        for _ in 0..7 {
+            api_b.eventual_counter_inc(key).unwrap();
+        }
+        for _ in 0..5 {
+            api_c.eventual_counter_inc(key).unwrap();
+        }
+
+        // Full sync before partition.
+        let val_a = api_a.get_eventual(key).unwrap().clone();
+        let val_b = api_b.get_eventual(key).unwrap().clone();
+        let val_c = api_c.get_eventual(key).unwrap().clone();
+        api_a.merge_remote(key.into(), &val_b).unwrap();
+        api_a.merge_remote(key.into(), &val_c).unwrap();
+        api_b.merge_remote(key.into(), &val_a).unwrap();
+        api_b.merge_remote(key.into(), &val_c).unwrap();
+        api_c.merge_remote(key.into(), &val_a).unwrap();
+        api_c.merge_remote(key.into(), &val_b).unwrap();
+
+        // Phase 2: Partition -- node-C is isolated.
+        for _ in 0..20 {
+            api_a.eventual_counter_inc(key).unwrap();
+        }
+        for _ in 0..15 {
+            api_b.eventual_counter_inc(key).unwrap();
+        }
+        for _ in 0..8 {
+            api_c.eventual_counter_inc(key).unwrap();
+        }
+
+        // A and B sync with each other (but not C).
+        let val_a = api_a.get_eventual(key).unwrap().clone();
+        let val_b = api_b.get_eventual(key).unwrap().clone();
+        api_a.merge_remote(key.into(), &val_b).unwrap();
+        api_b.merge_remote(key.into(), &val_a).unwrap();
+
+        // State is now divergent: A and B have (10+7+5+20+15)=57, C has (10+7+5+8)=30.
+
+        // Phase 3: Recovery -- measure convergence time.
+        let start = Instant::now();
+
+        let val_a = api_a.get_eventual(key).unwrap().clone();
+        let val_b = api_b.get_eventual(key).unwrap().clone();
+        let val_c = api_c.get_eventual(key).unwrap().clone();
+
+        api_a.merge_remote(key.into(), &val_c).unwrap();
+        api_b.merge_remote(key.into(), &val_c).unwrap();
+        api_c.merge_remote(key.into(), &val_a).unwrap();
+        api_c.merge_remote(key.into(), &val_b).unwrap();
+
+        // Also sync A <-> B to ensure they pick up C's partition writes.
+        let val_a_final = api_a.get_eventual(key).unwrap().clone();
+        let val_b_final = api_b.get_eventual(key).unwrap().clone();
+        api_a.merge_remote(key.into(), &val_b_final).unwrap();
+        api_b.merge_remote(key.into(), &val_a_final).unwrap();
+
+        let elapsed = start.elapsed();
+
+        // Verify all nodes converged to the same value.
+        let expected = 10 + 7 + 5 + 20 + 15 + 8; // 65
+        let get_val = |api: &EventualApi| match api.get_eventual(key).unwrap() {
+            CrdtValue::Counter(c) => c.value(),
+            _ => panic!("expected Counter"),
+        };
+        assert_eq!(get_val(&api_a), expected, "node-A should converge");
+        assert_eq!(get_val(&api_b), expected, "node-B should converge");
+        assert_eq!(get_val(&api_c), expected, "node-C should converge");
+
+        durations.push(elapsed);
+    }
+
+    let result = collect_latencies("recovery_convergence_time", &durations);
+    eprintln!(
+        "       mean={:.2}us  p50={:.2}us  p95={:.2}us  p99={:.2}us",
+        result.mean_us, result.p50_us, result.p95_us, result.p99_us
+    );
+    result
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+fn main() {
+    eprintln!("======================================================================");
+    eprintln!("AsteroidDB Benchmark Suite");
+    eprintln!("======================================================================");
+    eprintln!();
+
+    let results = vec![
+        bench_eventual_write_latency(1000),
+        bench_certified_confirmation_time(100),
+        bench_recovery_convergence_time(100),
+    ];
+
+    eprintln!();
+    eprintln!("----------------------------------------------------------------------");
+    eprintln!("Results (CSV)");
+    eprintln!("----------------------------------------------------------------------");
+    eprintln!("{}", csv_header());
+    for r in &results {
+        eprintln!("{}", to_csv_row(r));
+    }
+
+    // JSON output to stdout for programmatic consumption.
+    let json = serde_json::to_string_pretty(&results).expect("JSON serialization failed");
+    println!("{json}");
+
+    eprintln!();
+    eprintln!("JSON results printed to stdout.");
+    eprintln!("======================================================================");
+}

--- a/src/ops/metrics.rs
+++ b/src/ops/metrics.rs
@@ -1,0 +1,171 @@
+use serde::Serialize;
+use std::time::Duration;
+
+/// Aggregated benchmark result for a single measurement.
+///
+/// Captures latency statistics (mean, percentiles, min, max) for a named
+/// benchmark across a given number of iterations. All latency values are
+/// reported in microseconds.
+#[derive(Debug, Clone, Serialize)]
+pub struct BenchmarkResult {
+    /// Human-readable name of the benchmark.
+    pub name: String,
+    /// Number of iterations measured.
+    pub iterations: usize,
+    /// Mean latency in microseconds.
+    pub mean_us: f64,
+    /// Median (50th percentile) latency in microseconds.
+    pub p50_us: f64,
+    /// 95th percentile latency in microseconds.
+    pub p95_us: f64,
+    /// 99th percentile latency in microseconds.
+    pub p99_us: f64,
+    /// Minimum observed latency in microseconds.
+    pub min_us: f64,
+    /// Maximum observed latency in microseconds.
+    pub max_us: f64,
+}
+
+/// Compute latency statistics from a slice of [`Duration`] measurements.
+///
+/// Returns a [`BenchmarkResult`] with the given name, populated with
+/// mean, p50, p95, p99, min, and max latencies in microseconds.
+///
+/// # Panics
+///
+/// Panics if `durations` is empty.
+pub fn collect_latencies(name: &str, durations: &[Duration]) -> BenchmarkResult {
+    assert!(!durations.is_empty(), "durations must not be empty");
+
+    let mut us_values: Vec<f64> = durations
+        .iter()
+        .map(|d| d.as_secs_f64() * 1_000_000.0)
+        .collect();
+    us_values.sort_by(|a, b| a.partial_cmp(b).unwrap());
+
+    let n = us_values.len();
+    let sum: f64 = us_values.iter().sum();
+    let mean = sum / n as f64;
+
+    BenchmarkResult {
+        name: name.to_string(),
+        iterations: n,
+        mean_us: mean,
+        p50_us: percentile(&us_values, 50.0),
+        p95_us: percentile(&us_values, 95.0),
+        p99_us: percentile(&us_values, 99.0),
+        min_us: us_values[0],
+        max_us: us_values[n - 1],
+    }
+}
+
+/// Compute the value at a given percentile from a **sorted** slice.
+///
+/// Uses nearest-rank interpolation.
+fn percentile(sorted: &[f64], pct: f64) -> f64 {
+    let idx = ((pct / 100.0) * sorted.len() as f64).ceil() as usize;
+    let idx = idx.min(sorted.len()).saturating_sub(1);
+    sorted[idx]
+}
+
+/// Format a [`BenchmarkResult`] as a single-line CSV record.
+///
+/// Header: `name,iterations,mean_us,p50_us,p95_us,p99_us,min_us,max_us`
+pub fn to_csv_row(result: &BenchmarkResult) -> String {
+    format!(
+        "{},{},{:.2},{:.2},{:.2},{:.2},{:.2},{:.2}",
+        result.name,
+        result.iterations,
+        result.mean_us,
+        result.p50_us,
+        result.p95_us,
+        result.p99_us,
+        result.min_us,
+        result.max_us,
+    )
+}
+
+/// Return the CSV header line matching [`to_csv_row`] output.
+pub fn csv_header() -> &'static str {
+    "name,iterations,mean_us,p50_us,p95_us,p99_us,min_us,max_us"
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn collect_single_duration() {
+        let durations = vec![Duration::from_micros(100)];
+        let result = collect_latencies("single", &durations);
+        assert_eq!(result.iterations, 1);
+        assert!((result.mean_us - 100.0).abs() < 1.0);
+        assert!((result.p50_us - 100.0).abs() < 1.0);
+        assert!((result.min_us - 100.0).abs() < 1.0);
+        assert!((result.max_us - 100.0).abs() < 1.0);
+    }
+
+    #[test]
+    fn collect_multiple_durations() {
+        let durations: Vec<Duration> = (1..=100).map(|i| Duration::from_micros(i)).collect();
+        let result = collect_latencies("range", &durations);
+        assert_eq!(result.iterations, 100);
+        assert!((result.mean_us - 50.5).abs() < 1.0);
+        assert!((result.min_us - 1.0).abs() < 1.0);
+        assert!((result.max_us - 100.0).abs() < 1.0);
+        // p50 should be around 50
+        assert!(result.p50_us >= 49.0 && result.p50_us <= 51.0);
+        // p95 should be around 95
+        assert!(result.p95_us >= 94.0 && result.p95_us <= 96.0);
+        // p99 should be around 99
+        assert!(result.p99_us >= 98.0 && result.p99_us <= 100.0);
+    }
+
+    #[test]
+    fn csv_output_format() {
+        let result = BenchmarkResult {
+            name: "test".to_string(),
+            iterations: 10,
+            mean_us: 100.0,
+            p50_us: 95.0,
+            p95_us: 150.0,
+            p99_us: 200.0,
+            min_us: 50.0,
+            max_us: 250.0,
+        };
+        let csv = to_csv_row(&result);
+        assert_eq!(csv, "test,10,100.00,95.00,150.00,200.00,50.00,250.00");
+    }
+
+    #[test]
+    fn csv_header_matches_row_fields() {
+        let header = csv_header();
+        let fields: Vec<&str> = header.split(',').collect();
+        assert_eq!(fields.len(), 8);
+        assert_eq!(fields[0], "name");
+        assert_eq!(fields[7], "max_us");
+    }
+
+    #[test]
+    fn json_serialization() {
+        let result = BenchmarkResult {
+            name: "bench".to_string(),
+            iterations: 5,
+            mean_us: 42.0,
+            p50_us: 40.0,
+            p95_us: 50.0,
+            p99_us: 55.0,
+            min_us: 30.0,
+            max_us: 60.0,
+        };
+        let json = serde_json::to_string(&result).unwrap();
+        assert!(json.contains("\"name\":\"bench\""));
+        assert!(json.contains("\"iterations\":5"));
+    }
+
+    #[test]
+    #[should_panic(expected = "durations must not be empty")]
+    fn collect_empty_panics() {
+        collect_latencies("empty", &[]);
+    }
+}

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -1,1 +1,2 @@
 pub mod diagnostics;
+pub mod metrics;


### PR DESCRIPTION
## Summary

- Add `src/ops/metrics.rs` with `BenchmarkResult` struct and `collect_latencies()` helper for latency statistics (mean, p50, p95, p99, min, max) with JSON/CSV output support
- Add `examples/benchmark.rs` measuring three key metrics: eventual write latency (1000 iterations), certified confirmation time (100 iterations), and partition recovery convergence time (100 iterations)
- Add `docs/benchmark.md` with execution guide, metric descriptions, and result recording template

Closes #84

## Test plan

- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test` passes (all existing + new metrics module tests)
- [x] `cargo run --example benchmark` executes successfully and outputs JSON/CSV
- [ ] Verify JSON output is valid (`cargo run --example benchmark | jq .`)
- [ ] Verify results are reproducible across runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)