### PR TITLE
feat: add netem network testing scripts (#83)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,8 @@ services:
   node-1:
     build: .
     container_name: asteroidb-node-1
+    cap_add:
+      - NET_ADMIN
     ports:
       - "3001:3000"
     environment:
@@ -13,6 +15,8 @@ services:
   node-2:
     build: .
     container_name: asteroidb-node-2
+    cap_add:
+      - NET_ADMIN
     ports:
       - "3002:3000"
     environment:
@@ -24,6 +28,8 @@ services:
   node-3:
     build: .
     container_name: asteroidb-node-3
+    cap_add:
+      - NET_ADMIN
     ports:
       - "3003:3000"
     environment:

--- a/docs/netem-testing.md
+++ b/docs/netem-testing.md
@@ -1,0 +1,247 @@
+# AsteroidDB netem Testing Guide
+
+Linux の `tc` (traffic control) / netem を Docker コンテナ内で使い、
+ネットワーク遅延や分断をシミュレートして AsteroidDB の挙動を検証する手順を説明します。
+
+## 前提条件
+
+| 項目 | 要件 |
+|------|------|
+| **Docker** | 20.10 以降 |
+| **Docker Compose** | V2 (`docker compose` コマンド) |
+| **OS** | Linux (ホスト) または Docker Desktop (macOS/Windows) |
+| **Python 3** | シナリオスクリプト内で JSON パースに使用 |
+
+> **Note**: `tc` / netem は Linux カーネル機能です。Docker Desktop (macOS/Windows) では
+> Docker VM 内の Linux カーネルを使うため動作しますが、一部制約がある場合があります。
+
+### NET_ADMIN capability
+
+netem ルールの追加には `NET_ADMIN` capability が必要です。
+`docker-compose.yml` の各サービスに以下が設定されていることを確認してください:
+
+```yaml
+services:
+  node-1:
+    cap_add:
+      - NET_ADMIN
+    # ...
+```
+
+### iproute2
+
+コンテナ内に `tc` コマンドが必要です。スクリプトは `tc` が見つからない場合、
+自動的に `apt-get install iproute2` を実行します。
+
+## 基本コマンド
+
+### 遅延注入
+
+```bash
+# node-3 に 200ms の遅延を追加
+./scripts/netem/add-delay.sh asteroidb-node-3 200
+
+# node-1 に 50ms の遅延を追加
+./scripts/netem/add-delay.sh asteroidb-node-1 50
+```
+
+コンテナ内の全送信パケットに指定ミリ秒の遅延が挿入されます。
+受信側にも遅延を入れたい場合は、相手側コンテナにも同様に設定してください。
+
+### 完全分断 (100% パケットロス)
+
+```bash
+# node-3 を完全分断
+./scripts/netem/add-partition.sh asteroidb-node-3
+```
+
+100% のパケットロスを設定し、対象コンテナからの全通信を遮断します。
+コンテナ自体は正常に動作し続けますが、他ノードとの通信ができなくなります。
+
+### netem ルール除去 (復旧)
+
+```bash
+# node-3 のネットワークを復旧
+./scripts/netem/remove-netem.sh asteroidb-node-3
+```
+
+設定済みの netem ルールを削除し、通常のネットワーク状態に戻します。
+
+### 現在の設定確認
+
+```bash
+docker exec asteroidb-node-3 tc qdisc show dev eth0
+```
+
+## シナリオ
+
+### シナリオ 1: 遅延環境での eventual 収束
+
+高遅延環境でも CRDT マージにより最終的にデータが収束することを確認します。
+
+```bash
+# 1. クラスタ起動
+./scripts/cluster-up.sh
+
+# 2. 全ノードにヘルスチェック
+./scripts/cluster-status.sh
+
+# 3. node-2, node-3 に 200ms 遅延を注入
+./scripts/netem/add-delay.sh asteroidb-node-2 200
+./scripts/netem/add-delay.sh asteroidb-node-3 200
+
+# 4. node-1 にデータ書き込み
+curl -X POST http://localhost:3001/api/eventual/write \
+  -H "Content-Type: application/json" \
+  -d '{"type":"counter_inc","key":"delay-test"}'
+
+# 5. 通常より長く待機 (遅延分を考慮)
+sleep 5
+
+# 6. 各ノードの値を確認
+curl -s http://localhost:3001/api/eventual/delay-test
+curl -s http://localhost:3002/api/eventual/delay-test
+curl -s http://localhost:3003/api/eventual/delay-test
+
+# 7. 復旧
+./scripts/netem/remove-netem.sh asteroidb-node-2
+./scripts/netem/remove-netem.sh asteroidb-node-3
+```
+
+**期待結果**: 遅延があっても、十分な待機時間後に全ノードで同じカウンタ値が得られる。
+CRDT のマージは可換・結合・冪等であるため、到達順序に関係なく収束する。
+
+### シナリオ 2: 分断 -> 復旧 -> certified 確定
+
+ネットワーク分断中のデータ分岐と、復旧後の CRDT 収束を確認します。
+
+```bash
+# 自動スクリプトで実行
+./scripts/netem/scenario-partition-recovery.sh
+```
+
+手動で実行する場合:
+
+```bash
+# 1. クラスタ起動
+./scripts/cluster-up.sh
+
+# 2. node-1 にカウンタを3回インクリメント
+for i in 1 2 3; do
+  curl -sf -X POST http://localhost:3001/api/eventual/write \
+    -H "Content-Type: application/json" \
+    -d '{"type":"counter_inc","key":"partition-test"}'
+done
+
+# 3. 同期を待機
+sleep 3
+
+# 4. 全ノードで値を確認 (全て 3 であるべき)
+curl -s http://localhost:3001/api/eventual/partition-test
+curl -s http://localhost:3002/api/eventual/partition-test
+curl -s http://localhost:3003/api/eventual/partition-test
+
+# 5. node-3 を分断
+./scripts/netem/add-partition.sh asteroidb-node-3
+
+# 6. node-1 にさらに5回インクリメント
+for i in 1 2 3 4 5; do
+  curl -sf -X POST http://localhost:3001/api/eventual/write \
+    -H "Content-Type: application/json" \
+    -d '{"type":"counter_inc","key":"partition-test"}'
+done
+
+# 7. 同期を待機
+sleep 3
+
+# 8. 分岐を確認
+#    node-1, node-2: 8 (3 + 5)
+#    node-3: 3 (分断前の値のまま)
+curl -s http://localhost:3001/api/eventual/partition-test
+curl -s http://localhost:3002/api/eventual/partition-test
+curl -s http://localhost:3003/api/eventual/partition-test
+
+# 9. node-3 を復旧
+./scripts/netem/remove-netem.sh asteroidb-node-3
+
+# 10. 収束を待機して確認
+sleep 5
+curl -s http://localhost:3001/api/eventual/partition-test
+curl -s http://localhost:3002/api/eventual/partition-test
+curl -s http://localhost:3003/api/eventual/partition-test
+
+# 11. certified write を試行
+curl -X POST http://localhost:3001/api/certified/write \
+  -H "Content-Type: application/json" \
+  -d '{
+    "key": "partition-test",
+    "value": {"type": "counter", "value": 8},
+    "on_timeout": "pending"
+  }'
+
+# 12. 認証ステータス確認
+curl -s http://localhost:3001/api/status/partition-test
+```
+
+**期待結果**:
+
+| ステップ | node-1 | node-2 | node-3 | 状態 |
+|---------|--------|--------|--------|------|
+| 初期書き込み後 | 3 | 3 | 3 | 収束済み |
+| 分断中の追加書き込み後 | 8 | 8 | 3 | 分岐 |
+| 復旧後 | 8 | 8 | 8 | 再収束 |
+
+> **Note**: 現時点ではノード間レプリケーションが docker compose 構成で未接続のため、
+> 自動収束は確認できない場合があります。レプリケーション統合後に完全なシナリオが動作します。
+
+## トラブルシューティング
+
+### tc コマンドが見つからない
+
+```
+Error: exec: "tc": executable file not found in $PATH
+```
+
+**対処**: スクリプトは自動インストールを試みますが、手動で実行する場合:
+
+```bash
+docker exec asteroidb-node-3 bash -c "apt-get update && apt-get install -y iproute2"
+```
+
+### Permission denied
+
+```
+RTNETLINK answers: Operation not permitted
+```
+
+**対処**: `docker-compose.yml` に `cap_add: [NET_ADMIN]` が設定されているか確認してください。
+設定変更後は `docker compose up -d --build` で再起動が必要です。
+
+### netem ルールが適用されない (macOS/Windows)
+
+Docker Desktop 環境では Docker VM のネットワークスタックを経由するため、
+ホストからコンテナへの通信には netem ルールが効かない場合があります。
+コンテナ間通信 (Docker ネットワーク内) には正常に適用されます。
+
+### コンテナ名が見つからない
+
+```
+Error: No such container: asteroidb-poc-node-3-1
+```
+
+**対処**: `docker ps` でコンテナ名を確認してください。`docker-compose.yml` で
+`container_name` を明示設定している場合は `asteroidb-node-3` のようになります。
+
+```bash
+docker ps --format '{{.Names}}'
+```
+
+### 遅延が大きすぎてタイムアウトする
+
+HTTP API のデフォルトタイムアウトを超える遅延を設定すると、クライアント側で
+タイムアウトエラーが発生します。curl の `--max-time` を遅延に合わせて調整してください:
+
+```bash
+# 500ms 遅延の場合、タイムアウトを長めに設定
+curl --max-time 10 http://localhost:3003/api/eventual/test-key
+```

--- a/scripts/netem/add-delay.sh
+++ b/scripts/netem/add-delay.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Add network delay to a container using tc/netem.
+#
+# Usage: ./scripts/netem/add-delay.sh <container> <delay_ms>
+# Example: ./scripts/netem/add-delay.sh asteroidb-node-3 200
+#
+# Prerequisites:
+#   - The container must have NET_ADMIN capability (see docker-compose.yml).
+#   - iproute2 must be available inside the container. The script will
+#     attempt to install it via apt-get if the `tc` command is missing.
+set -euo pipefail
+
+CONTAINER="${1:?Usage: $0 <container> <delay_ms>}"
+DELAY_MS="${2:?Usage: $0 <container> <delay_ms>}"
+
+echo "[netem] Adding ${DELAY_MS}ms delay to ${CONTAINER} ..."
+
+# Ensure tc is available inside the container.
+if ! docker exec "$CONTAINER" which tc > /dev/null 2>&1; then
+    echo "[netem] tc not found in ${CONTAINER}, installing iproute2 ..."
+    docker exec "$CONTAINER" bash -c "apt-get update -qq && apt-get install -y -qq iproute2 > /dev/null 2>&1"
+fi
+
+# Remove any existing qdisc first (ignore errors if none exists).
+docker exec "$CONTAINER" tc qdisc del dev eth0 root 2>/dev/null || true
+
+# Add netem delay.
+docker exec "$CONTAINER" tc qdisc add dev eth0 root netem delay "${DELAY_MS}ms"
+
+echo "[netem] ${CONTAINER}: ${DELAY_MS}ms delay applied."
+echo "[netem] Verify with: docker exec ${CONTAINER} tc qdisc show dev eth0"

--- a/scripts/netem/add-partition.sh
+++ b/scripts/netem/add-partition.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Partition a container by dropping 100% of packets using tc/netem.
+#
+# Usage: ./scripts/netem/add-partition.sh <container>
+# Example: ./scripts/netem/add-partition.sh asteroidb-node-3
+#
+# This simulates a complete network partition: the container can still
+# run locally but cannot communicate with any other node.
+#
+# Prerequisites:
+#   - The container must have NET_ADMIN capability (see docker-compose.yml).
+#   - iproute2 must be available inside the container.
+set -euo pipefail
+
+CONTAINER="${1:?Usage: $0 <container>}"
+
+echo "[netem] Partitioning ${CONTAINER} (100% packet loss) ..."
+
+# Ensure tc is available inside the container.
+if ! docker exec "$CONTAINER" which tc > /dev/null 2>&1; then
+    echo "[netem] tc not found in ${CONTAINER}, installing iproute2 ..."
+    docker exec "$CONTAINER" bash -c "apt-get update -qq && apt-get install -y -qq iproute2 > /dev/null 2>&1"
+fi
+
+# Remove any existing qdisc first (ignore errors if none exists).
+docker exec "$CONTAINER" tc qdisc del dev eth0 root 2>/dev/null || true
+
+# Add 100% packet loss to simulate full partition.
+docker exec "$CONTAINER" tc qdisc add dev eth0 root netem loss 100%
+
+echo "[netem] ${CONTAINER}: fully partitioned (100% packet loss)."
+echo "[netem] Verify with: docker exec ${CONTAINER} tc qdisc show dev eth0"

--- a/scripts/netem/remove-netem.sh
+++ b/scripts/netem/remove-netem.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Remove all netem rules from a container, restoring normal networking.
+#
+# Usage: ./scripts/netem/remove-netem.sh <container>
+# Example: ./scripts/netem/remove-netem.sh asteroidb-node-3
+set -euo pipefail
+
+CONTAINER="${1:?Usage: $0 <container>}"
+
+echo "[netem] Removing netem rules from ${CONTAINER} ..."
+
+# Delete the root qdisc. If no netem qdisc exists, tc will return an
+# error which we silently ignore.
+if docker exec "$CONTAINER" tc qdisc del dev eth0 root 2>/dev/null; then
+    echo "[netem] ${CONTAINER}: netem rules removed. Network restored."
+else
+    echo "[netem] ${CONTAINER}: no netem rules found (already clean)."
+fi

--- a/scripts/netem/scenario-partition-recovery.sh
+++ b/scripts/netem/scenario-partition-recovery.sh
@@ -1,0 +1,240 @@
+#!/usr/bin/env bash
+# Scenario: Network partition and recovery with CRDT convergence verification.
+#
+# This script automates the following steps:
+#   1. Verify the 3-node cluster is up
+#   2. Write to node-1 via eventual API
+#   3. Confirm sync across nodes
+#   4. Partition node-3 (100% packet loss)
+#   5. Write additional data to node-1
+#   6. Verify node-3 still has old data
+#   7. Recover node-3 (remove netem rules)
+#   8. Wait and verify convergence
+#
+# Usage: ./scripts/netem/scenario-partition-recovery.sh
+#
+# Prerequisites:
+#   - Docker cluster running (./scripts/cluster-up.sh)
+#   - Containers have NET_ADMIN capability
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# --- Configuration ---
+NODE1_URL="http://localhost:3001"
+NODE2_URL="http://localhost:3002"
+NODE3_URL="http://localhost:3003"
+NODE3_CONTAINER="asteroidb-node-3"
+KEY="netem-test-key"
+
+# Interval (seconds) to wait for data propagation.
+SYNC_WAIT=3
+# Maximum retries when waiting for convergence after recovery.
+CONVERGENCE_RETRIES=10
+CONVERGENCE_INTERVAL=2
+
+separator() {
+    echo "======================================================================"
+}
+
+sub_separator() {
+    echo "----------------------------------------------------------------------"
+}
+
+check_node() {
+    local url="$1"
+    local name="$2"
+    local status
+    status=$(curl -s -o /dev/null -w "%{http_code}" --max-time 3 "${url}/api/eventual/__health_check" 2>/dev/null || echo "000")
+    if [ "$status" = "200" ]; then
+        echo "  ${name}: UP"
+        return 0
+    else
+        echo "  ${name}: DOWN (HTTP ${status})"
+        return 1
+    fi
+}
+
+read_counter() {
+    local url="$1"
+    curl -sf --max-time 5 "${url}/api/eventual/${KEY}" 2>/dev/null || echo '{"value":null}'
+}
+
+extract_value() {
+    local json="$1"
+    # Extract counter value. Handles {"key":"...","value":{"type":"counter","value":N}}.
+    echo "$json" | python3 -c "
+import sys, json
+try:
+    d = json.load(sys.stdin)
+    v = d.get('value')
+    if v is None:
+        print('null')
+    elif isinstance(v, dict):
+        print(v.get('value', 'null'))
+    else:
+        print(v)
+except Exception:
+    print('null')
+" 2>/dev/null || echo "null"
+}
+
+# === STEP 1: Cluster health check ===
+separator
+echo "STEP 1: Verify cluster health"
+sub_separator
+
+all_up=true
+for pair in "${NODE1_URL}:node-1" "${NODE2_URL}:node-2" "${NODE3_URL}:node-3"; do
+    url="${pair%%:*}:${pair#*:}"
+    # Re-split correctly
+    url_part="${pair%:node-*}"
+    name_part="${pair##*:}"
+    # Fix: pair format is "http://localhost:3001:node-1", need to handle the URL correctly
+    true
+done
+
+# Simpler approach
+if ! check_node "$NODE1_URL" "node-1"; then all_up=false; fi
+if ! check_node "$NODE2_URL" "node-2"; then all_up=false; fi
+if ! check_node "$NODE3_URL" "node-3"; then all_up=false; fi
+
+if ! $all_up; then
+    echo ""
+    echo "[ERROR] Not all nodes are up. Start the cluster first:"
+    echo "  ./scripts/cluster-up.sh"
+    exit 1
+fi
+echo ""
+echo "All nodes healthy."
+echo ""
+
+# === STEP 2: Initial eventual write to node-1 ===
+separator
+echo "STEP 2: Write counter to node-1 (3 increments)"
+sub_separator
+
+for i in 1 2 3; do
+    curl -sf -X POST "${NODE1_URL}/api/eventual/write" \
+        -H "Content-Type: application/json" \
+        -d "{\"type\":\"counter_inc\",\"key\":\"${KEY}\"}" > /dev/null
+    echo "  Increment ${i}/3 sent to node-1"
+done
+echo ""
+
+# === STEP 3: Wait and verify sync ===
+separator
+echo "STEP 3: Wait ${SYNC_WAIT}s for replication, then verify sync"
+sub_separator
+sleep "$SYNC_WAIT"
+
+for pair in "node-1:${NODE1_URL}" "node-2:${NODE2_URL}" "node-3:${NODE3_URL}"; do
+    name="${pair%%:*}"
+    url="${pair#*:}"
+    json=$(read_counter "$url")
+    val=$(extract_value "$json")
+    echo "  ${name}: counter = ${val}"
+done
+echo ""
+
+# === STEP 4: Partition node-3 ===
+separator
+echo "STEP 4: Partition node-3 (100% packet loss)"
+sub_separator
+
+"${SCRIPT_DIR}/add-partition.sh" "$NODE3_CONTAINER"
+echo ""
+
+# === STEP 5: Additional writes during partition ===
+separator
+echo "STEP 5: Write 5 more increments to node-1 (node-3 is partitioned)"
+sub_separator
+
+for i in 1 2 3 4 5; do
+    curl -sf -X POST "${NODE1_URL}/api/eventual/write" \
+        -H "Content-Type: application/json" \
+        -d "{\"type\":\"counter_inc\",\"key\":\"${KEY}\"}" > /dev/null
+    echo "  Increment ${i}/5 sent to node-1"
+done
+echo ""
+
+sleep "$SYNC_WAIT"
+
+# === STEP 6: Verify divergence ===
+separator
+echo "STEP 6: Verify state divergence"
+sub_separator
+
+for pair in "node-1:${NODE1_URL}" "node-2:${NODE2_URL}"; do
+    name="${pair%%:*}"
+    url="${pair#*:}"
+    json=$(read_counter "$url")
+    val=$(extract_value "$json")
+    echo "  ${name} (connected): counter = ${val}"
+done
+
+json3=$(read_counter "$NODE3_URL")
+val3=$(extract_value "$json3")
+echo "  node-3 (partitioned): counter = ${val3}"
+echo ""
+echo "  [Expected] node-1, node-2 have newer data; node-3 is behind."
+echo ""
+
+# === STEP 7: Recover node-3 ===
+separator
+echo "STEP 7: Recover node-3 (remove netem rules)"
+sub_separator
+
+"${SCRIPT_DIR}/remove-netem.sh" "$NODE3_CONTAINER"
+echo ""
+
+# === STEP 8: Wait for convergence ===
+separator
+echo "STEP 8: Wait for CRDT convergence after recovery"
+sub_separator
+
+# Read expected value from node-1.
+json1=$(read_counter "$NODE1_URL")
+expected=$(extract_value "$json1")
+echo "  Expected converged value (from node-1): ${expected}"
+
+converged=false
+for attempt in $(seq 1 "$CONVERGENCE_RETRIES"); do
+    sleep "$CONVERGENCE_INTERVAL"
+    json3=$(read_counter "$NODE3_URL")
+    val3=$(extract_value "$json3")
+    echo "  Attempt ${attempt}/${CONVERGENCE_RETRIES}: node-3 counter = ${val3}"
+
+    if [ "$val3" = "$expected" ]; then
+        converged=true
+        break
+    fi
+done
+
+echo ""
+if $converged; then
+    echo "  [OK] node-3 converged to ${expected}."
+else
+    echo "  [WARN] node-3 did not converge within the retry window."
+    echo "  Current node-3 value: ${val3}, expected: ${expected}"
+    echo "  This may be expected if inter-node replication is not yet wired."
+fi
+
+echo ""
+separator
+echo "SCENARIO COMPLETE"
+separator
+echo ""
+echo "Final state:"
+for pair in "node-1:${NODE1_URL}" "node-2:${NODE2_URL}" "node-3:${NODE3_URL}"; do
+    name="${pair%%:*}"
+    url="${pair#*:}"
+    json=$(read_counter "$url")
+    val=$(extract_value "$json")
+    echo "  ${name}: counter = ${val}"
+done
+echo ""
+echo "To clean up netem rules on all containers:"
+echo "  ./scripts/netem/remove-netem.sh asteroidb-node-1"
+echo "  ./scripts/netem/remove-netem.sh asteroidb-node-2"
+echo "  ./scripts/netem/remove-netem.sh asteroidb-node-3"


### PR DESCRIPTION
## Summary
- Add `scripts/netem/` with delay injection, partition simulation, and recovery scripts
- Add `docs/netem-testing.md` with scenario-based testing guide
- Update `docker-compose.yml` with `cap_add: [NET_ADMIN]` for all nodes

Closes #83