### PR TITLE
chore: fix clippy warnings (#94)

### DIFF
--- a/src/ops/metrics.rs
+++ b/src/ops/metrics.rs
@@ -107,7 +107,7 @@ mod tests {
 
     #[test]
     fn collect_multiple_durations() {
-        let durations: Vec<Duration> = (1..=100).map(|i| Duration::from_micros(i)).collect();
+        let durations: Vec<Duration> = (1..=100).map(Duration::from_micros).collect();
         let result = collect_latencies("range", &durations);
         assert_eq!(result.iterations, 100);
         assert!((result.mean_us - 50.5).abs() < 1.0);

--- a/tests/anti_entropy_convergence.rs
+++ b/tests/anti_entropy_convergence.rs
@@ -404,7 +404,7 @@ async fn three_node_convergence_via_sync() {
 
     // Run 2 rounds of full-mesh sync (push from each node to all others).
     for _round in 0..2 {
-        for i in 0..3 {
+        for (i, state) in states.iter().enumerate() {
             let self_id = node_id(&format!("node-{}", i + 1));
             let peers: Vec<PeerConfig> = (0..3)
                 .filter(|&j| j != i)
@@ -418,7 +418,7 @@ async fn three_node_convergence_via_sync() {
             let sync_client = SyncClient::new(registry);
 
             let entries: HashMap<String, CrdtValue> = {
-                let api = states[i].eventual.lock().await;
+                let api = state.eventual.lock().await;
                 api.store()
                     .all_entries()
                     .map(|(k, v)| (k.clone(), v.clone()))
@@ -432,8 +432,8 @@ async fn three_node_convergence_via_sync() {
     }
 
     // Verify all nodes converge to score = 2 + 3 + 1 = 6.
-    for i in 0..3 {
-        let api = states[i].eventual.lock().await;
+    for (i, state) in states.iter().enumerate() {
+        let api = state.eventual.lock().await;
         match api.get_eventual("score") {
             Some(CrdtValue::Counter(c)) => {
                 assert_eq!(


### PR DESCRIPTION
## Summary
- `tests/anti_entropy_convergence.rs`: `needless_range_loop` を `enumerate()` に置き換え（2箇所）
- `src/ops/metrics.rs`: `redundant_closure` を関数参照に置き換え

Closes #94

## Test plan
- [x] `cargo clippy --all-targets --all-features -- -D warnings` パス
- [x] `cargo test` 全648テスト パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)