### PR TITLE
feat: add automated netem test runner and scenarios

### DIFF
--- a/.github/workflows/netem.yml
+++ b/.github/workflows/netem.yml
@@ -1,0 +1,55 @@
+name: Netem Integration Tests
+
+on:
+  workflow_dispatch: # Manual trigger
+  schedule:
+    - cron: '0 3 * * *' # Nightly at 3 AM UTC
+
+jobs:
+  netem-tests:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq jq iproute2
+
+      - name: Build Docker image
+        run: docker compose build
+
+      - name: Start cluster
+        run: docker compose up -d
+
+      - name: Wait for cluster ready
+        run: |
+          echo "Waiting for cluster to be ready..."
+          sleep 10
+          # Basic health check
+          for port in 3001 3002 3003; do
+            for attempt in $(seq 1 10); do
+              if curl -sf --max-time 3 "http://localhost:${port}/api/eventual/__health_check" > /dev/null 2>&1; then
+                echo "Node on port ${port} is ready"
+                break
+              fi
+              echo "Waiting for node on port ${port} (attempt ${attempt}/10)..."
+              sleep 3
+            done
+          done
+
+      - name: Run netem scenarios
+        run: ./scripts/netem/runner.sh --all --json-output --results-dir ./netem-results
+
+      - name: Upload results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: netem-results
+          path: ./netem-results/
+
+      - name: Stop cluster
+        if: always()
+        run: docker compose down

--- a/docs/netem-testing.md
+++ b/docs/netem-testing.md
@@ -194,6 +194,130 @@ curl -s http://localhost:3001/api/status/partition-test
 > **Note**: 現時点ではノード間レプリケーションが docker compose 構成で未接続のため、
 > 自動収束は確認できない場合があります。レプリケーション統合後に完全なシナリオが動作します。
 
+## 自動テストランナー
+
+### 概要
+
+`runner.sh` は `scenarios.json` に定義されたシナリオを自動実行し、
+構造化された JSON 形式で結果を出力するテストランナーです。
+
+### 前提条件
+
+上記の前提条件に加えて:
+
+| 項目 | 要件 |
+|------|------|
+| **jq** | JSON パース用。`brew install jq` (macOS) / `apt-get install jq` (Linux) |
+
+### 使い方
+
+```bash
+# シナリオ一覧を表示
+./scripts/netem/runner.sh --list
+
+# 特定のシナリオを実行
+./scripts/netem/runner.sh --scenario partition-recovery
+
+# 全シナリオを実行
+./scripts/netem/runner.sh --all
+
+# JSON 出力付きで全シナリオを実行
+./scripts/netem/runner.sh --all --json-output
+
+# 結果の保存先を指定
+./scripts/netem/runner.sh --all --results-dir /tmp/netem-results
+```
+
+### オプション一覧
+
+| オプション | 説明 |
+|-----------|------|
+| `--scenario <name>` | 指定した名前のシナリオのみ実行 |
+| `--all` | 全シナリオを順次実行 |
+| `--list` | 利用可能なシナリオの一覧を表示 |
+| `--json-output` | 結果を JSON 形式で stdout に出力 |
+| `--results-dir <dir>` | 結果ファイルの保存先ディレクトリ (デフォルト: `./netem-results`) |
+| `--help` | ヘルプメッセージを表示 |
+
+### シナリオ定義 (`scenarios.json`)
+
+シナリオは `scripts/netem/scenarios.json` に JSON 形式で定義されています:
+
+```json
+{
+  "scenarios": [
+    {
+      "name": "partition-recovery",
+      "description": "Network partition and CRDT convergence after recovery",
+      "script": "scenario-partition-recovery.sh",
+      "nodes": 3,
+      "timeout_seconds": 120,
+      "tags": ["partition", "convergence"]
+    }
+  ]
+}
+```
+
+新しいシナリオを追加するには:
+1. `scripts/netem/scenario-<name>.sh` スクリプトを作成
+2. `scenarios.json` にエントリを追加
+3. スクリプトに実行権限を付与: `chmod +x scripts/netem/scenario-<name>.sh`
+
+### 結果の JSON フォーマット
+
+各シナリオの結果は以下の形式で保存されます:
+
+```json
+{
+  "timestamp": "2026-02-23T12:00:00Z",
+  "scenario": "partition-recovery",
+  "status": "pass",
+  "duration_seconds": 45,
+  "output": "..."
+}
+```
+
+| フィールド | 説明 |
+|-----------|------|
+| `timestamp` | 結果生成時の UTC タイムスタンプ (ISO 8601) |
+| `scenario` | シナリオ名 |
+| `status` | `pass` / `fail` / `timeout` / `error` |
+| `duration_seconds` | 実行時間 (秒) |
+| `output` | スクリプトの stdout/stderr 出力 |
+
+### 共有ライブラリ (`lib.sh`)
+
+シナリオスクリプト間で共有される関数群が `scripts/netem/lib.sh` に定義されています。
+新しいシナリオスクリプトでは先頭で source してください:
+
+```bash
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "${SCRIPT_DIR}/lib.sh"
+```
+
+提供される関数:
+
+| 関数 | 説明 |
+|------|------|
+| `separator` / `sub_separator` | 視覚的な区切り線を出力 |
+| `log_step <n> <msg>` | 番号付きステップヘッダーを出力 |
+| `check_node <url> <name>` | ノードの health check |
+| `check_cluster <url1> <url2> <url3>` | 3 ノード全体の health check |
+| `read_counter <url> <key>` | カウンタの JSON レスポンスを取得 |
+| `extract_value <json>` | JSON からカウンタ値を抽出 |
+| `wait_for_convergence <expected> <url> <name> <retries> <interval> <key>` | 収束をポーリング |
+| `now_epoch_ms` / `elapsed_ms <start>` | タイミング計測 |
+
+### CI (GitHub Actions)
+
+netem テストは GitHub Actions で自動実行できます:
+
+- **手動トリガー**: Actions タブから `Netem Integration Tests` を手動実行
+- **夜間スケジュール**: 毎日 UTC 3:00 (JST 12:00) に自動実行
+- **結果**: Artifacts として `netem-results` がダウンロード可能
+
+ワークフロー定義: `.github/workflows/netem.yml`
+
 ## トラブルシューティング
 
 ### tc コマンドが見つからない

--- a/scripts/netem/lib.sh
+++ b/scripts/netem/lib.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+# Shared library for netem scenario scripts.
+#
+# Source this file at the top of scenario scripts:
+#   SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+#   source "${SCRIPT_DIR}/lib.sh"
+#
+# Provides:
+#   - Color constants (CLR_GREEN, CLR_RED, CLR_YELLOW, CLR_CYAN, CLR_RESET)
+#   - separator / sub_separator - visual output formatting
+#   - log_step <n> <msg>        - numbered step header
+#   - check_node <url> <name>   - verify a node is responding
+#   - read_counter <url> <key>  - read a counter value via eventual API
+#   - extract_value <json>      - pull counter value from API JSON response
+#   - wait_for_convergence <expected> <url> <name> <retries> <interval>
+#                               - poll a node until its counter matches expected
+
+# --- Color constants ---
+if [ -t 1 ]; then
+    CLR_GREEN="\033[0;32m"
+    CLR_RED="\033[0;31m"
+    CLR_YELLOW="\033[0;33m"
+    CLR_CYAN="\033[0;36m"
+    CLR_BOLD="\033[1m"
+    CLR_RESET="\033[0m"
+else
+    CLR_GREEN=""
+    CLR_RED=""
+    CLR_YELLOW=""
+    CLR_CYAN=""
+    CLR_BOLD=""
+    CLR_RESET=""
+fi
+
+# --- Output formatting ---
+
+separator() {
+    echo "======================================================================"
+}
+
+sub_separator() {
+    echo "----------------------------------------------------------------------"
+}
+
+# log_step <step_number> <message>
+log_step() {
+    local step_num="$1"
+    shift
+    separator
+    echo -e "${CLR_BOLD}STEP ${step_num}: $*${CLR_RESET}"
+    sub_separator
+}
+
+# --- Node interaction ---
+
+# check_node <url> <name>
+# Returns 0 if the node responds with HTTP 200, 1 otherwise.
+check_node() {
+    local url="$1"
+    local name="$2"
+    local status
+    status=$(curl -s -o /dev/null -w "%{http_code}" --max-time 3 "${url}/api/eventual/__health_check" 2>/dev/null || echo "000")
+    if [ "$status" = "200" ]; then
+        echo -e "  ${CLR_GREEN}${name}: UP${CLR_RESET}"
+        return 0
+    else
+        echo -e "  ${CLR_RED}${name}: DOWN (HTTP ${status})${CLR_RESET}"
+        return 1
+    fi
+}
+
+# read_counter <url> <key>
+# Prints the raw JSON response for the given key.
+read_counter() {
+    local url="$1"
+    local key="$2"
+    curl -sf --max-time 5 "${url}/api/eventual/${key}" 2>/dev/null || echo '{"value":null}'
+}
+
+# extract_value <json>
+# Extracts the numeric counter value from an API JSON response.
+# Handles: {"key":"...","value":{"type":"counter","value":N}}
+extract_value() {
+    local json="$1"
+    echo "$json" | python3 -c "
+import sys, json
+try:
+    d = json.load(sys.stdin)
+    v = d.get('value')
+    if v is None:
+        print('null')
+    elif isinstance(v, dict):
+        print(v.get('value', 'null'))
+    else:
+        print(v)
+except Exception:
+    print('null')
+" 2>/dev/null || echo "null"
+}
+
+# --- Convergence helpers ---
+
+# wait_for_convergence <expected> <url> <name> <retries> <interval>
+# Polls a node until its counter value matches <expected>.
+# Returns 0 if converged, 1 if timed out.
+wait_for_convergence() {
+    local expected="$1"
+    local url="$2"
+    local name="$3"
+    local retries="${4:-10}"
+    local interval="${5:-2}"
+    local key="${6:-netem-test-key}"
+
+    for attempt in $(seq 1 "$retries"); do
+        sleep "$interval"
+        local json
+        json=$(read_counter "$url" "$key")
+        local val
+        val=$(extract_value "$json")
+        echo "  Attempt ${attempt}/${retries}: ${name} counter = ${val}"
+
+        if [ "$val" = "$expected" ]; then
+            echo -e "  ${CLR_GREEN}[OK] ${name} converged to ${expected}.${CLR_RESET}"
+            return 0
+        fi
+    done
+
+    echo -e "  ${CLR_YELLOW}[WARN] ${name} did not converge within the retry window.${CLR_RESET}"
+    echo "  Current value: ${val}, expected: ${expected}"
+    return 1
+}
+
+# --- Cluster validation ---
+
+# check_cluster <node1_url> <node2_url> <node3_url>
+# Returns 0 if all 3 nodes are up, 1 otherwise.
+check_cluster() {
+    local node1_url="$1"
+    local node2_url="$2"
+    local node3_url="$3"
+    local all_up=true
+
+    if ! check_node "$node1_url" "node-1"; then all_up=false; fi
+    if ! check_node "$node2_url" "node-2"; then all_up=false; fi
+    if ! check_node "$node3_url" "node-3"; then all_up=false; fi
+
+    if ! $all_up; then
+        echo ""
+        echo -e "${CLR_RED}[ERROR] Not all nodes are up. Start the cluster first:${CLR_RESET}"
+        echo "  ./scripts/cluster-up.sh"
+        return 1
+    fi
+
+    echo ""
+    echo -e "${CLR_GREEN}All nodes healthy.${CLR_RESET}"
+    return 0
+}
+
+# --- Timing helpers ---
+
+# now_epoch_ms - prints current time in milliseconds since epoch
+now_epoch_ms() {
+    python3 -c "import time; print(int(time.time() * 1000))"
+}
+
+# elapsed_ms <start_ms>
+# Prints elapsed milliseconds since <start_ms>.
+elapsed_ms() {
+    local start="$1"
+    local now
+    now=$(now_epoch_ms)
+    echo $(( now - start ))
+}

--- a/scripts/netem/runner.sh
+++ b/scripts/netem/runner.sh
@@ -1,0 +1,350 @@
+#!/usr/bin/env bash
+# Netem scenario runner for AsteroidDB.
+#
+# Reads scenario definitions from scenarios.json, executes them with
+# timeout enforcement, and produces structured JSON results.
+#
+# Usage: ./scripts/netem/runner.sh [OPTIONS]
+#
+# Options:
+#   --scenario <name>   Run a specific scenario by name
+#   --all               Run all scenarios
+#   --list              List available scenarios
+#   --json-output       Output results as JSON to stdout
+#   --results-dir <dir> Directory for results (default: ./netem-results)
+#   --help              Show this help message
+#
+# Prerequisites:
+#   - Docker cluster running (./scripts/cluster-up.sh)
+#   - jq installed (for JSON parsing)
+#   - Python 3 available (used by scenario scripts)
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCENARIOS_FILE="${SCRIPT_DIR}/scenarios.json"
+RESULTS_DIR="./netem-results"
+JSON_OUTPUT=false
+RUN_ALL=false
+SCENARIO_NAME=""
+
+# --- Argument parsing ---
+
+usage() {
+    cat <<'USAGE'
+Usage: ./scripts/netem/runner.sh [OPTIONS]
+
+Options:
+  --scenario <name>   Run a specific scenario by name
+  --all               Run all scenarios
+  --list              List available scenarios
+  --json-output       Output results as JSON to stdout
+  --results-dir <dir> Directory for results (default: ./netem-results)
+  --help              Show this help message
+
+Examples:
+  ./scripts/netem/runner.sh --list
+  ./scripts/netem/runner.sh --scenario partition-recovery
+  ./scripts/netem/runner.sh --all --json-output
+  ./scripts/netem/runner.sh --all --results-dir /tmp/netem-results
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --scenario)
+            SCENARIO_NAME="${2:?--scenario requires a name argument}"
+            shift 2
+            ;;
+        --all)
+            RUN_ALL=true
+            shift
+            ;;
+        --list)
+            LIST_ONLY=true
+            shift
+            ;;
+        --json-output)
+            JSON_OUTPUT=true
+            shift
+            ;;
+        --results-dir)
+            RESULTS_DIR="${2:?--results-dir requires a directory argument}"
+            shift 2
+            ;;
+        --help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1" >&2
+            usage >&2
+            exit 1
+            ;;
+    esac
+done
+
+# --- Prerequisites check ---
+
+if [ ! -f "$SCENARIOS_FILE" ]; then
+    echo "[ERROR] Scenarios file not found: ${SCENARIOS_FILE}" >&2
+    exit 1
+fi
+
+# Check for jq
+if ! command -v jq > /dev/null 2>&1; then
+    echo "[ERROR] jq is required but not installed." >&2
+    echo "  Install with: brew install jq (macOS) or apt-get install jq (Linux)" >&2
+    exit 1
+fi
+
+# --- Scenario loading ---
+
+# Get number of scenarios
+SCENARIO_COUNT=$(jq '.scenarios | length' "$SCENARIOS_FILE")
+
+# list_scenarios - print available scenarios in a table
+list_scenarios() {
+    echo "Available netem scenarios:"
+    echo ""
+    printf "  %-25s %-55s %s\n" "NAME" "DESCRIPTION" "TAGS"
+    printf "  %-25s %-55s %s\n" "----" "-----------" "----"
+    for i in $(seq 0 $(( SCENARIO_COUNT - 1 ))); do
+        local name description tags
+        name=$(jq -r ".scenarios[$i].name" "$SCENARIOS_FILE")
+        description=$(jq -r ".scenarios[$i].description" "$SCENARIOS_FILE")
+        tags=$(jq -r ".scenarios[$i].tags | join(\", \")" "$SCENARIOS_FILE")
+        printf "  %-25s %-55s %s\n" "$name" "$description" "$tags"
+    done
+    echo ""
+    echo "Total: ${SCENARIO_COUNT} scenario(s)"
+}
+
+# find_scenario <name> - prints the index of a scenario, or -1 if not found
+find_scenario() {
+    local target="$1"
+    for i in $(seq 0 $(( SCENARIO_COUNT - 1 ))); do
+        local name
+        name=$(jq -r ".scenarios[$i].name" "$SCENARIOS_FILE")
+        if [ "$name" = "$target" ]; then
+            echo "$i"
+            return 0
+        fi
+    done
+    echo "-1"
+    return 1
+}
+
+# --- List mode ---
+
+if [ "${LIST_ONLY:-false}" = "true" ]; then
+    list_scenarios
+    exit 0
+fi
+
+# --- Validate selection ---
+
+if [ "$RUN_ALL" = "false" ] && [ -z "$SCENARIO_NAME" ]; then
+    echo "[ERROR] Specify --all, --scenario <name>, or --list." >&2
+    echo "" >&2
+    usage >&2
+    exit 1
+fi
+
+# --- Docker cluster check ---
+
+check_docker_cluster() {
+    echo "[runner] Checking Docker cluster..."
+    local running
+    running=$(docker ps --filter "name=asteroidb-node" --format '{{.Names}}' 2>/dev/null | wc -l | tr -d ' ')
+    if [ "$running" -lt 1 ]; then
+        echo "[ERROR] No AsteroidDB containers running." >&2
+        echo "  Start the cluster with: ./scripts/cluster-up.sh" >&2
+        return 1
+    fi
+    echo "[runner] Found ${running} AsteroidDB container(s) running."
+    return 0
+}
+
+if ! check_docker_cluster; then
+    exit 1
+fi
+
+# --- Results directory ---
+
+mkdir -p "$RESULTS_DIR"
+
+# --- Run a single scenario ---
+
+# run_scenario <index>
+# Runs the scenario at the given index, captures output, and writes a JSON result.
+# Returns the exit code of the scenario script.
+run_scenario() {
+    local idx="$1"
+    local name description script timeout_seconds
+    name=$(jq -r ".scenarios[$idx].name" "$SCENARIOS_FILE")
+    description=$(jq -r ".scenarios[$idx].description" "$SCENARIOS_FILE")
+    script=$(jq -r ".scenarios[$idx].script" "$SCENARIOS_FILE")
+    timeout_seconds=$(jq -r ".scenarios[$idx].timeout_seconds" "$SCENARIOS_FILE")
+
+    local script_path="${SCRIPT_DIR}/${script}"
+
+    if [ ! -x "$script_path" ]; then
+        echo "[ERROR] Scenario script not found or not executable: ${script_path}" >&2
+        write_result "$name" "error" 0 "Script not found or not executable: ${script}"
+        return 1
+    fi
+
+    echo ""
+    echo "======================================================================"
+    echo "[runner] Starting scenario: ${name}"
+    echo "  Description: ${description}"
+    echo "  Script:      ${script}"
+    echo "  Timeout:     ${timeout_seconds}s"
+    echo "======================================================================"
+    echo ""
+
+    local start_time end_time duration_seconds exit_code output
+    start_time=$(date +%s)
+
+    # Run with timeout; capture both stdout and stderr.
+    local output_file="${RESULTS_DIR}/${name}-output.txt"
+    set +e
+    if command -v timeout > /dev/null 2>&1; then
+        # GNU coreutils timeout (Linux)
+        timeout "${timeout_seconds}" bash "$script_path" > "$output_file" 2>&1
+        exit_code=$?
+        if [ "$exit_code" -eq 124 ]; then
+            echo "[runner] Scenario timed out after ${timeout_seconds}s" | tee -a "$output_file"
+        fi
+    elif command -v gtimeout > /dev/null 2>&1; then
+        # GNU coreutils via Homebrew (macOS)
+        gtimeout "${timeout_seconds}" bash "$script_path" > "$output_file" 2>&1
+        exit_code=$?
+        if [ "$exit_code" -eq 124 ]; then
+            echo "[runner] Scenario timed out after ${timeout_seconds}s" | tee -a "$output_file"
+        fi
+    else
+        # Fallback: no timeout enforcement, just run the script
+        echo "[runner] WARNING: 'timeout' command not available; running without timeout enforcement."
+        bash "$script_path" > "$output_file" 2>&1
+        exit_code=$?
+    fi
+    set -e
+
+    end_time=$(date +%s)
+    duration_seconds=$(( end_time - start_time ))
+
+    # Print captured output
+    cat "$output_file"
+
+    local status
+    if [ "$exit_code" -eq 0 ]; then
+        status="pass"
+        echo ""
+        echo "[runner] Scenario '${name}' PASSED in ${duration_seconds}s"
+    elif [ "$exit_code" -eq 124 ]; then
+        status="timeout"
+        echo ""
+        echo "[runner] Scenario '${name}' TIMED OUT after ${timeout_seconds}s"
+    else
+        status="fail"
+        echo ""
+        echo "[runner] Scenario '${name}' FAILED (exit code ${exit_code}) in ${duration_seconds}s"
+    fi
+
+    output=$(cat "$output_file")
+    write_result "$name" "$status" "$duration_seconds" "$output"
+
+    return "$exit_code"
+}
+
+# write_result <name> <status> <duration_seconds> <output>
+# Writes a JSON result file.
+write_result() {
+    local name="$1"
+    local status="$2"
+    local duration_seconds="$3"
+    local output="$4"
+    local timestamp
+    timestamp=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+    local result_file="${RESULTS_DIR}/${name}-result.json"
+
+    # Use jq to safely encode the output string as JSON.
+    jq -n \
+        --arg timestamp "$timestamp" \
+        --arg scenario "$name" \
+        --arg status "$status" \
+        --argjson duration "$duration_seconds" \
+        --arg output "$output" \
+        '{
+            timestamp: $timestamp,
+            scenario: $scenario,
+            status: $status,
+            duration_seconds: $duration,
+            output: $output
+        }' > "$result_file"
+
+    if [ "$JSON_OUTPUT" = "true" ]; then
+        cat "$result_file"
+    fi
+}
+
+# --- Main execution ---
+
+ALL_RESULTS=()
+OVERALL_EXIT=0
+
+if [ "$RUN_ALL" = "true" ]; then
+    echo "[runner] Running all ${SCENARIO_COUNT} scenario(s)..."
+    for i in $(seq 0 $(( SCENARIO_COUNT - 1 ))); do
+        name=$(jq -r ".scenarios[$i].name" "$SCENARIOS_FILE")
+        set +e
+        run_scenario "$i"
+        ec=$?
+        set -e
+        ALL_RESULTS+=("${name}:${ec}")
+        if [ "$ec" -ne 0 ]; then
+            OVERALL_EXIT=1
+        fi
+    done
+else
+    idx=$(find_scenario "$SCENARIO_NAME" || true)
+    if [ "$idx" = "-1" ] || [ -z "$idx" ]; then
+        echo "[ERROR] Scenario not found: ${SCENARIO_NAME}" >&2
+        echo "" >&2
+        list_scenarios >&2
+        exit 1
+    fi
+    set +e
+    run_scenario "$idx"
+    ec=$?
+    set -e
+    ALL_RESULTS+=("${SCENARIO_NAME}:${ec}")
+    if [ "$ec" -ne 0 ]; then
+        OVERALL_EXIT=1
+    fi
+fi
+
+# --- Summary ---
+
+echo ""
+echo "======================================================================"
+echo "[runner] Summary"
+echo "======================================================================"
+for entry in "${ALL_RESULTS[@]}"; do
+    name="${entry%%:*}"
+    code="${entry##*:}"
+    if [ "$code" -eq 0 ]; then
+        echo "  PASS  ${name}"
+    elif [ "$code" -eq 124 ]; then
+        echo "  TIMEOUT  ${name}"
+    else
+        echo "  FAIL  ${name} (exit code ${code})"
+    fi
+done
+echo ""
+echo "Results saved to: ${RESULTS_DIR}/"
+echo "======================================================================"
+
+exit "$OVERALL_EXIT"

--- a/scripts/netem/scenario-delay-convergence.sh
+++ b/scripts/netem/scenario-delay-convergence.sh
@@ -1,0 +1,177 @@
+#!/usr/bin/env bash
+# Scenario: High latency impact on CRDT convergence time.
+#
+# This script measures how network delay affects CRDT convergence:
+#   1. Verify the 3-node cluster is up
+#   2. Add 200ms delay to node-2
+#   3. Write counter increments to node-1
+#   4. Measure time for values to appear on node-2 (delayed) and node-3 (normal)
+#   5. Remove delay
+#   6. Verify all nodes converge
+#   7. Report timing results
+#
+# Usage: ./scripts/netem/scenario-delay-convergence.sh
+#
+# Prerequisites:
+#   - Docker cluster running (./scripts/cluster-up.sh)
+#   - Containers have NET_ADMIN capability
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "${SCRIPT_DIR}/lib.sh"
+
+# --- Configuration ---
+NODE1_URL="http://localhost:3001"
+NODE2_URL="http://localhost:3002"
+NODE3_URL="http://localhost:3003"
+NODE2_CONTAINER="asteroidb-node-2"
+KEY="netem-delay-test-key"
+DELAY_MS=200
+
+# Interval (seconds) to wait for data propagation.
+SYNC_WAIT=3
+# Additional wait to account for delay.
+DELAY_SYNC_WAIT=5
+# Maximum retries when waiting for convergence.
+CONVERGENCE_RETRIES=10
+CONVERGENCE_INTERVAL=2
+
+# --- STEP 1: Cluster health check ---
+log_step 1 "Verify cluster health"
+
+if ! check_cluster "$NODE1_URL" "$NODE2_URL" "$NODE3_URL"; then
+    exit 1
+fi
+echo ""
+
+# --- STEP 2: Add 200ms delay to node-2 ---
+log_step 2 "Add ${DELAY_MS}ms delay to node-2"
+
+"${SCRIPT_DIR}/add-delay.sh" "$NODE2_CONTAINER" "$DELAY_MS"
+echo ""
+
+# --- STEP 3: Write counter increments to node-1 ---
+log_step 3 "Write counter to node-1 (5 increments)"
+
+for i in 1 2 3 4 5; do
+    curl -sf -X POST "${NODE1_URL}/api/eventual/write" \
+        -H "Content-Type: application/json" \
+        -d "{\"type\":\"counter_inc\",\"key\":\"${KEY}\"}" > /dev/null
+    echo "  Increment ${i}/5 sent to node-1"
+done
+echo ""
+
+# --- STEP 4: Measure convergence time on node-3 (no delay) ---
+log_step 4 "Measure convergence time on node-3 (no delay)"
+
+start_ms=$(now_epoch_ms)
+node3_converged=false
+node3_elapsed="N/A"
+
+for attempt in $(seq 1 "$CONVERGENCE_RETRIES"); do
+    sleep "$CONVERGENCE_INTERVAL"
+    json=$(read_counter "$NODE3_URL" "$KEY")
+    val=$(extract_value "$json")
+    echo "  Attempt ${attempt}/${CONVERGENCE_RETRIES}: node-3 counter = ${val}"
+
+    if [ "$val" = "5" ]; then
+        node3_elapsed=$(elapsed_ms "$start_ms")
+        node3_converged=true
+        echo -e "  ${CLR_GREEN}[OK] node-3 converged in ${node3_elapsed}ms${CLR_RESET}"
+        break
+    fi
+done
+
+if ! $node3_converged; then
+    node3_elapsed=$(elapsed_ms "$start_ms")
+    echo -e "  ${CLR_YELLOW}[WARN] node-3 did not converge within retry window (${node3_elapsed}ms elapsed)${CLR_RESET}"
+fi
+echo ""
+
+# --- STEP 5: Measure convergence time on node-2 (200ms delay) ---
+log_step 5 "Measure convergence time on node-2 (${DELAY_MS}ms delay)"
+
+start_ms=$(now_epoch_ms)
+node2_converged=false
+node2_elapsed="N/A"
+
+for attempt in $(seq 1 "$CONVERGENCE_RETRIES"); do
+    sleep "$CONVERGENCE_INTERVAL"
+    json=$(read_counter "$NODE2_URL" "$KEY")
+    val=$(extract_value "$json")
+    echo "  Attempt ${attempt}/${CONVERGENCE_RETRIES}: node-2 counter = ${val}"
+
+    if [ "$val" = "5" ]; then
+        node2_elapsed=$(elapsed_ms "$start_ms")
+        node2_converged=true
+        echo -e "  ${CLR_GREEN}[OK] node-2 converged in ${node2_elapsed}ms${CLR_RESET}"
+        break
+    fi
+done
+
+if ! $node2_converged; then
+    node2_elapsed=$(elapsed_ms "$start_ms")
+    echo -e "  ${CLR_YELLOW}[WARN] node-2 did not converge within retry window (${node2_elapsed}ms elapsed)${CLR_RESET}"
+fi
+echo ""
+
+# --- STEP 6: Remove delay from node-2 ---
+log_step 6 "Remove delay from node-2"
+
+"${SCRIPT_DIR}/remove-netem.sh" "$NODE2_CONTAINER"
+echo ""
+
+# --- STEP 7: Verify final convergence ---
+log_step 7 "Verify final convergence (all nodes)"
+
+sleep "$SYNC_WAIT"
+
+all_converged=true
+for pair in "node-1:${NODE1_URL}" "node-2:${NODE2_URL}" "node-3:${NODE3_URL}"; do
+    name="${pair%%:*}"
+    url="${pair#*:}"
+    json=$(read_counter "$url" "$KEY")
+    val=$(extract_value "$json")
+    echo "  ${name}: counter = ${val}"
+    if [ "$val" != "5" ]; then
+        all_converged=false
+    fi
+done
+echo ""
+
+# --- STEP 8: Report timing results ---
+log_step 8 "Timing results"
+
+echo ""
+echo "  Delay applied to node-2:  ${DELAY_MS}ms"
+echo "  node-3 (no delay):        ${node3_elapsed}ms to converge"
+echo "  node-2 (${DELAY_MS}ms delay):   ${node2_elapsed}ms to converge"
+echo ""
+
+if $node3_converged && $node2_converged; then
+    echo -e "  ${CLR_GREEN}[RESULT] Both nodes converged.${CLR_RESET}"
+elif $node3_converged; then
+    echo -e "  ${CLR_YELLOW}[RESULT] node-3 converged but node-2 (delayed) did not.${CLR_RESET}"
+else
+    echo -e "  ${CLR_YELLOW}[RESULT] Neither node converged within the retry window.${CLR_RESET}"
+    echo "  This may be expected if inter-node replication is not yet wired."
+fi
+
+echo ""
+separator
+echo "SCENARIO COMPLETE"
+separator
+echo ""
+echo "Final state:"
+for pair in "node-1:${NODE1_URL}" "node-2:${NODE2_URL}" "node-3:${NODE3_URL}"; do
+    name="${pair%%:*}"
+    url="${pair#*:}"
+    json=$(read_counter "$url" "$KEY")
+    val=$(extract_value "$json")
+    echo "  ${name}: counter = ${val}"
+done
+echo ""
+echo "To clean up netem rules on all containers:"
+echo "  ./scripts/netem/remove-netem.sh asteroidb-node-1"
+echo "  ./scripts/netem/remove-netem.sh asteroidb-node-2"
+echo "  ./scripts/netem/remove-netem.sh asteroidb-node-3"

--- a/scripts/netem/scenario-partition-recovery.sh
+++ b/scripts/netem/scenario-partition-recovery.sh
@@ -19,6 +19,7 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "${SCRIPT_DIR}/lib.sh"
 
 # --- Configuration ---
 NODE1_URL="http://localhost:3001"
@@ -33,86 +34,16 @@ SYNC_WAIT=3
 CONVERGENCE_RETRIES=10
 CONVERGENCE_INTERVAL=2
 
-separator() {
-    echo "======================================================================"
-}
-
-sub_separator() {
-    echo "----------------------------------------------------------------------"
-}
-
-check_node() {
-    local url="$1"
-    local name="$2"
-    local status
-    status=$(curl -s -o /dev/null -w "%{http_code}" --max-time 3 "${url}/api/eventual/__health_check" 2>/dev/null || echo "000")
-    if [ "$status" = "200" ]; then
-        echo "  ${name}: UP"
-        return 0
-    else
-        echo "  ${name}: DOWN (HTTP ${status})"
-        return 1
-    fi
-}
-
-read_counter() {
-    local url="$1"
-    curl -sf --max-time 5 "${url}/api/eventual/${KEY}" 2>/dev/null || echo '{"value":null}'
-}
-
-extract_value() {
-    local json="$1"
-    # Extract counter value. Handles {"key":"...","value":{"type":"counter","value":N}}.
-    echo "$json" | python3 -c "
-import sys, json
-try:
-    d = json.load(sys.stdin)
-    v = d.get('value')
-    if v is None:
-        print('null')
-    elif isinstance(v, dict):
-        print(v.get('value', 'null'))
-    else:
-        print(v)
-except Exception:
-    print('null')
-" 2>/dev/null || echo "null"
-}
-
 # === STEP 1: Cluster health check ===
-separator
-echo "STEP 1: Verify cluster health"
-sub_separator
+log_step 1 "Verify cluster health"
 
-all_up=true
-for pair in "${NODE1_URL}:node-1" "${NODE2_URL}:node-2" "${NODE3_URL}:node-3"; do
-    url="${pair%%:*}:${pair#*:}"
-    # Re-split correctly
-    url_part="${pair%:node-*}"
-    name_part="${pair##*:}"
-    # Fix: pair format is "http://localhost:3001:node-1", need to handle the URL correctly
-    true
-done
-
-# Simpler approach
-if ! check_node "$NODE1_URL" "node-1"; then all_up=false; fi
-if ! check_node "$NODE2_URL" "node-2"; then all_up=false; fi
-if ! check_node "$NODE3_URL" "node-3"; then all_up=false; fi
-
-if ! $all_up; then
-    echo ""
-    echo "[ERROR] Not all nodes are up. Start the cluster first:"
-    echo "  ./scripts/cluster-up.sh"
+if ! check_cluster "$NODE1_URL" "$NODE2_URL" "$NODE3_URL"; then
     exit 1
 fi
 echo ""
-echo "All nodes healthy."
-echo ""
 
 # === STEP 2: Initial eventual write to node-1 ===
-separator
-echo "STEP 2: Write counter to node-1 (3 increments)"
-sub_separator
+log_step 2 "Write counter to node-1 (3 increments)"
 
 for i in 1 2 3; do
     curl -sf -X POST "${NODE1_URL}/api/eventual/write" \
@@ -123,32 +54,26 @@ done
 echo ""
 
 # === STEP 3: Wait and verify sync ===
-separator
-echo "STEP 3: Wait ${SYNC_WAIT}s for replication, then verify sync"
-sub_separator
+log_step 3 "Wait ${SYNC_WAIT}s for replication, then verify sync"
 sleep "$SYNC_WAIT"
 
 for pair in "node-1:${NODE1_URL}" "node-2:${NODE2_URL}" "node-3:${NODE3_URL}"; do
     name="${pair%%:*}"
     url="${pair#*:}"
-    json=$(read_counter "$url")
+    json=$(read_counter "$url" "$KEY")
     val=$(extract_value "$json")
     echo "  ${name}: counter = ${val}"
 done
 echo ""
 
 # === STEP 4: Partition node-3 ===
-separator
-echo "STEP 4: Partition node-3 (100% packet loss)"
-sub_separator
+log_step 4 "Partition node-3 (100% packet loss)"
 
 "${SCRIPT_DIR}/add-partition.sh" "$NODE3_CONTAINER"
 echo ""
 
 # === STEP 5: Additional writes during partition ===
-separator
-echo "STEP 5: Write 5 more increments to node-1 (node-3 is partitioned)"
-sub_separator
+log_step 5 "Write 5 more increments to node-1 (node-3 is partitioned)"
 
 for i in 1 2 3 4 5; do
     curl -sf -X POST "${NODE1_URL}/api/eventual/write" \
@@ -161,19 +86,17 @@ echo ""
 sleep "$SYNC_WAIT"
 
 # === STEP 6: Verify divergence ===
-separator
-echo "STEP 6: Verify state divergence"
-sub_separator
+log_step 6 "Verify state divergence"
 
 for pair in "node-1:${NODE1_URL}" "node-2:${NODE2_URL}"; do
     name="${pair%%:*}"
     url="${pair#*:}"
-    json=$(read_counter "$url")
+    json=$(read_counter "$url" "$KEY")
     val=$(extract_value "$json")
     echo "  ${name} (connected): counter = ${val}"
 done
 
-json3=$(read_counter "$NODE3_URL")
+json3=$(read_counter "$NODE3_URL" "$KEY")
 val3=$(extract_value "$json3")
 echo "  node-3 (partitioned): counter = ${val3}"
 echo ""
@@ -181,42 +104,26 @@ echo "  [Expected] node-1, node-2 have newer data; node-3 is behind."
 echo ""
 
 # === STEP 7: Recover node-3 ===
-separator
-echo "STEP 7: Recover node-3 (remove netem rules)"
-sub_separator
+log_step 7 "Recover node-3 (remove netem rules)"
 
 "${SCRIPT_DIR}/remove-netem.sh" "$NODE3_CONTAINER"
 echo ""
 
 # === STEP 8: Wait for convergence ===
-separator
-echo "STEP 8: Wait for CRDT convergence after recovery"
-sub_separator
+log_step 8 "Wait for CRDT convergence after recovery"
 
 # Read expected value from node-1.
-json1=$(read_counter "$NODE1_URL")
+json1=$(read_counter "$NODE1_URL" "$KEY")
 expected=$(extract_value "$json1")
 echo "  Expected converged value (from node-1): ${expected}"
 
 converged=false
-for attempt in $(seq 1 "$CONVERGENCE_RETRIES"); do
-    sleep "$CONVERGENCE_INTERVAL"
-    json3=$(read_counter "$NODE3_URL")
-    val3=$(extract_value "$json3")
-    echo "  Attempt ${attempt}/${CONVERGENCE_RETRIES}: node-3 counter = ${val3}"
-
-    if [ "$val3" = "$expected" ]; then
-        converged=true
-        break
-    fi
-done
+if wait_for_convergence "$expected" "$NODE3_URL" "node-3" "$CONVERGENCE_RETRIES" "$CONVERGENCE_INTERVAL" "$KEY"; then
+    converged=true
+fi
 
 echo ""
-if $converged; then
-    echo "  [OK] node-3 converged to ${expected}."
-else
-    echo "  [WARN] node-3 did not converge within the retry window."
-    echo "  Current node-3 value: ${val3}, expected: ${expected}"
+if ! $converged; then
     echo "  This may be expected if inter-node replication is not yet wired."
 fi
 
@@ -229,7 +136,7 @@ echo "Final state:"
 for pair in "node-1:${NODE1_URL}" "node-2:${NODE2_URL}" "node-3:${NODE3_URL}"; do
     name="${pair%%:*}"
     url="${pair#*:}"
-    json=$(read_counter "$url")
+    json=$(read_counter "$url" "$KEY")
     val=$(extract_value "$json")
     echo "  ${name}: counter = ${val}"
 done

--- a/scripts/netem/scenarios.json
+++ b/scripts/netem/scenarios.json
@@ -1,0 +1,20 @@
+{
+  "scenarios": [
+    {
+      "name": "partition-recovery",
+      "description": "Network partition and CRDT convergence after recovery",
+      "script": "scenario-partition-recovery.sh",
+      "nodes": 3,
+      "timeout_seconds": 120,
+      "tags": ["partition", "convergence"]
+    },
+    {
+      "name": "delay-convergence",
+      "description": "High latency impact on CRDT convergence time",
+      "script": "scenario-delay-convergence.sh",
+      "nodes": 3,
+      "timeout_seconds": 120,
+      "tags": ["delay", "convergence"]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Extract shared library (`scripts/netem/lib.sh`) with common functions from scenario scripts
- Create declarative scenario registry (`scripts/netem/scenarios.json`)
- Add new `delay-convergence` scenario measuring latency impact on CRDT convergence
- Create `runner.sh` for single-command execution with JSON result output, timeout enforcement, and structured reporting
- Refactor `scenario-partition-recovery.sh` to use shared library
- Add GitHub Actions workflow (`.github/workflows/netem.yml`) for nightly netem integration tests
- Update `docs/netem-testing.md` with runner documentation, JSON result format, and CI information

Closes #100

## Test plan

- [ ] `./scripts/netem/runner.sh --list` lists both scenarios with descriptions and tags
- [ ] `./scripts/netem/runner.sh --help` shows usage information
- [ ] `./scripts/netem/runner.sh --scenario partition-recovery` runs the partition-recovery scenario
- [ ] `./scripts/netem/runner.sh --all --json-output` runs all scenarios and produces JSON results
- [ ] JSON result files are written to `./netem-results/` with correct format
- [ ] `bash -n scripts/netem/*.sh` passes syntax validation for all scripts
- [ ] `.github/workflows/netem.yml` is valid YAML
- [ ] All `.sh` files have executable permission

🤖 Generated with [Claude Code](https://claude.com/claude-code)