### PR TITLE
feat: add control-plane HTTP API (#96)

### DIFF
--- a/examples/benchmark.rs
+++ b/examples/benchmark.rs
@@ -9,6 +9,8 @@
 /// JSON output: `cargo run --example benchmark 2>/dev/null`
 use std::time::Instant;
 
+use std::sync::{Arc, RwLock};
+
 use asteroidb_poc::api::certified::{CertifiedApi, OnTimeout};
 use asteroidb_poc::api::eventual::EventualApi;
 use asteroidb_poc::authority::ack_frontier::AckFrontier;
@@ -49,13 +51,13 @@ fn make_frontier(authority: &str, physical: u64, prefix: &str) -> AckFrontier {
     }
 }
 
-fn default_namespace() -> SystemNamespace {
+fn default_namespace() -> Arc<RwLock<SystemNamespace>> {
     let mut ns = SystemNamespace::new();
     ns.set_authority_definition(AuthorityDefinition {
         key_range: kr(""),
         authority_nodes: vec![node("auth-1"), node("auth-2"), node("auth-3")],
     });
-    ns
+    Arc::new(RwLock::new(ns))
 }
 
 fn counter_value(n: i64) -> CrdtValue {

--- a/examples/demo_partition_recovery.rs
+++ b/examples/demo_partition_recovery.rs
@@ -4,6 +4,8 @@
 /// and recovery, demonstrating CRDT convergence and certified confirmation.
 ///
 /// Run: `cargo run --example demo_partition_recovery`
+use std::sync::{Arc, RwLock};
+
 use asteroidb_poc::api::certified::{CertifiedApi, OnTimeout};
 use asteroidb_poc::api::eventual::EventualApi;
 use asteroidb_poc::authority::ack_frontier::AckFrontier;
@@ -82,7 +84,7 @@ fn main() {
         },
         authority_nodes: vec![node_a.clone(), node_b.clone(), node_c.clone()],
     });
-    let mut certified_api = CertifiedApi::new(node_a.clone(), namespace);
+    let mut certified_api = CertifiedApi::new(node_a.clone(), Arc::new(RwLock::new(namespace)));
     println!("  Nodes: node-A, node-B, node-C");
     println!("  Authority set: all 3 nodes (majority = 2)");
     println!("  Key: \"sensor/temperature\" (PN-Counter)");

--- a/src/api/certified.rs
+++ b/src/api/certified.rs
@@ -1,3 +1,5 @@
+use std::sync::{Arc, RwLock};
+
 use crate::authority::ack_frontier::{AckFrontier, AckFrontierSet};
 use crate::control_plane::system_namespace::SystemNamespace;
 use crate::error::CrdtError;
@@ -80,7 +82,7 @@ pub struct CertifiedApi {
     store: Store,
     clock: Hlc,
     frontiers: AckFrontierSet,
-    namespace: SystemNamespace,
+    namespace: Arc<RwLock<SystemNamespace>>,
     pending_writes: Vec<PendingWrite>,
     retention: RetentionPolicy,
     /// Cumulative count of pending writes evicted due to `max_entries` pressure.
@@ -92,7 +94,7 @@ impl CertifiedApi {
     ///
     /// The `namespace` provides authority definitions for key-range-scoped
     /// certification decisions via longest-prefix match.
-    pub fn new(node_id: NodeId, namespace: SystemNamespace) -> Self {
+    pub fn new(node_id: NodeId, namespace: Arc<RwLock<SystemNamespace>>) -> Self {
         Self {
             store: Store::new(),
             clock: Hlc::new(node_id.0),
@@ -107,7 +109,7 @@ impl CertifiedApi {
     /// Create a new `CertifiedApi` with a custom retention policy.
     pub fn with_retention(
         node_id: NodeId,
-        namespace: SystemNamespace,
+        namespace: Arc<RwLock<SystemNamespace>>,
         retention: RetentionPolicy,
     ) -> Self {
         Self {
@@ -127,15 +129,15 @@ impl CertifiedApi {
     /// namespace. Returns the key range, current policy version, and total
     /// authority count for that range.
     fn resolve_scope(&self, key: &str) -> Result<(KeyRange, PolicyVersion, usize), CrdtError> {
-        let auth_def = self.namespace.get_authorities_for_key(key).ok_or_else(|| {
+        let ns = self.namespace.read().unwrap();
+        let auth_def = ns.get_authorities_for_key(key).ok_or_else(|| {
             CrdtError::PolicyDenied(format!("no authority definition for key: {key}"))
         })?;
 
         let key_range = auth_def.key_range.clone();
         let total = auth_def.authority_nodes.len();
 
-        let policy_version = self
-            .namespace
+        let policy_version = ns
             .get_placement_policy(&key_range.prefix)
             .map(|p| p.version)
             .unwrap_or(PolicyVersion(1));
@@ -410,8 +412,8 @@ impl CertifiedApi {
         self.evicted_count
     }
 
-    /// Return a reference to the system namespace.
-    pub fn namespace(&self) -> &SystemNamespace {
+    /// Return a reference to the shared system namespace.
+    pub fn namespace(&self) -> &Arc<RwLock<SystemNamespace>> {
         &self.namespace
     }
 
@@ -442,6 +444,10 @@ mod tests {
         KeyRange {
             prefix: prefix.into(),
         }
+    }
+
+    fn wrap_ns(ns: SystemNamespace) -> Arc<RwLock<SystemNamespace>> {
+        Arc::new(RwLock::new(ns))
     }
 
     fn make_frontier(authority: &str, physical: u64, logical: u32, prefix: &str) -> AckFrontier {
@@ -493,17 +499,17 @@ mod tests {
     /// Create a namespace with a single catch-all authority definition (prefix "")
     /// with 3 authorities. This preserves backward-compatible behaviour for
     /// existing tests.
-    fn default_namespace() -> SystemNamespace {
+    fn default_namespace() -> Arc<RwLock<SystemNamespace>> {
         make_namespace("", &["auth-1", "auth-2", "auth-3"])
     }
 
-    fn make_namespace(prefix: &str, authorities: &[&str]) -> SystemNamespace {
+    fn make_namespace(prefix: &str, authorities: &[&str]) -> Arc<RwLock<SystemNamespace>> {
         let mut ns = SystemNamespace::new();
         ns.set_authority_definition(AuthorityDefinition {
             key_range: kr(prefix),
             authority_nodes: authorities.iter().map(|a| node(a)).collect(),
         });
-        ns
+        wrap_ns(ns)
     }
 
     // ---------------------------------------------------------------
@@ -1037,7 +1043,7 @@ mod tests {
             authority_nodes: vec![node("auth-o1"), node("auth-o2"), node("auth-o3")],
         });
 
-        let mut api = CertifiedApi::new(node("node-1"), ns);
+        let mut api = CertifiedApi::new(node("node-1"), wrap_ns(ns));
 
         // Write to both ranges.
         api.certified_write("user/alice".into(), counter_value(1), OnTimeout::Pending)
@@ -1095,7 +1101,7 @@ mod tests {
             authority_nodes: vec![node("auth-o1"), node("auth-o2"), node("auth-o3")],
         });
 
-        let mut api = CertifiedApi::new(node("node-1"), ns);
+        let mut api = CertifiedApi::new(node("node-1"), wrap_ns(ns));
 
         // Set different frontier levels for each range.
         api.update_frontier(make_frontier("auth-u1", 100, 0, "user/"));
@@ -1131,7 +1137,7 @@ mod tests {
             PlacementPolicy::new(PolicyVersion(2), kr("data/"), 3).with_certified(true),
         );
 
-        let mut api = CertifiedApi::new(node("node-1"), ns);
+        let mut api = CertifiedApi::new(node("node-1"), wrap_ns(ns));
 
         // Write a key — should resolve to data/ with policy version 2.
         api.certified_write("data/sensor".into(), counter_value(42), OnTimeout::Pending)
@@ -1179,7 +1185,7 @@ mod tests {
             authority_nodes: vec![node("auth-v1"), node("auth-v2")],
         });
 
-        let mut api = CertifiedApi::new(node("node-1"), ns);
+        let mut api = CertifiedApi::new(node("node-1"), wrap_ns(ns));
 
         // Write to user/vip/alice — should resolve to user/vip/ (2 authorities).
         api.certified_write(
@@ -1256,7 +1262,7 @@ mod tests {
             max_age_ms: 5_000,
             max_entries: 10_000,
         };
-        let mut api = CertifiedApi::with_retention(node("node-1"), ns, policy);
+        let mut api = CertifiedApi::with_retention(node("node-1"), wrap_ns(ns), policy);
 
         // Write to cert/ range (will be certified).
         api.certified_write("cert/key1".into(), counter_value(1), OnTimeout::Pending)

--- a/src/http/handlers.rs
+++ b/src/http/handlers.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::sync::{Arc, RwLock};
 
 use axum::Json;
 use axum::extract::{Path, State};
@@ -6,21 +6,27 @@ use tokio::sync::Mutex;
 
 use crate::api::certified::{CertifiedApi, OnTimeout};
 use crate::api::eventual::EventualApi;
+use crate::control_plane::system_namespace::{AuthorityDefinition, SystemNamespace};
 use crate::crdt::pn_counter::PnCounter;
 use crate::error::CrdtError;
+use crate::placement::PlacementPolicy;
 use crate::store::kv::CrdtValue;
+use crate::types::{KeyRange, NodeId, PolicyVersion};
 
 use crate::network::sync::{KeyDumpResponse, SyncError, SyncRequest, SyncResponse};
 
 use super::types::{
-    ApiError, CertifiedReadResponse, CertifiedWriteRequest, CertifiedWriteResponse, CrdtValueJson,
-    EventualReadResponse, EventualWriteRequest, FrontierJson, StatusResponse, WriteResponse,
+    ApiError, AuthorityDefinitionResponse, CertifiedReadResponse, CertifiedWriteRequest,
+    CertifiedWriteResponse, CrdtValueJson, EventualReadResponse, EventualWriteRequest,
+    FrontierJson, PlacementPolicyResponse, SetAuthorityDefinitionRequest,
+    SetPlacementPolicyRequest, StatusResponse, VersionHistoryResponse, WriteResponse,
 };
 
 /// Shared application state for HTTP handlers.
 pub struct AppState {
     pub eventual: Mutex<EventualApi>,
     pub certified: Mutex<CertifiedApi>,
+    pub namespace: Arc<RwLock<SystemNamespace>>,
 }
 
 // ---------------------------------------------------------------
@@ -172,6 +178,207 @@ pub async fn get_internal_frontiers(
     let api = state.certified.lock().await;
     let frontiers = api.all_frontiers().into_iter().cloned().collect();
     Json(crate::network::frontier_sync::FrontierPullResponse { frontiers })
+}
+
+// ---------------------------------------------------------------
+// Control-plane handlers
+// ---------------------------------------------------------------
+
+/// `GET /api/control-plane/authorities`
+///
+/// Returns all authority definitions from the system namespace.
+pub async fn list_authorities(
+    State(state): State<Arc<AppState>>,
+) -> Json<Vec<AuthorityDefinitionResponse>> {
+    let ns = state.namespace.read().unwrap();
+    let defs: Vec<AuthorityDefinitionResponse> = ns
+        .all_authority_definitions()
+        .into_iter()
+        .map(|def| AuthorityDefinitionResponse {
+            key_range_prefix: def.key_range.prefix.clone(),
+            authority_nodes: def.authority_nodes.iter().map(|n| n.0.clone()).collect(),
+        })
+        .collect();
+    Json(defs)
+}
+
+/// `GET /api/control-plane/authorities/{prefix}`
+///
+/// Returns the authority definition for the given key range prefix.
+pub async fn get_authority_definition(
+    State(state): State<Arc<AppState>>,
+    Path(prefix): Path<String>,
+) -> Result<Json<AuthorityDefinitionResponse>, ApiError> {
+    let ns = state.namespace.read().unwrap();
+    let def = ns.get_authority_definition(&prefix).ok_or_else(|| {
+        ApiError(CrdtError::KeyNotFound(format!(
+            "authority definition: {prefix}"
+        )))
+    })?;
+    Ok(Json(AuthorityDefinitionResponse {
+        key_range_prefix: def.key_range.prefix.clone(),
+        authority_nodes: def.authority_nodes.iter().map(|n| n.0.clone()).collect(),
+    }))
+}
+
+/// `PUT /api/control-plane/authorities`
+///
+/// Sets an authority definition in the system namespace.
+pub async fn set_authority_definition(
+    State(state): State<Arc<AppState>>,
+    Json(req): Json<SetAuthorityDefinitionRequest>,
+) -> Json<AuthorityDefinitionResponse> {
+    let mut ns = state.namespace.write().unwrap();
+    let def = AuthorityDefinition {
+        key_range: KeyRange {
+            prefix: req.key_range_prefix.clone(),
+        },
+        authority_nodes: req
+            .authority_nodes
+            .iter()
+            .map(|n| NodeId(n.clone()))
+            .collect(),
+    };
+    ns.set_authority_definition(def);
+    Json(AuthorityDefinitionResponse {
+        key_range_prefix: req.key_range_prefix,
+        authority_nodes: req.authority_nodes,
+    })
+}
+
+/// `GET /api/control-plane/policies`
+///
+/// Returns all placement policies from the system namespace.
+pub async fn list_policies(
+    State(state): State<Arc<AppState>>,
+) -> Json<Vec<PlacementPolicyResponse>> {
+    let ns = state.namespace.read().unwrap();
+    let policies: Vec<PlacementPolicyResponse> = ns
+        .all_placement_policies()
+        .into_iter()
+        .map(|p| PlacementPolicyResponse {
+            key_range_prefix: p.key_range.prefix.clone(),
+            version: p.version.0,
+            replica_count: p.replica_count,
+            required_tags: p.required_tags.iter().map(|t| t.0.clone()).collect(),
+            forbidden_tags: p.forbidden_tags.iter().map(|t| t.0.clone()).collect(),
+            allow_local_write_on_partition: p.allow_local_write_on_partition,
+            certified: p.certified,
+        })
+        .collect();
+    Json(policies)
+}
+
+/// `GET /api/control-plane/policies/{prefix}`
+///
+/// Returns the placement policy for the given key range prefix.
+pub async fn get_policy(
+    State(state): State<Arc<AppState>>,
+    Path(prefix): Path<String>,
+) -> Result<Json<PlacementPolicyResponse>, ApiError> {
+    let ns = state.namespace.read().unwrap();
+    let p = ns.get_placement_policy(&prefix).ok_or_else(|| {
+        ApiError(CrdtError::KeyNotFound(format!(
+            "placement policy: {prefix}"
+        )))
+    })?;
+    Ok(Json(PlacementPolicyResponse {
+        key_range_prefix: p.key_range.prefix.clone(),
+        version: p.version.0,
+        replica_count: p.replica_count,
+        required_tags: p.required_tags.iter().map(|t| t.0.clone()).collect(),
+        forbidden_tags: p.forbidden_tags.iter().map(|t| t.0.clone()).collect(),
+        allow_local_write_on_partition: p.allow_local_write_on_partition,
+        certified: p.certified,
+    }))
+}
+
+/// `PUT /api/control-plane/policies`
+///
+/// Sets a placement policy in the system namespace.
+pub async fn set_placement_policy(
+    State(state): State<Arc<AppState>>,
+    Json(req): Json<SetPlacementPolicyRequest>,
+) -> Json<PlacementPolicyResponse> {
+    let mut ns = state.namespace.write().unwrap();
+    let current_version = ns.version().0;
+
+    let mut policy = PlacementPolicy::new(
+        PolicyVersion(current_version + 1),
+        KeyRange {
+            prefix: req.key_range_prefix.clone(),
+        },
+        req.replica_count,
+    );
+
+    if !req.required_tags.is_empty() {
+        policy = policy.with_required_tags(
+            req.required_tags
+                .iter()
+                .map(|t| crate::types::Tag(t.clone()))
+                .collect(),
+        );
+    }
+    if !req.forbidden_tags.is_empty() {
+        policy = policy.with_forbidden_tags(
+            req.forbidden_tags
+                .iter()
+                .map(|t| crate::types::Tag(t.clone()))
+                .collect(),
+        );
+    }
+    policy = policy.with_local_write_on_partition(req.allow_local_write_on_partition);
+    policy = policy.with_certified(req.certified);
+
+    let resp = PlacementPolicyResponse {
+        key_range_prefix: policy.key_range.prefix.clone(),
+        version: policy.version.0,
+        replica_count: policy.replica_count,
+        required_tags: req.required_tags,
+        forbidden_tags: req.forbidden_tags,
+        allow_local_write_on_partition: policy.allow_local_write_on_partition,
+        certified: policy.certified,
+    };
+
+    ns.set_placement_policy(policy);
+    Json(resp)
+}
+
+/// `DELETE /api/control-plane/policies/{prefix}`
+///
+/// Removes the placement policy for the given key range prefix.
+pub async fn remove_policy(
+    State(state): State<Arc<AppState>>,
+    Path(prefix): Path<String>,
+) -> Result<Json<PlacementPolicyResponse>, ApiError> {
+    let mut ns = state.namespace.write().unwrap();
+    let removed = ns.remove_placement_policy(&prefix).ok_or_else(|| {
+        ApiError(CrdtError::KeyNotFound(format!(
+            "placement policy: {prefix}"
+        )))
+    })?;
+    Ok(Json(PlacementPolicyResponse {
+        key_range_prefix: removed.key_range.prefix.clone(),
+        version: removed.version.0,
+        replica_count: removed.replica_count,
+        required_tags: removed.required_tags.iter().map(|t| t.0.clone()).collect(),
+        forbidden_tags: removed.forbidden_tags.iter().map(|t| t.0.clone()).collect(),
+        allow_local_write_on_partition: removed.allow_local_write_on_partition,
+        certified: removed.certified,
+    }))
+}
+
+/// `GET /api/control-plane/versions`
+///
+/// Returns the version history of the system namespace.
+pub async fn get_version_history(
+    State(state): State<Arc<AppState>>,
+) -> Json<VersionHistoryResponse> {
+    let ns = state.namespace.read().unwrap();
+    Json(VersionHistoryResponse {
+        current_version: ns.version().0,
+        history: ns.version_history().iter().map(|v| v.0).collect(),
+    })
 }
 
 // ---------------------------------------------------------------

--- a/src/http/routes.rs
+++ b/src/http/routes.rs
@@ -4,8 +4,10 @@ use axum::Router;
 use axum::routing::{get, post};
 
 use super::handlers::{
-    AppState, certified_write, eventual_write, get_certification_status, get_certified,
-    get_eventual, get_internal_frontiers, internal_keys, internal_sync, post_internal_frontiers,
+    AppState, certified_write, eventual_write, get_authority_definition, get_certification_status,
+    get_certified, get_eventual, get_internal_frontiers, get_policy, get_version_history,
+    internal_keys, internal_sync, list_authorities, list_policies, post_internal_frontiers,
+    remove_policy, set_authority_definition, set_placement_policy,
 };
 
 /// Build the HTTP API router with all endpoints.
@@ -22,6 +24,24 @@ pub fn router(state: Arc<AppState>) -> Router {
         )
         .route("/api/internal/sync", post(internal_sync))
         .route("/api/internal/keys", get(internal_keys))
+        // Control-plane endpoints
+        .route(
+            "/api/control-plane/authorities",
+            get(list_authorities).put(set_authority_definition),
+        )
+        .route(
+            "/api/control-plane/authorities/{prefix}",
+            get(get_authority_definition),
+        )
+        .route(
+            "/api/control-plane/policies",
+            get(list_policies).put(set_placement_policy),
+        )
+        .route(
+            "/api/control-plane/policies/{prefix}",
+            get(get_policy).delete(remove_policy),
+        )
+        .route("/api/control-plane/versions", get(get_version_history))
         .with_state(state)
 }
 
@@ -32,13 +52,15 @@ mod tests {
     use crate::api::eventual::EventualApi;
     use crate::control_plane::system_namespace::{AuthorityDefinition, SystemNamespace};
     use crate::http::types::{
-        CertifiedReadResponse, CertifiedWriteResponse, CrdtValueJson, EventualReadResponse,
-        StatusResponse, WriteResponse,
+        AuthorityDefinitionResponse, CertifiedReadResponse, CertifiedWriteResponse, CrdtValueJson,
+        EventualReadResponse, PlacementPolicyResponse, StatusResponse, VersionHistoryResponse,
+        WriteResponse,
     };
     use crate::types::{CertificationStatus, KeyRange, NodeId};
     use axum::body::Body;
     use axum::http::{Request, StatusCode};
     use http_body_util::BodyExt;
+    use std::sync::RwLock;
     use tokio::sync::Mutex;
     use tower::ServiceExt;
 
@@ -57,9 +79,12 @@ mod tests {
             ],
         });
 
+        let namespace = Arc::new(RwLock::new(ns));
+
         Arc::new(AppState {
             eventual: Mutex::new(EventualApi::new(node_id.clone())),
-            certified: Mutex::new(CertifiedApi::new(node_id, ns)),
+            certified: Mutex::new(CertifiedApi::new(node_id, Arc::clone(&namespace))),
+            namespace,
         })
     }
 
@@ -517,5 +542,289 @@ mod tests {
         let body = body_string(resp.into_body()).await;
         let read_resp: CertifiedReadResponse = serde_json::from_str(&body).unwrap();
         assert!(read_resp.value.is_some());
+    }
+
+    // ---------------------------------------------------------------
+    // Control-plane: Authority definitions
+    // ---------------------------------------------------------------
+
+    #[tokio::test]
+    async fn control_plane_list_authorities() {
+        let state = test_state();
+        let app = router(state);
+
+        let req = Request::builder()
+            .uri("/api/control-plane/authorities")
+            .body(Body::empty())
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let body = body_string(resp.into_body()).await;
+        let defs: Vec<AuthorityDefinitionResponse> = serde_json::from_str(&body).unwrap();
+        // test_state creates one catch-all authority definition
+        assert_eq!(defs.len(), 1);
+        assert_eq!(defs[0].key_range_prefix, "");
+        assert_eq!(defs[0].authority_nodes.len(), 3);
+    }
+
+    #[tokio::test]
+    async fn control_plane_set_and_get_authority() {
+        let state = test_state();
+        let app = router(state);
+
+        // Set a new authority definition
+        let req = Request::builder()
+            .method("PUT")
+            .uri("/api/control-plane/authorities")
+            .header("content-type", "application/json")
+            .body(Body::from(
+                r#"{"key_range_prefix":"user/","authority_nodes":["auth-u1","auth-u2"]}"#,
+            ))
+            .unwrap();
+
+        let resp = app.clone().oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let body = body_string(resp.into_body()).await;
+        let def: AuthorityDefinitionResponse = serde_json::from_str(&body).unwrap();
+        assert_eq!(def.key_range_prefix, "user/");
+        assert_eq!(def.authority_nodes, vec!["auth-u1", "auth-u2"]);
+
+        // Get it back
+        let req = Request::builder()
+            .uri("/api/control-plane/authorities/user%2F")
+            .body(Body::empty())
+            .unwrap();
+
+        let resp = app.clone().oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let body = body_string(resp.into_body()).await;
+        let def: AuthorityDefinitionResponse = serde_json::from_str(&body).unwrap();
+        assert_eq!(def.key_range_prefix, "user/");
+        assert_eq!(def.authority_nodes.len(), 2);
+
+        // List should now have 2 definitions
+        let req = Request::builder()
+            .uri("/api/control-plane/authorities")
+            .body(Body::empty())
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        let body = body_string(resp.into_body()).await;
+        let defs: Vec<AuthorityDefinitionResponse> = serde_json::from_str(&body).unwrap();
+        assert_eq!(defs.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn control_plane_get_nonexistent_authority() {
+        let state = test_state();
+        let app = router(state);
+
+        let req = Request::builder()
+            .uri("/api/control-plane/authorities/missing%2F")
+            .body(Body::empty())
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    // ---------------------------------------------------------------
+    // Control-plane: Placement policies
+    // ---------------------------------------------------------------
+
+    #[tokio::test]
+    async fn control_plane_set_and_get_policy() {
+        let state = test_state();
+        let app = router(state);
+
+        // Set a placement policy
+        let req = Request::builder()
+            .method("PUT")
+            .uri("/api/control-plane/policies")
+            .header("content-type", "application/json")
+            .body(Body::from(
+                r#"{"key_range_prefix":"user/","replica_count":3,"required_tags":["dc:tokyo"],"certified":true}"#,
+            ))
+            .unwrap();
+
+        let resp = app.clone().oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let body = body_string(resp.into_body()).await;
+        let policy: PlacementPolicyResponse = serde_json::from_str(&body).unwrap();
+        assert_eq!(policy.key_range_prefix, "user/");
+        assert_eq!(policy.replica_count, 3);
+        assert!(policy.certified);
+        assert_eq!(policy.required_tags, vec!["dc:tokyo"]);
+
+        // Get it back
+        let req = Request::builder()
+            .uri("/api/control-plane/policies/user%2F")
+            .body(Body::empty())
+            .unwrap();
+
+        let resp = app.clone().oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let body = body_string(resp.into_body()).await;
+        let policy: PlacementPolicyResponse = serde_json::from_str(&body).unwrap();
+        assert_eq!(policy.key_range_prefix, "user/");
+        assert_eq!(policy.replica_count, 3);
+    }
+
+    #[tokio::test]
+    async fn control_plane_list_policies_empty() {
+        let state = test_state();
+        let app = router(state);
+
+        let req = Request::builder()
+            .uri("/api/control-plane/policies")
+            .body(Body::empty())
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let body = body_string(resp.into_body()).await;
+        let policies: Vec<PlacementPolicyResponse> = serde_json::from_str(&body).unwrap();
+        assert!(policies.is_empty());
+    }
+
+    #[tokio::test]
+    async fn control_plane_remove_policy() {
+        let state = test_state();
+        let app = router(state);
+
+        // First set a policy
+        let req = Request::builder()
+            .method("PUT")
+            .uri("/api/control-plane/policies")
+            .header("content-type", "application/json")
+            .body(Body::from(
+                r#"{"key_range_prefix":"data/","replica_count":5}"#,
+            ))
+            .unwrap();
+        app.clone().oneshot(req).await.unwrap();
+
+        // Remove it
+        let req = Request::builder()
+            .method("DELETE")
+            .uri("/api/control-plane/policies/data%2F")
+            .body(Body::empty())
+            .unwrap();
+
+        let resp = app.clone().oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let body = body_string(resp.into_body()).await;
+        let removed: PlacementPolicyResponse = serde_json::from_str(&body).unwrap();
+        assert_eq!(removed.key_range_prefix, "data/");
+
+        // Should be gone now
+        let req = Request::builder()
+            .uri("/api/control-plane/policies/data%2F")
+            .body(Body::empty())
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn control_plane_remove_nonexistent_policy() {
+        let state = test_state();
+        let app = router(state);
+
+        let req = Request::builder()
+            .method("DELETE")
+            .uri("/api/control-plane/policies/missing%2F")
+            .body(Body::empty())
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    // ---------------------------------------------------------------
+    // Control-plane: Version history
+    // ---------------------------------------------------------------
+
+    #[tokio::test]
+    async fn control_plane_version_history() {
+        let state = test_state();
+        let app = router(state);
+
+        // Initial version history (namespace had 1 authority set → version 2)
+        let req = Request::builder()
+            .uri("/api/control-plane/versions")
+            .body(Body::empty())
+            .unwrap();
+
+        let resp = app.clone().oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let body = body_string(resp.into_body()).await;
+        let versions: VersionHistoryResponse = serde_json::from_str(&body).unwrap();
+        assert_eq!(versions.current_version, 2);
+        assert_eq!(versions.history, vec![1, 2]);
+
+        // Set a policy → version should increment
+        let req = Request::builder()
+            .method("PUT")
+            .uri("/api/control-plane/policies")
+            .header("content-type", "application/json")
+            .body(Body::from(
+                r#"{"key_range_prefix":"test/","replica_count":1}"#,
+            ))
+            .unwrap();
+        app.clone().oneshot(req).await.unwrap();
+
+        // Check version history again
+        let req = Request::builder()
+            .uri("/api/control-plane/versions")
+            .body(Body::empty())
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        let body = body_string(resp.into_body()).await;
+        let versions: VersionHistoryResponse = serde_json::from_str(&body).unwrap();
+        assert_eq!(versions.current_version, 3);
+        assert_eq!(versions.history, vec![1, 2, 3]);
+    }
+
+    #[tokio::test]
+    async fn control_plane_update_policy_increments_version() {
+        let state = test_state();
+        let app = router(state);
+
+        // Set policy twice → version should increment each time
+        for i in 0..2 {
+            let req = Request::builder()
+                .method("PUT")
+                .uri("/api/control-plane/policies")
+                .header("content-type", "application/json")
+                .body(Body::from(format!(
+                    r#"{{"key_range_prefix":"data/","replica_count":{}}}"#,
+                    i + 1
+                )))
+                .unwrap();
+            app.clone().oneshot(req).await.unwrap();
+        }
+
+        let req = Request::builder()
+            .uri("/api/control-plane/versions")
+            .body(Body::empty())
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        let body = body_string(resp.into_body()).await;
+        let versions: VersionHistoryResponse = serde_json::from_str(&body).unwrap();
+        // initial(1) + auth_def(2) + policy_set(3) + policy_set(4)
+        assert_eq!(versions.current_version, 4);
+        assert_eq!(versions.history.len(), 4);
     }
 }

--- a/src/http/types.rs
+++ b/src/http/types.rs
@@ -137,6 +137,62 @@ pub struct StatusResponse {
 }
 
 // ---------------------------------------------------------------
+// Control-plane request types
+// ---------------------------------------------------------------
+
+/// Request body for `PUT /api/control-plane/authorities`.
+#[derive(Debug, Deserialize)]
+pub struct SetAuthorityDefinitionRequest {
+    pub key_range_prefix: String,
+    pub authority_nodes: Vec<String>,
+}
+
+/// Request body for `PUT /api/control-plane/policies`.
+#[derive(Debug, Deserialize)]
+pub struct SetPlacementPolicyRequest {
+    pub key_range_prefix: String,
+    pub replica_count: usize,
+    #[serde(default)]
+    pub required_tags: Vec<String>,
+    #[serde(default)]
+    pub forbidden_tags: Vec<String>,
+    #[serde(default)]
+    pub allow_local_write_on_partition: bool,
+    #[serde(default)]
+    pub certified: bool,
+}
+
+// ---------------------------------------------------------------
+// Control-plane response types
+// ---------------------------------------------------------------
+
+/// Response for authority definition endpoints.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct AuthorityDefinitionResponse {
+    pub key_range_prefix: String,
+    pub authority_nodes: Vec<String>,
+}
+
+/// Response for placement policy endpoints.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct PlacementPolicyResponse {
+    pub key_range_prefix: String,
+    pub version: u64,
+    pub replica_count: usize,
+    pub required_tags: Vec<String>,
+    pub forbidden_tags: Vec<String>,
+    pub allow_local_write_on_partition: bool,
+    pub certified: bool,
+}
+
+/// Response for `GET /api/control-plane/versions`.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct VersionHistoryResponse {
+    pub current_version: u64,
+    pub history: Vec<u64>,
+}
+
+// ---------------------------------------------------------------
 // Error response
 // ---------------------------------------------------------------
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::sync::{Arc, RwLock};
 
 use tokio::sync::Mutex;
 
@@ -34,16 +34,19 @@ async fn main() {
         ],
     });
 
+    let namespace = Arc::new(RwLock::new(ns));
+
     // Build shared HTTP state.
     let state = Arc::new(AppState {
         eventual: Mutex::new(EventualApi::new(node_id.clone())),
-        certified: Mutex::new(CertifiedApi::new(node_id.clone(), ns.clone())),
+        certified: Mutex::new(CertifiedApi::new(node_id.clone(), Arc::clone(&namespace))),
+        namespace: Arc::clone(&namespace),
     });
 
     let app = router(state);
 
     // Build NodeRunner with its own CertifiedApi for background processing.
-    let runner_api = CertifiedApi::new(node_id.clone(), ns);
+    let runner_api = CertifiedApi::new(node_id.clone(), Arc::clone(&namespace));
     let engine = CompactionEngine::with_defaults();
     let mut runner = NodeRunner::new(node_id, runner_api, engine, NodeRunnerConfig::default());
     let shutdown_handle = runner.shutdown_handle();

--- a/src/ops/diagnostics.rs
+++ b/src/ops/diagnostics.rs
@@ -203,6 +203,8 @@ pub fn collect_node_diagnostics(
 
 #[cfg(test)]
 mod tests {
+    use std::sync::{Arc, RwLock};
+
     use super::*;
     use crate::api::certified::{CertifiedApi, OnTimeout, RetentionPolicy};
     use crate::authority::ack_frontier::{AckFrontier, AckFrontierSet};
@@ -248,13 +250,17 @@ mod tests {
         CrdtValue::Counter(counter)
     }
 
-    fn default_namespace() -> SystemNamespace {
+    fn wrap_ns(ns: SystemNamespace) -> Arc<RwLock<SystemNamespace>> {
+        Arc::new(RwLock::new(ns))
+    }
+
+    fn default_namespace() -> Arc<RwLock<SystemNamespace>> {
         let mut ns = SystemNamespace::new();
         ns.set_authority_definition(AuthorityDefinition {
             key_range: kr(""),
             authority_nodes: vec![node("auth-1"), node("auth-2"), node("auth-3")],
         });
-        ns
+        wrap_ns(ns)
     }
 
     // ---------------------------------------------------------------

--- a/src/runtime/node_runner.rs
+++ b/src/runtime/node_runner.rs
@@ -92,7 +92,10 @@ impl NodeRunner {
         compaction_engine: CompactionEngine,
         config: NodeRunnerConfig,
     ) -> Self {
-        let reporter = FrontierReporter::new(node_id.clone(), certified_api.namespace());
+        let reporter = {
+            let ns = certified_api.namespace().read().unwrap();
+            FrontierReporter::new(node_id.clone(), &ns)
+        };
         let frontier_reporter = if reporter.is_authority() {
             Some(reporter)
         } else {
@@ -126,7 +129,10 @@ impl NodeRunner {
         sync_client: SyncClient,
         eventual_api: Arc<Mutex<EventualApi>>,
     ) -> Self {
-        let reporter = FrontierReporter::new(node_id.clone(), certified_api.namespace());
+        let reporter = {
+            let ns = certified_api.namespace().read().unwrap();
+            FrontierReporter::new(node_id.clone(), &ns)
+        };
         let frontier_reporter = if reporter.is_authority() {
             Some(reporter)
         } else {
@@ -340,10 +346,10 @@ impl NodeRunner {
     fn check_compaction(&mut self) {
         let now = self.clock.now();
 
+        let ns = self.certified_api.namespace().read().unwrap();
+
         // Iterate over all authority definitions to check each key range.
-        let defs: Vec<_> = self
-            .certified_api
-            .namespace()
+        let defs: Vec<_> = ns
             .all_authority_definitions()
             .into_iter()
             .map(|def| (def.key_range.clone(), def.authority_nodes.len()))
@@ -354,9 +360,7 @@ impl NodeRunner {
                 // Create a checkpoint with a placeholder digest.
                 // In a full implementation this would compute an actual digest
                 // over the store data for this key range.
-                let policy_version = self
-                    .certified_api
-                    .namespace()
+                let policy_version = ns
                     .get_placement_policy(&key_range.prefix)
                     .map(|p| p.version)
                     .unwrap_or(crate::types::PolicyVersion(1));
@@ -384,6 +388,7 @@ mod tests {
     use crate::hlc::HlcTimestamp;
     use crate::store::kv::CrdtValue;
     use crate::types::{CertificationStatus, KeyRange, NodeId, PolicyVersion};
+    use std::sync::{Arc, RwLock};
 
     fn node_id(s: &str) -> NodeId {
         NodeId(s.into())
@@ -395,13 +400,17 @@ mod tests {
         }
     }
 
-    fn default_namespace() -> SystemNamespace {
+    fn wrap_ns(ns: SystemNamespace) -> Arc<RwLock<SystemNamespace>> {
+        Arc::new(RwLock::new(ns))
+    }
+
+    fn default_namespace() -> Arc<RwLock<SystemNamespace>> {
         let mut ns = SystemNamespace::new();
         ns.set_authority_definition(AuthorityDefinition {
             key_range: kr(""),
             authority_nodes: vec![node_id("auth-1"), node_id("auth-2"), node_id("auth-3")],
         });
-        ns
+        wrap_ns(ns)
     }
 
     fn counter_value(n: i64) -> CrdtValue {
@@ -555,7 +564,7 @@ mod tests {
             authority_nodes: vec![node_id("auth-1"), node_id("auth-2"), node_id("auth-3")],
         });
 
-        let api = CertifiedApi::new(node_id("node-1"), ns);
+        let api = CertifiedApi::new(node_id("node-1"), wrap_ns(ns));
 
         let compaction_config = CompactionConfig {
             time_threshold_ms: 10,
@@ -785,7 +794,7 @@ mod tests {
             authority_nodes: vec![node_id("auth-1")],
         });
 
-        let mut api = CertifiedApi::new(node_id("auth-1"), ns);
+        let mut api = CertifiedApi::new(node_id("auth-1"), wrap_ns(ns));
         api.certified_write("key1".into(), counter_value(1), OnTimeout::Pending)
             .unwrap();
         assert_eq!(api.pending_writes()[0].status, CertificationStatus::Pending);
@@ -828,7 +837,7 @@ mod tests {
             authority_nodes: vec![node_id("auth-1")],
         });
 
-        let mut api = CertifiedApi::new(node_id("auth-1"), ns);
+        let mut api = CertifiedApi::new(node_id("auth-1"), wrap_ns(ns));
 
         // Set a very high initial frontier manually.
         api.update_frontier(AckFrontier {

--- a/tests/anti_entropy_convergence.rs
+++ b/tests/anti_entropy_convergence.rs
@@ -4,7 +4,7 @@
 //! using the anti-entropy sync loop (push-based replication via HTTP).
 
 use std::collections::HashMap;
-use std::sync::Arc;
+use std::sync::{Arc, RwLock};
 use std::time::Duration;
 
 use asteroidb_poc::api::certified::CertifiedApi;
@@ -19,6 +19,10 @@ use asteroidb_poc::store::kv::CrdtValue;
 use asteroidb_poc::types::{KeyRange, NodeId};
 
 use tokio::sync::Mutex;
+
+fn wrap_ns(ns: SystemNamespace) -> Arc<RwLock<SystemNamespace>> {
+    Arc::new(RwLock::new(ns))
+}
 
 fn node_id(s: &str) -> NodeId {
     NodeId(s.into())
@@ -47,15 +51,19 @@ async fn two_node_anti_entropy_convergence() {
     let addr2 = listener2.local_addr().unwrap();
 
     // Build state for node 1.
+    let ns1 = wrap_ns(default_namespace());
     let state1 = Arc::new(AppState {
         eventual: Mutex::new(EventualApi::new(node_id("node-1"))),
-        certified: Mutex::new(CertifiedApi::new(node_id("node-1"), default_namespace())),
+        certified: Mutex::new(CertifiedApi::new(node_id("node-1"), Arc::clone(&ns1))),
+        namespace: ns1,
     });
 
     // Build state for node 2.
+    let ns2 = wrap_ns(default_namespace());
     let state2 = Arc::new(AppState {
         eventual: Mutex::new(EventualApi::new(node_id("node-2"))),
-        certified: Mutex::new(CertifiedApi::new(node_id("node-2"), default_namespace())),
+        certified: Mutex::new(CertifiedApi::new(node_id("node-2"), Arc::clone(&ns2))),
+        namespace: ns2,
     });
 
     // Write some data to node 1.
@@ -225,9 +233,11 @@ async fn pull_based_sync() {
     let addr = listener.local_addr().unwrap();
 
     // Build state with some data.
+    let ns_source = wrap_ns(default_namespace());
     let state = Arc::new(AppState {
         eventual: Mutex::new(EventualApi::new(node_id("source"))),
-        certified: Mutex::new(CertifiedApi::new(node_id("source"), default_namespace())),
+        certified: Mutex::new(CertifiedApi::new(node_id("source"), Arc::clone(&ns_source))),
+        namespace: ns_source,
     });
 
     {
@@ -272,9 +282,11 @@ async fn sync_endpoint_partial_failure() {
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();
 
+    let ns_target = wrap_ns(default_namespace());
     let state = Arc::new(AppState {
         eventual: Mutex::new(EventualApi::new(node_id("target"))),
-        certified: Mutex::new(CertifiedApi::new(node_id("target"), default_namespace())),
+        certified: Mutex::new(CertifiedApi::new(node_id("target"), Arc::clone(&ns_target))),
+        namespace: ns_target,
     });
 
     // Pre-populate with a counter at "k".
@@ -359,9 +371,11 @@ async fn three_node_convergence_via_sync() {
     let mut states = Vec::new();
     for i in 0..3 {
         let nid = node_id(&format!("node-{}", i + 1));
+        let ns_i = wrap_ns(default_namespace());
         let state = Arc::new(AppState {
             eventual: Mutex::new(EventualApi::new(nid.clone())),
-            certified: Mutex::new(CertifiedApi::new(nid, default_namespace())),
+            certified: Mutex::new(CertifiedApi::new(nid, Arc::clone(&ns_i))),
+            namespace: ns_i,
         });
         states.push(state);
     }
@@ -459,9 +473,11 @@ async fn internal_keys_endpoint() {
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();
 
+    let ns_keys = wrap_ns(default_namespace());
     let state = Arc::new(AppState {
         eventual: Mutex::new(EventualApi::new(node_id("node-1"))),
-        certified: Mutex::new(CertifiedApi::new(node_id("node-1"), default_namespace())),
+        certified: Mutex::new(CertifiedApi::new(node_id("node-1"), Arc::clone(&ns_keys))),
+        namespace: ns_keys,
     });
 
     {

--- a/tests/certification_worker.rs
+++ b/tests/certification_worker.rs
@@ -12,6 +12,7 @@
 //! 4. **Status tracking**: certification status transitions are observable
 //!    through the `CertifiedApi` and `CertificationTracker` APIs.
 
+use std::sync::{Arc, RwLock};
 use std::time::Duration;
 
 use asteroidb_poc::api::certified::{CertifiedApi, OnTimeout, RetentionPolicy};
@@ -25,6 +26,10 @@ use asteroidb_poc::hlc::HlcTimestamp;
 use asteroidb_poc::runtime::{NodeRunner, NodeRunnerConfig};
 use asteroidb_poc::store::kv::CrdtValue;
 use asteroidb_poc::types::{CertificationStatus, KeyRange, NodeId, PolicyVersion};
+
+fn wrap_ns(ns: SystemNamespace) -> Arc<RwLock<SystemNamespace>> {
+    Arc::new(RwLock::new(ns))
+}
 
 fn node_id(s: &str) -> NodeId {
     NodeId(s.into())
@@ -70,6 +75,10 @@ fn three_authority_namespace() -> SystemNamespace {
     ns
 }
 
+fn three_authority_namespace_shared() -> Arc<RwLock<SystemNamespace>> {
+    wrap_ns(three_authority_namespace())
+}
+
 /// Fast runner config with short intervals for testing.
 fn fast_config() -> NodeRunnerConfig {
     NodeRunnerConfig {
@@ -104,7 +113,7 @@ async fn three_authority_auto_certification() {
     assert!(reporter3.is_authority());
 
     // Client node: writes a pending entry.
-    let mut client_api = CertifiedApi::new(node_id("client"), ns);
+    let mut client_api = CertifiedApi::new(node_id("client"), wrap_ns(ns));
     client_api
         .certified_write("sensor/temp".into(), counter_value(42), OnTimeout::Pending)
         .unwrap();
@@ -158,7 +167,7 @@ async fn three_authority_auto_certification() {
 /// the network sync that would deliver them.
 #[tokio::test]
 async fn three_authority_node_runner_certification() {
-    let ns = three_authority_namespace();
+    let ns = three_authority_namespace_shared();
 
     // auth-1 is an authority node that also has the pending write.
     let mut api = CertifiedApi::new(node_id("auth-1"), ns);
@@ -209,7 +218,7 @@ async fn single_authority_self_certification() {
         authority_nodes: vec![node_id("auth-1")],
     });
 
-    let mut api = CertifiedApi::new(node_id("auth-1"), ns);
+    let mut api = CertifiedApi::new(node_id("auth-1"), wrap_ns(ns));
     api.certified_write("key1".into(), counter_value(10), OnTimeout::Pending)
         .unwrap();
     assert_eq!(
@@ -256,7 +265,7 @@ async fn timeout_auto_detection() {
         max_age_ms: 10, // Very short TTL for test.
         max_entries: 10_000,
     };
-    let ns = three_authority_namespace();
+    let ns = three_authority_namespace_shared();
     let mut api = CertifiedApi::with_retention(node_id("node-1"), ns, retention);
 
     api.certified_write("key1".into(), counter_value(1), OnTimeout::Pending)
@@ -303,8 +312,8 @@ async fn timeout_auto_detection() {
 /// status is observable through the API.
 #[tokio::test]
 async fn rejected_transition_observable() {
-    let ns = three_authority_namespace();
-    let mut api = CertifiedApi::new(node_id("node-1"), ns);
+    let ns = three_authority_namespace_shared();
+    let mut api = CertifiedApi::new(node_id("node-1"), Arc::clone(&ns));
 
     api.certified_write("key1".into(), counter_value(1), OnTimeout::Pending)
         .unwrap();
@@ -452,7 +461,7 @@ async fn status_tracker_mirrors_certification_flow() {
 /// Verifies the majority condition precisely.
 #[tokio::test]
 async fn majority_certification_requires_two_of_three() {
-    let ns = three_authority_namespace();
+    let ns = three_authority_namespace_shared();
     let mut api = CertifiedApi::new(node_id("node-1"), ns);
 
     api.certified_write("data/x".into(), counter_value(1), OnTimeout::Pending)
@@ -506,7 +515,7 @@ async fn mixed_outcomes_all_observable() {
         max_age_ms: 5_000,
         max_entries: 10_000,
     };
-    let mut api = CertifiedApi::with_retention(node_id("node-1"), ns, retention);
+    let mut api = CertifiedApi::with_retention(node_id("node-1"), wrap_ns(ns), retention);
 
     // Write 3 keys to different ranges.
     api.certified_write("cert/key".into(), counter_value(1), OnTimeout::Pending)
@@ -563,7 +572,7 @@ async fn cleanup_after_auto_certification() {
         authority_nodes: vec![node_id("auth-b1"), node_id("auth-b2"), node_id("auth-b3")],
     });
 
-    let mut api = CertifiedApi::new(node_id("node-1"), ns);
+    let mut api = CertifiedApi::new(node_id("node-1"), wrap_ns(ns));
 
     api.certified_write("a/key1".into(), counter_value(1), OnTimeout::Pending)
         .unwrap();

--- a/tests/e2e_multiprocess.rs
+++ b/tests/e2e_multiprocess.rs
@@ -10,7 +10,7 @@
 
 use std::collections::HashMap;
 use std::net::SocketAddr;
-use std::sync::Arc;
+use std::sync::{Arc, RwLock};
 use std::time::Duration;
 
 use asteroidb_poc::api::certified::CertifiedApi;
@@ -50,9 +50,11 @@ fn default_namespace() -> SystemNamespace {
 async fn spawn_node(name: &str) -> (Arc<AppState>, SocketAddr, JoinHandle<()>) {
     let nid = node_id(name);
 
+    let namespace = Arc::new(RwLock::new(default_namespace()));
     let state = Arc::new(AppState {
         eventual: Mutex::new(EventualApi::new(nid.clone())),
-        certified: Mutex::new(CertifiedApi::new(nid, default_namespace())),
+        certified: Mutex::new(CertifiedApi::new(nid, Arc::clone(&namespace))),
+        namespace,
     });
 
     let app = router(state.clone());

--- a/tests/http_server.rs
+++ b/tests/http_server.rs
@@ -1,6 +1,6 @@
 //! Integration tests for HTTP server startup, API access, and graceful shutdown.
 
-use std::sync::Arc;
+use std::sync::{Arc, RwLock};
 use std::time::Duration;
 
 use asteroidb_poc::api::certified::CertifiedApi;
@@ -26,9 +26,12 @@ fn test_state() -> Arc<AppState> {
         ],
     });
 
+    let namespace = Arc::new(RwLock::new(ns));
+
     Arc::new(AppState {
         eventual: Mutex::new(EventualApi::new(node_id.clone())),
-        certified: Mutex::new(CertifiedApi::new(node_id, ns)),
+        certified: Mutex::new(CertifiedApi::new(node_id, Arc::clone(&namespace))),
+        namespace,
     })
 }
 

--- a/tests/integration/authority_certified_flow.rs
+++ b/tests/integration/authority_certified_flow.rs
@@ -1,3 +1,5 @@
+use std::sync::{Arc, RwLock};
+
 use asteroidb_poc::api::certified::{CertifiedApi, OnTimeout};
 use asteroidb_poc::api::status::{CertificationTracker, WriteId};
 use asteroidb_poc::authority::ack_frontier::{AckFrontier, AckFrontierSet};
@@ -78,21 +80,25 @@ fn make_key_pair() -> (SigningKey, ed25519_dalek::VerifyingKey) {
     (sk, vk)
 }
 
+fn wrap_ns(ns: SystemNamespace) -> Arc<RwLock<SystemNamespace>> {
+    Arc::new(RwLock::new(ns))
+}
+
 /// Create a namespace with a catch-all authority definition (prefix "").
-fn default_namespace() -> SystemNamespace {
+fn default_namespace() -> Arc<RwLock<SystemNamespace>> {
     make_namespace("", &["auth-1", "auth-2", "auth-3"])
 }
 
-fn make_namespace(prefix: &str, authorities: &[&str]) -> SystemNamespace {
+fn make_namespace(prefix: &str, authorities: &[&str]) -> Arc<RwLock<SystemNamespace>> {
     let mut ns = SystemNamespace::new();
     ns.set_authority_definition(AuthorityDefinition {
         key_range: key_range(prefix),
         authority_nodes: authorities.iter().map(|a| node(a)).collect(),
     });
-    ns
+    wrap_ns(ns)
 }
 
-fn five_auth_namespace() -> SystemNamespace {
+fn five_auth_namespace() -> Arc<RwLock<SystemNamespace>> {
     make_namespace("", &["auth-1", "auth-2", "auth-3", "auth-4", "auth-5"])
 }
 
@@ -887,7 +893,7 @@ fn cross_range_certification_contamination_prevented() {
         authority_nodes: vec![node("auth-o1"), node("auth-o2"), node("auth-o3")],
     });
 
-    let mut api = CertifiedApi::new(node("node-1"), ns);
+    let mut api = CertifiedApi::new(node("node-1"), wrap_ns(ns));
 
     // Write to both ranges.
     api.certified_write("user/alice".into(), counter_value(10), OnTimeout::Pending)
@@ -960,7 +966,7 @@ fn policy_version_transition_certification() {
         PlacementPolicy::new(PolicyVersion(2), key_range("data/"), 3).with_certified(true),
     );
 
-    let mut api = CertifiedApi::new(node("node-1"), ns);
+    let mut api = CertifiedApi::new(node("node-1"), wrap_ns(ns));
 
     // Write resolves to data/ with policy version 2.
     api.certified_write("data/sensor".into(), counter_value(42), OnTimeout::Pending)
@@ -1005,7 +1011,7 @@ fn longest_prefix_authority_resolution_in_integration() {
         authority_nodes: vec![node("auth-v1"), node("auth-v2")],
     });
 
-    let mut api = CertifiedApi::new(node("node-1"), ns);
+    let mut api = CertifiedApi::new(node("node-1"), wrap_ns(ns));
 
     // VIP key — resolves to user/vip/ with 2 authorities (majority = 2).
     api.certified_write(

--- a/tests/integration/quorum_safety_regression.rs
+++ b/tests/integration/quorum_safety_regression.rs
@@ -6,6 +6,8 @@
 //! - #42: MajorityCertificate and CertificationTracker unique-authority quorum
 //! - #43: CertifiedApi pending_writes retention/cleanup
 
+use std::sync::{Arc, RwLock};
+
 use asteroidb_poc::api::certified::{CertifiedApi, OnTimeout, RetentionPolicy};
 use asteroidb_poc::api::status::{CertificationTracker, WriteId};
 use asteroidb_poc::authority::ack_frontier::{AckFrontier, AckFrontierSet, FrontierScope};
@@ -86,15 +88,19 @@ fn counter_value(n: i64) -> CrdtValue {
     CrdtValue::Counter(counter)
 }
 
+fn wrap_ns(ns: SystemNamespace) -> Arc<RwLock<SystemNamespace>> {
+    Arc::new(RwLock::new(ns))
+}
+
 /// Create a default SystemNamespace with a single authority definition
 /// covering the empty prefix (all keys), with 3 authority nodes.
-fn default_namespace() -> SystemNamespace {
+fn default_namespace() -> Arc<RwLock<SystemNamespace>> {
     let mut ns = SystemNamespace::new();
     ns.set_authority_definition(AuthorityDefinition {
         key_range: key_range(""),
         authority_nodes: vec![node("auth-1"), node("auth-2"), node("auth-3")],
     });
-    ns
+    wrap_ns(ns)
 }
 
 fn make_key_pair() -> (SigningKey, ed25519_dalek::VerifyingKey) {

--- a/tests/partition_tolerance.rs
+++ b/tests/partition_tolerance.rs
@@ -8,6 +8,8 @@
 //! Node topology: 3 nodes {A, B, C} with 3 Authority nodes {auth-1, auth-2, auth-3}.
 //! Partition: {A, B} vs {C}.
 
+use std::sync::{Arc, RwLock};
+
 use asteroidb_poc::api::certified::{CertifiedApi, OnTimeout};
 use asteroidb_poc::api::eventual::EventualApi;
 use asteroidb_poc::authority::ack_frontier::{AckFrontier, AckFrontierSet};
@@ -51,14 +53,18 @@ fn make_frontier(authority: &str, physical: u64, logical: u32, prefix: &str) -> 
     }
 }
 
+fn wrap_ns(ns: SystemNamespace) -> Arc<RwLock<SystemNamespace>> {
+    Arc::new(RwLock::new(ns))
+}
+
 /// Create a namespace with a catch-all authority definition (prefix "").
-fn default_namespace() -> SystemNamespace {
+fn default_namespace() -> Arc<RwLock<SystemNamespace>> {
     let mut ns = SystemNamespace::new();
     ns.set_authority_definition(AuthorityDefinition {
         key_range: KeyRange { prefix: "".into() },
         authority_nodes: vec![node("auth-1"), node("auth-2"), node("auth-3")],
     });
-    ns
+    wrap_ns(ns)
 }
 
 /// Bidirectional merge between two EventualApi nodes for a single key.


### PR DESCRIPTION
## Summary
- Add HTTP endpoints for managing authority definitions, placement policies, and version history
- Share `SystemNamespace` via `Arc<RwLock<SystemNamespace>>` between HTTP handlers and NodeRunner
- 8 new handlers: list/set/get authorities, list/set/get/remove policies, version history
- Update all existing tests and examples to use shared namespace pattern

Closes #96

## Test plan
- [x] All existing tests pass (476 lib + integration)
- [x] 9 new route tests for control-plane endpoints
- [x] `cargo fmt --check && cargo clippy -- -D warnings && cargo test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)