### PR TITLE
fix: prevent O(n) DoS in counter JSON conversion

### DIFF
--- a/src/crdt/pn_counter.rs
+++ b/src/crdt/pn_counter.rs
@@ -28,6 +28,20 @@ impl PnCounter {
         }
     }
 
+    /// Create a counter pre-initialized with the given value for the specified node.
+    ///
+    /// This is O(1) unlike repeated `increment`/`decrement` calls, which would
+    /// be O(|value|) and susceptible to DoS for large magnitudes.
+    pub fn from_value(node: &NodeId, value: i64) -> Self {
+        let mut counter = PnCounter::new();
+        if value >= 0 {
+            counter.p.insert(node.clone(), value as u64);
+        } else {
+            counter.n.insert(node.clone(), value.unsigned_abs());
+        }
+        counter
+    }
+
     /// Increment the counter for the given node.
     pub fn increment(&mut self, node_id: &NodeId) {
         *self.p.entry(node_id.clone()).or_insert(0) += 1;
@@ -283,5 +297,64 @@ mod tests {
     fn default_is_zero() {
         let counter = PnCounter::default();
         assert_eq!(counter.value(), 0);
+    }
+
+    #[test]
+    fn from_value_positive() {
+        let n = node("node-a");
+        let counter = PnCounter::from_value(&n, 42);
+        assert_eq!(counter.value(), 42);
+    }
+
+    #[test]
+    fn from_value_negative() {
+        let n = node("node-a");
+        let counter = PnCounter::from_value(&n, -7);
+        assert_eq!(counter.value(), -7);
+    }
+
+    #[test]
+    fn from_value_zero() {
+        let n = node("node-a");
+        let counter = PnCounter::from_value(&n, 0);
+        assert_eq!(counter.value(), 0);
+    }
+
+    #[test]
+    fn from_value_large_positive() {
+        let n = node("node-a");
+        let counter = PnCounter::from_value(&n, 999_999_999);
+        assert_eq!(counter.value(), 999_999_999);
+    }
+
+    #[test]
+    fn from_value_large_negative() {
+        let n = node("node-a");
+        let counter = PnCounter::from_value(&n, -999_999_999);
+        assert_eq!(counter.value(), -999_999_999);
+    }
+
+    #[test]
+    fn from_value_merges_with_incremented() {
+        let na = node("node-a");
+        let nb = node("node-b");
+
+        // Build one counter via from_value, another via increment.
+        let counter_a = PnCounter::from_value(&na, 100);
+
+        let mut counter_b = PnCounter::new();
+        for _ in 0..5 {
+            counter_b.increment(&nb);
+        }
+        counter_b.decrement(&nb); // net +4
+
+        let mut merged = counter_a.clone();
+        merged.merge(&counter_b);
+        assert_eq!(merged.value(), 104);
+
+        // Commutativity: merge the other direction.
+        let mut merged_rev = counter_b.clone();
+        merged_rev.merge(&counter_a);
+        assert_eq!(merged_rev.value(), 104);
     }
 }

--- a/src/http/handlers.rs
+++ b/src/http/handlers.rs
@@ -511,11 +511,18 @@ pub async fn get_metrics(State(state): State<Arc<AppState>>) -> Json<MetricsSnap
 // Helpers
 // ---------------------------------------------------------------
 
+/// Maximum allowed absolute value for counter initialization via HTTP API.
+///
+/// Values exceeding this limit are rejected with `InvalidArgument` to prevent
+/// resource exhaustion. This is a defense-in-depth measure; the O(1) constructor
+/// already prevents CPU-based DoS.
+const MAX_COUNTER_MAGNITUDE: i64 = 1_000_000_000;
+
 /// Convert a JSON CRDT value representation into an internal `CrdtValue`.
 ///
-/// For Counter, creates a PnCounter with the specified value by incrementing
-/// a synthetic writer node. For Set/Map/Register, constructs the appropriate
-/// CRDT type from the provided data.
+/// For Counter, creates a PnCounter with the specified value using O(1)
+/// `PnCounter::from_value` (not by looping). For Set/Map/Register,
+/// constructs the appropriate CRDT type from the provided data.
 fn json_to_crdt_value(json: &CrdtValueJson) -> Result<CrdtValue, CrdtError> {
     use crate::crdt::lww_register::LwwRegister;
     use crate::crdt::or_map::OrMap;
@@ -527,16 +534,13 @@ fn json_to_crdt_value(json: &CrdtValueJson) -> Result<CrdtValue, CrdtError> {
 
     match json {
         CrdtValueJson::Counter { value } => {
-            let mut counter = PnCounter::new();
-            if *value >= 0 {
-                for _ in 0..*value {
-                    counter.increment(&writer);
-                }
-            } else {
-                for _ in 0..value.unsigned_abs() {
-                    counter.decrement(&writer);
-                }
+            if value.unsigned_abs() > MAX_COUNTER_MAGNITUDE as u64 {
+                return Err(CrdtError::InvalidArgument(format!(
+                    "counter magnitude {} exceeds maximum allowed value {MAX_COUNTER_MAGNITUDE}",
+                    value.unsigned_abs()
+                )));
             }
+            let counter = PnCounter::from_value(&writer, *value);
             Ok(CrdtValue::Counter(counter))
         }
         CrdtValueJson::Set { elements } => {
@@ -654,6 +658,71 @@ mod tests {
                 assert_eq!(r.get(), None);
             }
             other => panic!("expected Register, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn json_to_crdt_counter_large_value_is_o1() {
+        // This would take O(999_999_999) iterations with the old loop-based
+        // approach. With from_value it completes instantly.
+        let json = CrdtValueJson::Counter { value: 999_999_999 };
+        let val = json_to_crdt_value(&json).unwrap();
+        match val {
+            CrdtValue::Counter(c) => assert_eq!(c.value(), 999_999_999),
+            other => panic!("expected Counter, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn json_to_crdt_counter_large_negative_is_o1() {
+        let json = CrdtValueJson::Counter {
+            value: -999_999_999,
+        };
+        let val = json_to_crdt_value(&json).unwrap();
+        match val {
+            CrdtValue::Counter(c) => assert_eq!(c.value(), -999_999_999),
+            other => panic!("expected Counter, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn json_to_crdt_counter_exceeds_max_magnitude() {
+        let json = CrdtValueJson::Counter {
+            value: 1_000_000_001,
+        };
+        let err = json_to_crdt_value(&json).unwrap_err();
+        match err {
+            CrdtError::InvalidArgument(msg) => {
+                assert!(msg.contains("exceeds maximum"), "unexpected message: {msg}");
+            }
+            other => panic!("expected InvalidArgument, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn json_to_crdt_counter_negative_exceeds_max_magnitude() {
+        let json = CrdtValueJson::Counter {
+            value: -1_000_000_001,
+        };
+        let err = json_to_crdt_value(&json).unwrap_err();
+        match err {
+            CrdtError::InvalidArgument(msg) => {
+                assert!(msg.contains("exceeds maximum"), "unexpected message: {msg}");
+            }
+            other => panic!("expected InvalidArgument, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn json_to_crdt_counter_at_max_magnitude_is_ok() {
+        // Exactly at the boundary should succeed.
+        let json = CrdtValueJson::Counter {
+            value: 1_000_000_000,
+        };
+        let val = json_to_crdt_value(&json).unwrap();
+        match val {
+            CrdtValue::Counter(c) => assert_eq!(c.value(), 1_000_000_000),
+            other => panic!("expected Counter, got {other:?}"),
         }
     }
 }


### PR DESCRIPTION
## Summary

- Add `PnCounter::from_value(node, i64)` constructor that initializes counters in O(1) instead of looping O(|value|) times via increment/decrement
- Replace the vulnerable loop in `json_to_crdt_value` with the new O(1) constructor
- Add `MAX_COUNTER_MAGNITUDE` (1 billion) validation as defense-in-depth, rejecting out-of-range values with `InvalidArgument`

Closes #104

## Test plan

- [x] Unit tests for `PnCounter::from_value` with positive, negative, zero, and large values
- [x] Unit test verifying `from_value` counters merge correctly with increment-based counters (commutativity)
- [x] Handler test: large counter values (999M) are handled instantly (O(1))
- [x] Handler test: values exceeding max magnitude return `InvalidArgument` error
- [x] Handler test: values exactly at boundary (1B) succeed
- [x] All existing tests continue to pass
- [x] CI gate passes: `cargo fmt --check && cargo clippy -- -D warnings && cargo test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)