### PR TITLE
fix: validate on_timeout parameter in certified_write handler

### DIFF
--- a/src/http/handlers.rs
+++ b/src/http/handlers.rs
@@ -102,7 +102,12 @@ pub async fn certified_write(
 ) -> Result<Json<CertifiedWriteResponse>, ApiError> {
     let on_timeout = match req.on_timeout.as_str() {
         "error" => OnTimeout::Error,
-        _ => OnTimeout::Pending,
+        "pending" => OnTimeout::Pending,
+        other => {
+            return Err(ApiError(CrdtError::InvalidArgument(format!(
+                "invalid on_timeout value: {other}; expected \"error\" or \"pending\""
+            ))));
+        }
     };
 
     let crdt_value = json_to_crdt_value(&req.value)?;

--- a/tests/http_server.rs
+++ b/tests/http_server.rs
@@ -147,3 +147,104 @@ async fn server_graceful_shutdown_via_abort() {
         .await;
     assert!(result.is_err(), "expected connection error after shutdown");
 }
+
+#[tokio::test]
+async fn certified_write_rejects_invalid_on_timeout() {
+    let state = test_state();
+    let app = router(state);
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    let server = tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    let client = reqwest::Client::new();
+
+    // "bogus" should be rejected.
+    let resp = client
+        .post(format!("http://{addr}/api/certified/write"))
+        .header("content-type", "application/json")
+        .body(r#"{"key":"k","value":{"type":"counter","value":1},"on_timeout":"bogus"}"#)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 400);
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(body["error_code"], "INVALID_ARGUMENT");
+    assert!(
+        body["message"]
+            .as_str()
+            .unwrap()
+            .contains("invalid on_timeout value"),
+        "expected descriptive error message, got: {}",
+        body["message"]
+    );
+
+    // "ERROR" (wrong case) should also be rejected.
+    let resp = client
+        .post(format!("http://{addr}/api/certified/write"))
+        .header("content-type", "application/json")
+        .body(r#"{"key":"k","value":{"type":"counter","value":1},"on_timeout":"ERROR"}"#)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 400);
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(body["error_code"], "INVALID_ARGUMENT");
+
+    server.abort();
+}
+
+#[tokio::test]
+async fn certified_write_accepts_valid_on_timeout_values() {
+    let state = test_state();
+    let app = router(state);
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    let server = tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    let client = reqwest::Client::new();
+
+    // "error" should be accepted (returns 504 because certification is not
+    // immediately available, which is the correct OnTimeout::Error behaviour).
+    let resp = client
+        .post(format!("http://{addr}/api/certified/write"))
+        .header("content-type", "application/json")
+        .body(r#"{"key":"k1","value":{"type":"counter","value":1},"on_timeout":"error"}"#)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 504);
+
+    // "pending" should be accepted.
+    let resp = client
+        .post(format!("http://{addr}/api/certified/write"))
+        .header("content-type", "application/json")
+        .body(r#"{"key":"k2","value":{"type":"counter","value":1},"on_timeout":"pending"}"#)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+
+    // Omitted on_timeout should default to "pending" and succeed.
+    let resp = client
+        .post(format!("http://{addr}/api/certified/write"))
+        .header("content-type", "application/json")
+        .body(r#"{"key":"k3","value":{"type":"counter","value":1}}"#)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+
+    server.abort();
+}


### PR DESCRIPTION
## Summary

- Reject invalid `on_timeout` values in `certified_write` handler with `INVALID_ARGUMENT` (400) error instead of silently defaulting to `Pending`
- Only `"error"`, `"pending"`, and omitted (defaults to `"pending"`) are accepted
- Add integration tests for invalid values (`"bogus"`, `"ERROR"`) and valid values (`"error"`, `"pending"`, omitted)

Closes #103

## Test plan

- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test` passes (all 503+ tests)
- [x] New test: `"bogus"` on_timeout returns 400 with `INVALID_ARGUMENT`
- [x] New test: `"ERROR"` (wrong case) returns 400 with `INVALID_ARGUMENT`
- [x] Existing test: `"error"` on_timeout accepted (returns 504 per OnTimeout::Error semantics)
- [x] Existing test: `"pending"` on_timeout accepted (returns 200)
- [x] Existing test: omitted on_timeout defaults to pending (returns 200)

🤖 Generated with [Claude Code](https://claude.com/claude-code)