### PR TITLE
fix: frontier push response overcounts accepted updates

### DIFF
--- a/src/api/certified.rs
+++ b/src/api/certified.rs
@@ -338,9 +338,11 @@ impl CertifiedApi {
 
     /// Update an Authority's ack frontier.
     ///
-    /// Simulates receiving an ack from an Authority node.
-    pub fn update_frontier(&mut self, frontier: AckFrontier) {
-        self.frontiers.update(frontier);
+    /// Simulates receiving an ack from an Authority node. Returns `true` if
+    /// the frontier was actually advanced, `false` if the update was
+    /// stale or duplicate.
+    pub fn update_frontier(&mut self, frontier: AckFrontier) -> bool {
+        self.frontiers.update(frontier)
     }
 
     /// Re-evaluate all pending writes against the current frontiers.

--- a/src/authority/ack_frontier.rs
+++ b/src/authority/ack_frontier.rs
@@ -118,14 +118,19 @@ impl AckFrontierSet {
     /// The scope key `{key_range, policy_version, authority_id}` is derived
     /// from the frontier itself. Only advances the frontier forward within
     /// its scope; an older `frontier_hlc` is ignored to prevent regression.
-    pub fn update(&mut self, frontier: AckFrontier) {
+    ///
+    /// Returns `true` if the frontier was actually advanced (inserted or
+    /// updated), `false` if the update was stale or duplicate.
+    pub fn update(&mut self, frontier: AckFrontier) -> bool {
         let scope = FrontierScope::from_frontier(&frontier);
         match self.frontiers.get(&scope) {
             Some(existing) if existing.frontier_hlc >= frontier.frontier_hlc => {
                 // Existing frontier is same or newer; ignore the update.
+                false
             }
             _ => {
                 self.frontiers.insert(scope, frontier);
+                true
             }
         }
     }
@@ -994,5 +999,46 @@ mod tests {
             err_msg.contains("scope mismatch"),
             "expected scope mismatch error, got: {err_msg}"
         );
+    }
+
+    // ---------------------------------------------------------------
+    // update() return value tests (#105)
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn update_new_frontier_returns_true() {
+        let mut set = AckFrontierSet::new();
+        let f = make_frontier("auth-1", 100, 0, "user/");
+        assert!(set.update(f), "inserting a new frontier should return true");
+    }
+
+    #[test]
+    fn update_stale_frontier_returns_false() {
+        let mut set = AckFrontierSet::new();
+        set.update(make_frontier("auth-1", 200, 0, "user/"));
+
+        // Submitting an older frontier should return false.
+        let stale = make_frontier("auth-1", 100, 0, "user/");
+        assert!(!set.update(stale), "stale frontier should return false");
+    }
+
+    #[test]
+    fn update_duplicate_frontier_returns_false() {
+        let mut set = AckFrontierSet::new();
+        set.update(make_frontier("auth-1", 100, 0, "user/"));
+
+        // Submitting the same frontier again should return false.
+        let dup = make_frontier("auth-1", 100, 0, "user/");
+        assert!(!set.update(dup), "duplicate frontier should return false");
+    }
+
+    #[test]
+    fn update_newer_frontier_returns_true() {
+        let mut set = AckFrontierSet::new();
+        set.update(make_frontier("auth-1", 100, 0, "user/"));
+
+        // Submitting a newer frontier should return true.
+        let newer = make_frontier("auth-1", 200, 0, "user/");
+        assert!(set.update(newer), "advancing frontier should return true");
     }
 }

--- a/src/http/handlers.rs
+++ b/src/http/handlers.rs
@@ -183,8 +183,9 @@ pub async fn post_internal_frontiers(
     let mut api = state.certified.lock().await;
     let mut accepted = 0;
     for frontier in req.frontiers {
-        api.update_frontier(frontier);
-        accepted += 1;
+        if api.update_frontier(frontier) {
+            accepted += 1;
+        }
     }
     Json(crate::network::frontier_sync::FrontierPushResponse { accepted })
 }

--- a/src/http/routes.rs
+++ b/src/http/routes.rs
@@ -1111,4 +1111,88 @@ mod tests {
         assert_eq!(result.contributing_count, 1);
         assert_eq!(result.required_count, 3);
     }
+
+    // ---------------------------------------------------------------
+    // Internal frontier push: accepted count reflects actual changes (#105)
+    // ---------------------------------------------------------------
+
+    #[tokio::test]
+    async fn post_internal_frontiers_accepted_counts_actual_changes() {
+        use crate::network::frontier_sync::FrontierPushResponse;
+
+        let state = test_state();
+        let app = router(state);
+
+        let frontier_json = r#"{
+            "frontiers": [
+                {
+                    "authority_id": "auth-1",
+                    "frontier_hlc": {"physical": 100, "logical": 0, "node_id": "auth-1"},
+                    "key_range": {"prefix": ""},
+                    "policy_version": 1,
+                    "digest_hash": "h1"
+                }
+            ]
+        }"#;
+
+        // First push: frontier is new, accepted should be 1.
+        let req = Request::builder()
+            .method("POST")
+            .uri("/api/internal/frontiers")
+            .header("content-type", "application/json")
+            .body(Body::from(frontier_json))
+            .unwrap();
+
+        let resp = app.clone().oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let body = body_string(resp.into_body()).await;
+        let result: FrontierPushResponse = serde_json::from_str(&body).unwrap();
+        assert_eq!(result.accepted, 1, "new frontier should be accepted");
+
+        // Second push: same frontier (stale/duplicate), accepted should be 0.
+        let req = Request::builder()
+            .method("POST")
+            .uri("/api/internal/frontiers")
+            .header("content-type", "application/json")
+            .body(Body::from(frontier_json))
+            .unwrap();
+
+        let resp = app.clone().oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let body = body_string(resp.into_body()).await;
+        let result: FrontierPushResponse = serde_json::from_str(&body).unwrap();
+        assert_eq!(
+            result.accepted, 0,
+            "duplicate frontier should not be accepted"
+        );
+
+        // Third push: newer frontier, accepted should be 1.
+        let newer_json = r#"{
+            "frontiers": [
+                {
+                    "authority_id": "auth-1",
+                    "frontier_hlc": {"physical": 200, "logical": 0, "node_id": "auth-1"},
+                    "key_range": {"prefix": ""},
+                    "policy_version": 1,
+                    "digest_hash": "h2"
+                }
+            ]
+        }"#;
+
+        let req = Request::builder()
+            .method("POST")
+            .uri("/api/internal/frontiers")
+            .header("content-type", "application/json")
+            .body(Body::from(newer_json))
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let body = body_string(resp.into_body()).await;
+        let result: FrontierPushResponse = serde_json::from_str(&body).unwrap();
+        assert_eq!(result.accepted, 1, "newer frontier should be accepted");
+    }
 }


### PR DESCRIPTION
## Summary

- `AckFrontierSet::update()` now returns `bool` indicating whether the frontier was actually advanced (inserted or updated) vs stale/duplicate
- `CertifiedApi::update_frontier()` propagates the return value
- `POST /api/internal/frontiers` handler only increments `accepted` count when `update_frontier()` returns `true`

Closes #105

## Test plan

- [x] Unit test: `update_new_frontier_returns_true` -- inserting a brand-new frontier returns true
- [x] Unit test: `update_stale_frontier_returns_false` -- submitting an older frontier returns false
- [x] Unit test: `update_duplicate_frontier_returns_false` -- submitting the exact same frontier returns false
- [x] Unit test: `update_newer_frontier_returns_true` -- advancing the frontier returns true
- [x] HTTP test: `post_internal_frontiers_accepted_counts_actual_changes` -- push same frontier twice, accepted is 1 not 2; push newer frontier, accepted increments
- [x] CI gate passes: `cargo fmt --check && cargo clippy -- -D warnings && cargo test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)