### PR TITLE
feat: add policy version safe transition

### DIFF
--- a/src/api/certified.rs
+++ b/src/api/certified.rs
@@ -479,6 +479,20 @@ impl CertifiedApi {
     pub fn all_frontiers(&self) -> Vec<&AckFrontier> {
         self.frontiers.all()
     }
+
+    /// Fence a (key_range, policy_version) pair in the frontier set.
+    ///
+    /// After fencing, all subsequent frontier updates for this combination
+    /// are silently rejected. This isolates frontier judgment at version
+    /// boundaries during policy transitions (FR-009).
+    pub fn fence_version(&mut self, range: &KeyRange, version: PolicyVersion) {
+        self.frontiers.fence_version(range, version);
+    }
+
+    /// Check whether a (key_range, policy_version) pair has been fenced.
+    pub fn is_version_fenced(&self, range: &KeyRange, version: &PolicyVersion) -> bool {
+        self.frontiers.is_version_fenced(range, version)
+    }
 }
 
 #[cfg(test)]

--- a/src/authority/ack_frontier.rs
+++ b/src/authority/ack_frontier.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::io;
 use std::path::Path;
 
@@ -6,6 +6,20 @@ use serde::{Deserialize, Serialize};
 
 use crate::hlc::HlcTimestamp;
 use crate::types::{KeyRange, NodeId, PolicyVersion};
+
+/// A fenced (key_range, policy_version) pair.
+///
+/// Once a version is fenced for a key range, no new frontier updates for that
+/// combination are accepted. This prevents "frontier pollution" where stale
+/// updates from an old policy version contaminate the new version's frontier
+/// tracking (FR-009 safe transition).
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct FencedVersion {
+    /// The key range that is fenced.
+    pub key_range: KeyRange,
+    /// The policy version that is fenced.
+    pub policy_version: PolicyVersion,
+}
 
 /// Tracks how far an Authority node has consumed updates for a key range.
 ///
@@ -72,6 +86,10 @@ impl FrontierScope {
 pub struct AckFrontierSet {
     #[serde(with = "frontier_map_serde")]
     frontiers: HashMap<FrontierScope, AckFrontier>,
+    /// Fenced (key_range, policy_version) pairs. Updates targeting a fenced
+    /// combination are silently rejected by `update()`.
+    #[serde(default)]
+    fenced_versions: HashSet<FencedVersion>,
 }
 
 /// Custom serde for `HashMap<FrontierScope, AckFrontier>`.
@@ -110,6 +128,7 @@ impl AckFrontierSet {
     pub fn new() -> Self {
         Self {
             frontiers: HashMap::new(),
+            fenced_versions: HashSet::new(),
         }
     }
 
@@ -122,6 +141,11 @@ impl AckFrontierSet {
     /// Returns `true` if the frontier was actually advanced (inserted or
     /// updated), `false` if the update was stale or duplicate.
     pub fn update(&mut self, frontier: AckFrontier) -> bool {
+        // Reject updates targeting a fenced (key_range, policy_version) pair.
+        if self.is_version_fenced(&frontier.key_range, &frontier.policy_version) {
+            return false;
+        }
+
         let scope = FrontierScope::from_frontier(&frontier);
         match self.frontiers.get(&scope) {
             Some(existing) if existing.frontier_hlc >= frontier.frontier_hlc => {
@@ -133,6 +157,27 @@ impl AckFrontierSet {
                 true
             }
         }
+    }
+
+    /// Fence a (key_range, policy_version) pair.
+    ///
+    /// After fencing, all subsequent `update()` calls targeting this
+    /// combination are silently rejected. Existing frontier entries for
+    /// the fenced pair are preserved (they remain readable via `get_scoped`
+    /// and scoped query methods).
+    pub fn fence_version(&mut self, range: &KeyRange, version: PolicyVersion) {
+        self.fenced_versions.insert(FencedVersion {
+            key_range: range.clone(),
+            policy_version: version,
+        });
+    }
+
+    /// Check whether a (key_range, policy_version) pair has been fenced.
+    pub fn is_version_fenced(&self, range: &KeyRange, version: &PolicyVersion) -> bool {
+        self.fenced_versions.contains(&FencedVersion {
+            key_range: range.clone(),
+            policy_version: *version,
+        })
     }
 
     /// Get the frontier for a specific authority by `NodeId`.
@@ -1040,5 +1085,123 @@ mod tests {
         // Submitting a newer frontier should return true.
         let newer = make_frontier("auth-1", 200, 0, "user/");
         assert!(set.update(newer), "advancing frontier should return true");
+    }
+
+    // ---------------------------------------------------------------
+    // Version fencing tests (#98)
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn fence_version_blocks_new_updates() {
+        let mut set = AckFrontierSet::new();
+
+        // Insert a frontier at v1.
+        set.update(make_frontier_v("auth-1", 100, 0, "user/", 1));
+
+        // Fence v1 for user/.
+        set.fence_version(&kr("user/"), PolicyVersion(1));
+
+        // New update at v1 should be rejected.
+        let blocked = set.update(make_frontier_v("auth-1", 200, 0, "user/", 1));
+        assert!(!blocked, "fenced version should block new updates");
+
+        // Existing entry should remain unchanged.
+        let scope = FrontierScope::new(kr("user/"), pv(1), NodeId("auth-1".into()));
+        assert_eq!(set.get_scoped(&scope).unwrap().frontier_hlc.physical, 100);
+    }
+
+    #[test]
+    fn fence_version_does_not_affect_other_versions() {
+        let mut set = AckFrontierSet::new();
+
+        // Fence v1 for user/.
+        set.fence_version(&kr("user/"), PolicyVersion(1));
+
+        // v2 for the same key range should still be accepted.
+        let accepted = set.update(make_frontier_v("auth-1", 500, 0, "user/", 2));
+        assert!(accepted, "unfenced version should be accepted");
+
+        let scope_v2 = FrontierScope::new(kr("user/"), pv(2), NodeId("auth-1".into()));
+        assert_eq!(
+            set.get_scoped(&scope_v2).unwrap().frontier_hlc.physical,
+            500
+        );
+    }
+
+    #[test]
+    fn fence_version_does_not_affect_other_key_ranges() {
+        let mut set = AckFrontierSet::new();
+
+        // Fence v1 for user/.
+        set.fence_version(&kr("user/"), PolicyVersion(1));
+
+        // v1 for order/ should still be accepted.
+        let accepted = set.update(make_frontier_v("auth-1", 300, 0, "order/", 1));
+        assert!(accepted, "different key range should not be fenced");
+    }
+
+    #[test]
+    fn is_version_fenced_returns_correct_state() {
+        let mut set = AckFrontierSet::new();
+
+        assert!(!set.is_version_fenced(&kr("user/"), &PolicyVersion(1)));
+
+        set.fence_version(&kr("user/"), PolicyVersion(1));
+        assert!(set.is_version_fenced(&kr("user/"), &PolicyVersion(1)));
+        assert!(!set.is_version_fenced(&kr("user/"), &PolicyVersion(2)));
+        assert!(!set.is_version_fenced(&kr("order/"), &PolicyVersion(1)));
+    }
+
+    #[test]
+    fn fenced_version_preserves_existing_entries() {
+        let mut set = AckFrontierSet::new();
+
+        // Insert entries at v1 and v2.
+        set.update(make_frontier_v("auth-1", 100, 0, "user/", 1));
+        set.update(make_frontier_v("auth-2", 200, 0, "user/", 1));
+        set.update(make_frontier_v("auth-1", 50, 0, "user/", 2));
+
+        // Fence v1.
+        set.fence_version(&kr("user/"), PolicyVersion(1));
+
+        // All existing entries are still readable.
+        assert_eq!(set.all_for_scope(&kr("user/"), &pv(1)).len(), 2);
+        assert_eq!(set.all_for_scope(&kr("user/"), &pv(2)).len(), 1);
+
+        // Scoped queries still work.
+        let mf = set
+            .majority_frontier_for_scope(&kr("user/"), &pv(1), 3)
+            .unwrap();
+        assert_eq!(mf.physical, 100);
+    }
+
+    #[test]
+    fn fence_new_insert_also_blocked() {
+        let mut set = AckFrontierSet::new();
+
+        // Fence v1 before any data exists.
+        set.fence_version(&kr("user/"), PolicyVersion(1));
+
+        // First-time insert should also be blocked.
+        let blocked = set.update(make_frontier_v("auth-1", 100, 0, "user/", 1));
+        assert!(!blocked, "fenced version should block first-time inserts");
+        assert!(set.all().is_empty());
+    }
+
+    #[test]
+    fn fenced_versions_serde_roundtrip() {
+        let mut set = AckFrontierSet::new();
+        set.update(make_frontier_v("auth-1", 100, 0, "user/", 1));
+        set.fence_version(&kr("user/"), PolicyVersion(1));
+
+        let json = set.to_json().expect("serialize");
+        let mut restored = AckFrontierSet::from_json(&json).expect("deserialize");
+
+        // Fencing state should survive serialization.
+        assert!(restored.is_version_fenced(&kr("user/"), &PolicyVersion(1)));
+
+        // Updates should still be blocked after deserialization.
+        let blocked = restored.update(make_frontier_v("auth-1", 200, 0, "user/", 1));
+        assert!(!blocked, "fenced version should survive serde roundtrip");
     }
 }

--- a/src/runtime/node_runner.rs
+++ b/src/runtime/node_runner.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::atomic::Ordering;
 use std::time::Duration;
@@ -8,10 +9,11 @@ use crate::api::certified::CertifiedApi;
 use crate::api::eventual::EventualApi;
 use crate::authority::frontier_reporter::FrontierReporter;
 use crate::compaction::CompactionEngine;
+use crate::control_plane::system_namespace::SystemNamespace;
 use crate::hlc::Hlc;
 use crate::network::sync::SyncClient;
 use crate::ops::metrics::RuntimeMetrics;
-use crate::types::{CertificationStatus, NodeId};
+use crate::types::{CertificationStatus, KeyRange, NodeId, PolicyVersion};
 
 /// Configuration for the background processing intervals of [`NodeRunner`].
 #[derive(Debug, Clone)]
@@ -68,6 +70,13 @@ pub struct NodeRunner {
     eventual_api: Option<Arc<Mutex<EventualApi>>>,
     /// Runtime metrics for operational monitoring.
     metrics: Arc<RuntimeMetrics>,
+    /// Tracked policy versions per key range prefix.
+    ///
+    /// On each certification tick the runner snapshots the current
+    /// namespace versions and compares with these tracked values.
+    /// When a version change is detected, the old version is fenced
+    /// and the frontier reporter is refreshed.
+    tracked_policy_versions: HashMap<String, PolicyVersion>,
 }
 
 /// Counters returned after the run loop exits, useful for testing and observability.
@@ -97,10 +106,12 @@ impl NodeRunner {
         config: NodeRunnerConfig,
         metrics: Arc<RuntimeMetrics>,
     ) -> Self {
-        let reporter = {
+        let (reporter, tracked_versions) = {
             let api = certified_api.lock().await;
             let ns = api.namespace().read().unwrap();
-            FrontierReporter::new(node_id.clone(), &ns)
+            let reporter = FrontierReporter::new(node_id.clone(), &ns);
+            let versions = Self::snapshot_policy_versions(&ns);
+            (reporter, versions)
         };
         let frontier_reporter = if reporter.is_authority() {
             Some(reporter)
@@ -121,6 +132,7 @@ impl NodeRunner {
             sync_client: None,
             eventual_api: None,
             metrics,
+            tracked_policy_versions: tracked_versions,
         }
     }
 
@@ -137,10 +149,12 @@ impl NodeRunner {
         eventual_api: Arc<Mutex<EventualApi>>,
         metrics: Arc<RuntimeMetrics>,
     ) -> Self {
-        let reporter = {
+        let (reporter, tracked_versions) = {
             let api = certified_api.lock().await;
             let ns = api.namespace().read().unwrap();
-            FrontierReporter::new(node_id.clone(), &ns)
+            let reporter = FrontierReporter::new(node_id.clone(), &ns);
+            let versions = Self::snapshot_policy_versions(&ns);
+            (reporter, versions)
         };
         let frontier_reporter = if reporter.is_authority() {
             Some(reporter)
@@ -161,6 +175,7 @@ impl NodeRunner {
             sync_client: Some(sync_client),
             eventual_api: Some(eventual_api),
             metrics,
+            tracked_policy_versions: tracked_versions,
         }
     }
 
@@ -205,6 +220,65 @@ impl NodeRunner {
     /// Return a reference to the runtime metrics.
     pub fn metrics(&self) -> &Arc<RuntimeMetrics> {
         &self.metrics
+    }
+
+    /// Snapshot the current policy version for each placement policy
+    /// in the system namespace.
+    fn snapshot_policy_versions(ns: &SystemNamespace) -> HashMap<String, PolicyVersion> {
+        ns.all_placement_policies()
+            .into_iter()
+            .map(|p| (p.key_range.prefix.clone(), p.version))
+            .collect()
+    }
+
+    /// Detect policy version changes and fence old versions.
+    ///
+    /// Compares the current namespace policy versions against the tracked
+    /// snapshot. When a version change is detected:
+    /// 1. The old version is fenced in the `AckFrontierSet` (via `CertifiedApi`)
+    /// 2. The `FrontierReporter` is refreshed to pick up the new scopes
+    /// 3. The tracked versions are updated
+    async fn detect_version_changes(&mut self) {
+        // Snapshot current versions while briefly holding the locks.
+        let current_versions: HashMap<String, PolicyVersion> = {
+            let api = self.certified_api.lock().await;
+            let ns = api.namespace().read().unwrap();
+            Self::snapshot_policy_versions(&ns)
+        };
+
+        // Collect version changes: (prefix, old_version, new_version).
+        let mut changes: Vec<(String, PolicyVersion, PolicyVersion)> = Vec::new();
+        for (prefix, new_version) in &current_versions {
+            if let Some(old_version) = self.tracked_policy_versions.get(prefix)
+                && old_version != new_version
+            {
+                changes.push((prefix.clone(), *old_version, *new_version));
+            }
+        }
+
+        if changes.is_empty() {
+            return;
+        }
+
+        // Apply fencing and refresh reporter.
+        {
+            let mut api = self.certified_api.lock().await;
+            for (prefix, old_version, _new_version) in &changes {
+                let key_range = KeyRange {
+                    prefix: prefix.clone(),
+                };
+                api.fence_version(&key_range, *old_version);
+            }
+
+            // Refresh the frontier reporter scopes.
+            if let Some(reporter) = &mut self.frontier_reporter {
+                let ns = api.namespace().read().unwrap();
+                reporter.refresh_scopes(&ns);
+            }
+        }
+
+        // Update tracked versions.
+        self.tracked_policy_versions = current_versions;
     }
 
     /// Run the node event loop until shutdown is signalled.
@@ -265,6 +339,7 @@ impl NodeRunner {
                     }
                 }
                 _ = cert_interval.tick() => {
+                    self.detect_version_changes().await;
                     self.process_certifications().await;
                     stats.certification_ticks += 1;
                 }

--- a/tests/policy_version_transition.rs
+++ b/tests/policy_version_transition.rs
@@ -1,0 +1,474 @@
+//! Integration tests for policy version safe transition (#98).
+//!
+//! Verifies that frontier judgment is isolated at version boundaries,
+//! that certified judgment rules are correct during migration, and
+//! that the NodeRunner auto-detects version changes.
+
+use std::sync::{Arc, RwLock};
+use std::time::Duration;
+
+use asteroidb_poc::api::certified::{CertifiedApi, OnTimeout};
+use asteroidb_poc::authority::ack_frontier::{AckFrontier, AckFrontierSet};
+use asteroidb_poc::compaction::CompactionEngine;
+use asteroidb_poc::control_plane::system_namespace::{AuthorityDefinition, SystemNamespace};
+use asteroidb_poc::crdt::pn_counter::PnCounter;
+use asteroidb_poc::hlc::HlcTimestamp;
+use asteroidb_poc::ops::metrics::RuntimeMetrics;
+use asteroidb_poc::placement::PlacementPolicy;
+use asteroidb_poc::runtime::{NodeRunner, NodeRunnerConfig};
+use asteroidb_poc::store::kv::CrdtValue;
+use asteroidb_poc::types::{CertificationStatus, KeyRange, NodeId, PolicyVersion};
+
+fn node(name: &str) -> NodeId {
+    NodeId(name.into())
+}
+
+fn kr(prefix: &str) -> KeyRange {
+    KeyRange {
+        prefix: prefix.into(),
+    }
+}
+
+fn wrap_ns(ns: SystemNamespace) -> Arc<RwLock<SystemNamespace>> {
+    Arc::new(RwLock::new(ns))
+}
+
+fn counter_value(n: i64) -> CrdtValue {
+    let mut counter = PnCounter::new();
+    for _ in 0..n {
+        counter.increment(&node("writer"));
+    }
+    CrdtValue::Counter(counter)
+}
+
+fn make_frontier_v(
+    authority: &str,
+    physical: u64,
+    logical: u32,
+    prefix: &str,
+    version: u64,
+) -> AckFrontier {
+    AckFrontier {
+        authority_id: NodeId(authority.into()),
+        frontier_hlc: HlcTimestamp {
+            physical,
+            logical,
+            node_id: authority.into(),
+        },
+        key_range: KeyRange {
+            prefix: prefix.into(),
+        },
+        policy_version: PolicyVersion(version),
+        digest_hash: format!("{authority}-{physical}-{logical}"),
+    }
+}
+
+// ---------------------------------------------------------------
+// Test 1: Version isolation in AckFrontierSet
+// ---------------------------------------------------------------
+
+#[test]
+fn version_isolation_in_frontier_set() {
+    let mut set = AckFrontierSet::new();
+
+    // Set up v1 frontiers.
+    set.update(make_frontier_v("auth-1", 100, 0, "data/", 1));
+    set.update(make_frontier_v("auth-2", 200, 0, "data/", 1));
+    set.update(make_frontier_v("auth-3", 150, 0, "data/", 1));
+
+    // Fence v1.
+    set.fence_version(&kr("data/"), PolicyVersion(1));
+
+    // Set up v2 frontiers (fresh start).
+    set.update(make_frontier_v("auth-1", 10, 0, "data/", 2));
+    set.update(make_frontier_v("auth-2", 20, 0, "data/", 2));
+    set.update(make_frontier_v("auth-3", 15, 0, "data/", 2));
+
+    // v1 frontiers should be frozen (existing entries readable but no new updates).
+    let blocked = set.update(make_frontier_v("auth-1", 999, 0, "data/", 1));
+    assert!(!blocked, "fenced v1 should reject new updates");
+
+    // v1 majority frontier: sorted [100, 150, 200], majority=2 -> 150.
+    let mf_v1 = set
+        .majority_frontier_for_scope(&kr("data/"), &PolicyVersion(1), 3)
+        .unwrap();
+    assert_eq!(mf_v1.physical, 150);
+
+    // v2 majority frontier: sorted [10, 15, 20], majority=2 -> 15.
+    let mf_v2 = set
+        .majority_frontier_for_scope(&kr("data/"), &PolicyVersion(2), 3)
+        .unwrap();
+    assert_eq!(mf_v2.physical, 15);
+
+    // Certification isolation: ts=100 certified at v1 but not at v2.
+    let ts_100 = HlcTimestamp {
+        physical: 100,
+        logical: 0,
+        node_id: "client".into(),
+    };
+    assert!(set.is_certified_at_for_scope(&ts_100, &kr("data/"), &PolicyVersion(1), 3));
+    assert!(!set.is_certified_at_for_scope(&ts_100, &kr("data/"), &PolicyVersion(2), 3));
+}
+
+// ---------------------------------------------------------------
+// Test 2: Full version switch with CertifiedApi
+// ---------------------------------------------------------------
+
+#[test]
+fn full_version_switch_with_certified_api() {
+    let mut ns = SystemNamespace::new();
+    ns.set_authority_definition(AuthorityDefinition {
+        key_range: kr("data/"),
+        authority_nodes: vec![node("auth-1"), node("auth-2"), node("auth-3")],
+    });
+    // Start at policy version 1.
+    ns.set_placement_policy(
+        PlacementPolicy::new(PolicyVersion(1), kr("data/"), 3).with_certified(true),
+    );
+
+    let shared_ns = wrap_ns(ns);
+    let mut api = CertifiedApi::new(node("node-1"), shared_ns.clone());
+
+    // Write under v1.
+    api.certified_write("data/key1".into(), counter_value(1), OnTimeout::Pending)
+        .unwrap();
+    let ts1 = api.pending_writes()[0].timestamp.physical;
+    assert_eq!(api.pending_writes()[0].policy_version, PolicyVersion(1));
+
+    // Advance v1 frontiers past the write.
+    api.update_frontier(make_frontier_v("auth-1", ts1 + 100, 0, "data/", 1));
+    api.update_frontier(make_frontier_v("auth-2", ts1 + 200, 0, "data/", 1));
+    api.process_certifications();
+
+    assert_eq!(
+        api.get_certification_status("data/key1"),
+        CertificationStatus::Certified
+    );
+
+    // Transition to v2.
+    {
+        let mut ns = shared_ns.write().unwrap();
+        ns.set_placement_policy(
+            PlacementPolicy::new(PolicyVersion(2), kr("data/"), 3).with_certified(true),
+        );
+    }
+
+    // Fence v1.
+    api.fence_version(&kr("data/"), PolicyVersion(1));
+
+    // Write under v2.
+    api.certified_write("data/key2".into(), counter_value(2), OnTimeout::Pending)
+        .unwrap();
+    let pw_idx = api.pending_writes().len() - 1;
+    let ts2 = api.pending_writes()[pw_idx].timestamp.physical;
+    assert_eq!(
+        api.pending_writes()[pw_idx].policy_version,
+        PolicyVersion(2)
+    );
+
+    // v1 frontiers should be blocked.
+    let blocked = api.update_frontier(make_frontier_v("auth-1", ts2 + 500, 0, "data/", 1));
+    assert!(!blocked, "fenced v1 should reject frontier updates");
+
+    // v2 frontiers should work.
+    api.update_frontier(make_frontier_v("auth-1", ts2 + 100, 0, "data/", 2));
+    api.update_frontier(make_frontier_v("auth-2", ts2 + 200, 0, "data/", 2));
+    api.process_certifications();
+
+    assert_eq!(
+        api.get_certification_status("data/key2"),
+        CertificationStatus::Certified
+    );
+}
+
+// ---------------------------------------------------------------
+// Test 3: Fencing preserves existing entries
+// ---------------------------------------------------------------
+
+#[test]
+fn fencing_preserves_existing_entries() {
+    let mut set = AckFrontierSet::new();
+
+    // Build up v1 state.
+    set.update(make_frontier_v("auth-1", 100, 0, "user/", 1));
+    set.update(make_frontier_v("auth-2", 200, 0, "user/", 1));
+    set.update(make_frontier_v("auth-3", 150, 0, "user/", 1));
+
+    // Record pre-fence state.
+    let pre_mf = set
+        .majority_frontier_for_scope(&kr("user/"), &PolicyVersion(1), 3)
+        .unwrap();
+    assert_eq!(pre_mf.physical, 150);
+
+    // Fence v1.
+    set.fence_version(&kr("user/"), PolicyVersion(1));
+
+    // Post-fence: existing entries are still readable.
+    let post_mf = set
+        .majority_frontier_for_scope(&kr("user/"), &PolicyVersion(1), 3)
+        .unwrap();
+    assert_eq!(
+        post_mf.physical, 150,
+        "fencing must preserve existing entries"
+    );
+
+    // Certification still works against existing entries.
+    let ts = HlcTimestamp {
+        physical: 100,
+        logical: 0,
+        node_id: "client".into(),
+    };
+    assert!(set.is_certified_at_for_scope(&ts, &kr("user/"), &PolicyVersion(1), 3));
+}
+
+// ---------------------------------------------------------------
+// Test 4: Cross-version frontier pollution prevented
+// ---------------------------------------------------------------
+
+#[test]
+fn cross_version_frontier_pollution_prevented() {
+    let mut ns = SystemNamespace::new();
+    ns.set_authority_definition(AuthorityDefinition {
+        key_range: kr("data/"),
+        authority_nodes: vec![node("auth-1"), node("auth-2"), node("auth-3")],
+    });
+    ns.set_placement_policy(
+        PlacementPolicy::new(PolicyVersion(1), kr("data/"), 3).with_certified(true),
+    );
+
+    let shared_ns = wrap_ns(ns);
+    let mut api = CertifiedApi::new(node("node-1"), shared_ns.clone());
+
+    // Transition to v2 and fence v1.
+    {
+        let mut ns = shared_ns.write().unwrap();
+        ns.set_placement_policy(
+            PlacementPolicy::new(PolicyVersion(2), kr("data/"), 3).with_certified(true),
+        );
+    }
+    api.fence_version(&kr("data/"), PolicyVersion(1));
+
+    // Write under v2.
+    api.certified_write("data/sensor".into(), counter_value(42), OnTimeout::Pending)
+        .unwrap();
+    let ts = api.pending_writes()[0].timestamp.physical;
+    assert_eq!(api.pending_writes()[0].policy_version, PolicyVersion(2));
+
+    // Attempt to advance using v1 frontiers (should be blocked).
+    let blocked1 = api.update_frontier(make_frontier_v("auth-1", ts + 100, 0, "data/", 1));
+    let blocked2 = api.update_frontier(make_frontier_v("auth-2", ts + 200, 0, "data/", 1));
+    assert!(!blocked1);
+    assert!(!blocked2);
+
+    api.process_certifications();
+
+    // Write should still be pending (no v2 frontiers).
+    assert_eq!(
+        api.get_certification_status("data/sensor"),
+        CertificationStatus::Pending,
+        "v1 frontiers must not certify a v2 write"
+    );
+
+    // Now advance v2 frontiers.
+    api.update_frontier(make_frontier_v("auth-1", ts + 100, 0, "data/", 2));
+    api.update_frontier(make_frontier_v("auth-2", ts + 200, 0, "data/", 2));
+    api.process_certifications();
+
+    assert_eq!(
+        api.get_certification_status("data/sensor"),
+        CertificationStatus::Certified,
+        "v2 frontiers should certify the v2 write"
+    );
+}
+
+// ---------------------------------------------------------------
+// Test 5: NodeRunner auto-detects version changes
+// ---------------------------------------------------------------
+
+#[tokio::test]
+async fn node_runner_auto_detects_version_changes() {
+    let mut ns = SystemNamespace::new();
+    ns.set_authority_definition(AuthorityDefinition {
+        key_range: kr("data/"),
+        authority_nodes: vec![node("auth-1")],
+    });
+    ns.set_placement_policy(
+        PlacementPolicy::new(PolicyVersion(1), kr("data/"), 1).with_certified(true),
+    );
+
+    let shared_ns = wrap_ns(ns);
+    let api = CertifiedApi::new(node("auth-1"), shared_ns.clone());
+    let shared_api = Arc::new(tokio::sync::Mutex::new(api));
+    let engine = CompactionEngine::with_defaults();
+    let metrics = Arc::new(RuntimeMetrics::default());
+
+    let config = NodeRunnerConfig {
+        certification_interval: Duration::from_millis(10),
+        cleanup_interval: Duration::from_secs(60),
+        compaction_check_interval: Duration::from_secs(60),
+        frontier_report_interval: Duration::from_millis(10),
+        sync_interval: None,
+    };
+
+    let mut runner =
+        NodeRunner::new(node("auth-1"), shared_api.clone(), engine, config, metrics).await;
+    let handle = runner.shutdown_handle();
+
+    // Change policy version while runner is running.
+    let ns_clone = shared_ns.clone();
+    let api_clone = shared_api.clone();
+    tokio::spawn(async move {
+        // Wait for a few ticks to establish v1 frontiers.
+        tokio::time::sleep(Duration::from_millis(40)).await;
+
+        // Bump to v2.
+        {
+            let mut ns = ns_clone.write().unwrap();
+            ns.set_placement_policy(
+                PlacementPolicy::new(PolicyVersion(2), kr("data/"), 1).with_certified(true),
+            );
+        }
+
+        // Wait for detection.
+        tokio::time::sleep(Duration::from_millis(40)).await;
+
+        // Verify that v1 was fenced.
+        let api = api_clone.lock().await;
+        assert!(
+            api.is_version_fenced(&kr("data/"), &PolicyVersion(1)),
+            "NodeRunner should auto-fence old version"
+        );
+
+        // Shutdown.
+        let _ = handle.send(true);
+    });
+
+    runner.run().await;
+}
+
+// ---------------------------------------------------------------
+// Test 6: Multiple version transitions
+// ---------------------------------------------------------------
+
+#[test]
+fn multiple_version_transitions() {
+    let mut ns = SystemNamespace::new();
+    ns.set_authority_definition(AuthorityDefinition {
+        key_range: kr("data/"),
+        authority_nodes: vec![node("auth-1"), node("auth-2"), node("auth-3")],
+    });
+    ns.set_placement_policy(
+        PlacementPolicy::new(PolicyVersion(1), kr("data/"), 3).with_certified(true),
+    );
+
+    let shared_ns = wrap_ns(ns);
+    let mut api = CertifiedApi::new(node("node-1"), shared_ns.clone());
+
+    // ---- v1 write and certify ----
+    api.certified_write("data/v1key".into(), counter_value(1), OnTimeout::Pending)
+        .unwrap();
+    let ts1 = api.pending_writes()[0].timestamp.physical;
+
+    api.update_frontier(make_frontier_v("auth-1", ts1 + 100, 0, "data/", 1));
+    api.update_frontier(make_frontier_v("auth-2", ts1 + 200, 0, "data/", 1));
+    api.process_certifications();
+    assert_eq!(
+        api.get_certification_status("data/v1key"),
+        CertificationStatus::Certified
+    );
+
+    // ---- Transition v1 -> v2 ----
+    {
+        let mut ns = shared_ns.write().unwrap();
+        ns.set_placement_policy(
+            PlacementPolicy::new(PolicyVersion(2), kr("data/"), 3).with_certified(true),
+        );
+    }
+    api.fence_version(&kr("data/"), PolicyVersion(1));
+
+    // Write under v2.
+    api.certified_write("data/v2key".into(), counter_value(2), OnTimeout::Pending)
+        .unwrap();
+    let pw_v2_idx = api.pending_writes().len() - 1;
+    let ts2 = api.pending_writes()[pw_v2_idx].timestamp.physical;
+    assert_eq!(
+        api.pending_writes()[pw_v2_idx].policy_version,
+        PolicyVersion(2)
+    );
+
+    api.update_frontier(make_frontier_v("auth-1", ts2 + 100, 0, "data/", 2));
+    api.update_frontier(make_frontier_v("auth-2", ts2 + 200, 0, "data/", 2));
+    api.process_certifications();
+    assert_eq!(
+        api.get_certification_status("data/v2key"),
+        CertificationStatus::Certified
+    );
+
+    // ---- Transition v2 -> v3 ----
+    {
+        let mut ns = shared_ns.write().unwrap();
+        ns.set_placement_policy(
+            PlacementPolicy::new(PolicyVersion(3), kr("data/"), 3).with_certified(true),
+        );
+    }
+    api.fence_version(&kr("data/"), PolicyVersion(2));
+
+    // Write under v3.
+    api.certified_write("data/v3key".into(), counter_value(3), OnTimeout::Pending)
+        .unwrap();
+    let pw_v3_idx = api.pending_writes().len() - 1;
+    let ts3 = api.pending_writes()[pw_v3_idx].timestamp.physical;
+    assert_eq!(
+        api.pending_writes()[pw_v3_idx].policy_version,
+        PolicyVersion(3)
+    );
+
+    // v1 and v2 frontiers should both be blocked.
+    assert!(!api.update_frontier(make_frontier_v("auth-1", ts3 + 500, 0, "data/", 1)));
+    assert!(!api.update_frontier(make_frontier_v("auth-1", ts3 + 500, 0, "data/", 2)));
+
+    // v3 frontiers should work.
+    api.update_frontier(make_frontier_v("auth-1", ts3 + 100, 0, "data/", 3));
+    api.update_frontier(make_frontier_v("auth-2", ts3 + 200, 0, "data/", 3));
+    api.process_certifications();
+    assert_eq!(
+        api.get_certification_status("data/v3key"),
+        CertificationStatus::Certified
+    );
+}
+
+// ---------------------------------------------------------------
+// Test 7: Concurrent key ranges have independent fencing
+// ---------------------------------------------------------------
+
+#[test]
+fn concurrent_key_ranges_independent_fencing() {
+    let mut set = AckFrontierSet::new();
+
+    // Set up v1 for both user/ and order/.
+    set.update(make_frontier_v("auth-1", 100, 0, "user/", 1));
+    set.update(make_frontier_v("auth-2", 200, 0, "user/", 1));
+
+    set.update(make_frontier_v("auth-1", 300, 0, "order/", 1));
+    set.update(make_frontier_v("auth-2", 400, 0, "order/", 1));
+
+    // Fence only user/ v1.
+    set.fence_version(&kr("user/"), PolicyVersion(1));
+
+    // user/ v1 should be blocked.
+    assert!(!set.update(make_frontier_v("auth-1", 999, 0, "user/", 1)));
+
+    // order/ v1 should still accept updates.
+    assert!(set.update(make_frontier_v("auth-1", 500, 0, "order/", 1)));
+
+    // Verify order/ frontier advanced.
+    let scope_order = asteroidb_poc::authority::ack_frontier::FrontierScope::new(
+        kr("order/"),
+        PolicyVersion(1),
+        node("auth-1"),
+    );
+    assert_eq!(
+        set.get_scoped(&scope_order).unwrap().frontier_hlc.physical,
+        500
+    );
+}


### PR DESCRIPTION
## Summary

- Add `FencedVersion` struct and `fenced_versions: HashSet<FencedVersion>` field to `AckFrontierSet` to block frontier updates for retired policy versions
- Add `fence_version()` / `is_version_fenced()` methods on `AckFrontierSet` and proxy methods on `CertifiedApi`
- Add `detect_version_changes()` to `NodeRunner` that auto-detects namespace policy version changes, fences old versions, and refreshes the `FrontierReporter`
- Add 7 unit tests for fencing in `AckFrontierSet` and 7 integration tests covering version isolation, full version switch, fencing preservation, cross-version pollution prevention, NodeRunner auto-detection, multiple transitions, and concurrent key range independence

Closes #98

## Test plan

- [x] 7 new unit tests in `src/authority/ack_frontier.rs` verify fencing behavior
- [x] 7 new integration tests in `tests/policy_version_transition.rs` cover end-to-end version transition scenarios
- [x] All 526 existing library tests pass unchanged
- [x] CI gate passes: `cargo fmt --check && cargo clippy -- -D warnings && cargo test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)