### PR TITLE
fix: share EventualApi instance between AppState and NodeRunner

### DIFF
--- a/src/http/handlers.rs
+++ b/src/http/handlers.rs
@@ -31,7 +31,7 @@ use super::types::{
 
 /// Shared application state for HTTP handlers.
 pub struct AppState {
-    pub eventual: Mutex<EventualApi>,
+    pub eventual: Arc<Mutex<EventualApi>>,
     pub certified: Arc<Mutex<CertifiedApi>>,
     pub namespace: Arc<RwLock<SystemNamespace>>,
     pub metrics: Arc<RuntimeMetrics>,

--- a/src/http/routes.rs
+++ b/src/http/routes.rs
@@ -89,7 +89,7 @@ mod tests {
         let namespace = Arc::new(RwLock::new(ns));
 
         Arc::new(AppState {
-            eventual: Mutex::new(EventualApi::new(node_id.clone())),
+            eventual: Arc::new(Mutex::new(EventualApi::new(node_id.clone()))),
             certified: Arc::new(Mutex::new(CertifiedApi::new(
                 node_id,
                 Arc::clone(&namespace),

--- a/src/main.rs
+++ b/src/main.rs
@@ -56,9 +56,13 @@ async fn main() {
         ))
     };
 
+    // Share a single EventualApi between HTTP handlers and NodeRunner
+    // so that HTTP writes are visible to the anti-entropy sync loop.
+    let eventual_api = Arc::new(Mutex::new(EventualApi::new(node_id.clone())));
+
     // Build shared HTTP state.
     let state = Arc::new(AppState {
-        eventual: Mutex::new(EventualApi::new(node_id.clone())),
+        eventual: Arc::clone(&eventual_api),
         certified: Arc::clone(&certified_api),
         namespace: Arc::clone(&namespace),
         metrics: Arc::clone(&metrics),
@@ -67,7 +71,8 @@ async fn main() {
 
     let app = router(state);
 
-    // NodeRunner uses the same CertifiedApi instance for background processing.
+    // NodeRunner uses the same CertifiedApi and EventualApi instances
+    // for background processing, ensuring sync sees HTTP writes.
     let engine = CompactionEngine::with_defaults();
     let mut runner = NodeRunner::new(
         node_id,
@@ -77,6 +82,7 @@ async fn main() {
         Arc::clone(&metrics),
     )
     .await;
+    runner.set_eventual_api(eventual_api);
     let shutdown_handle = runner.shutdown_handle();
 
     // Bind the TCP listener.

--- a/src/runtime/node_runner.rs
+++ b/src/runtime/node_runner.rs
@@ -234,6 +234,15 @@ impl NodeRunner {
         self.shutdown_tx.clone()
     }
 
+    /// Set the shared `EventualApi` reference.
+    ///
+    /// This allows the `NodeRunner` to access the same eventual store
+    /// used by HTTP handlers, ensuring that HTTP writes are visible
+    /// to the anti-entropy sync loop.
+    pub fn set_eventual_api(&mut self, api: Arc<Mutex<EventualApi>>) {
+        self.eventual_api = Some(api);
+    }
+
     /// Return a reference to the node ID.
     pub fn node_id(&self) -> &NodeId {
         &self.node_id

--- a/tests/anti_entropy_convergence.rs
+++ b/tests/anti_entropy_convergence.rs
@@ -54,7 +54,7 @@ async fn two_node_anti_entropy_convergence() {
     // Build state for node 1.
     let ns1 = wrap_ns(default_namespace());
     let state1 = Arc::new(AppState {
-        eventual: Mutex::new(EventualApi::new(node_id("node-1"))),
+        eventual: Arc::new(Mutex::new(EventualApi::new(node_id("node-1")))),
         certified: Arc::new(Mutex::new(CertifiedApi::new(
             node_id("node-1"),
             Arc::clone(&ns1),
@@ -67,7 +67,7 @@ async fn two_node_anti_entropy_convergence() {
     // Build state for node 2.
     let ns2 = wrap_ns(default_namespace());
     let state2 = Arc::new(AppState {
-        eventual: Mutex::new(EventualApi::new(node_id("node-2"))),
+        eventual: Arc::new(Mutex::new(EventualApi::new(node_id("node-2")))),
         certified: Arc::new(Mutex::new(CertifiedApi::new(
             node_id("node-2"),
             Arc::clone(&ns2),
@@ -246,7 +246,7 @@ async fn pull_based_sync() {
     // Build state with some data.
     let ns_source = wrap_ns(default_namespace());
     let state = Arc::new(AppState {
-        eventual: Mutex::new(EventualApi::new(node_id("source"))),
+        eventual: Arc::new(Mutex::new(EventualApi::new(node_id("source")))),
         certified: Arc::new(Mutex::new(CertifiedApi::new(
             node_id("source"),
             Arc::clone(&ns_source),
@@ -302,7 +302,7 @@ async fn sync_endpoint_partial_failure() {
 
     let ns_target = wrap_ns(default_namespace());
     let state = Arc::new(AppState {
-        eventual: Mutex::new(EventualApi::new(node_id("target"))),
+        eventual: Arc::new(Mutex::new(EventualApi::new(node_id("target")))),
         certified: Arc::new(Mutex::new(CertifiedApi::new(
             node_id("target"),
             Arc::clone(&ns_target),
@@ -396,7 +396,7 @@ async fn three_node_convergence_via_sync() {
         let nid = node_id(&format!("node-{}", i + 1));
         let ns_i = wrap_ns(default_namespace());
         let state = Arc::new(AppState {
-            eventual: Mutex::new(EventualApi::new(nid.clone())),
+            eventual: Arc::new(Mutex::new(EventualApi::new(nid.clone()))),
             certified: Arc::new(Mutex::new(CertifiedApi::new(nid, Arc::clone(&ns_i)))),
             namespace: ns_i,
             metrics: Arc::new(RuntimeMetrics::default()),
@@ -500,7 +500,7 @@ async fn internal_keys_endpoint() {
 
     let ns_keys = wrap_ns(default_namespace());
     let state = Arc::new(AppState {
-        eventual: Mutex::new(EventualApi::new(node_id("node-1"))),
+        eventual: Arc::new(Mutex::new(EventualApi::new(node_id("node-1")))),
         certified: Arc::new(Mutex::new(CertifiedApi::new(
             node_id("node-1"),
             Arc::clone(&ns_keys),
@@ -565,7 +565,7 @@ async fn full_sync_records_remote_frontier_not_local() {
 
     let ns_remote = wrap_ns(default_namespace());
     let remote_state = Arc::new(AppState {
-        eventual: Mutex::new(EventualApi::new(node_id("remote"))),
+        eventual: Arc::new(Mutex::new(EventualApi::new(node_id("remote")))),
         certified: Arc::new(Mutex::new(CertifiedApi::new(
             node_id("remote"),
             Arc::clone(&ns_remote),

--- a/tests/delta_sync.rs
+++ b/tests/delta_sync.rs
@@ -49,7 +49,7 @@ fn test_state() -> Arc<AppState> {
     let namespace = Arc::new(RwLock::new(ns));
 
     Arc::new(AppState {
-        eventual: Mutex::new(EventualApi::new(nid.clone())),
+        eventual: Arc::new(Mutex::new(EventualApi::new(nid.clone()))),
         certified: Arc::new(Mutex::new(CertifiedApi::new(nid, Arc::clone(&namespace)))),
         namespace,
         metrics: Arc::new(RuntimeMetrics::default()),

--- a/tests/e2e_multiprocess.rs
+++ b/tests/e2e_multiprocess.rs
@@ -53,7 +53,7 @@ async fn spawn_node(name: &str) -> (Arc<AppState>, SocketAddr, JoinHandle<()>) {
 
     let namespace = Arc::new(RwLock::new(default_namespace()));
     let state = Arc::new(AppState {
-        eventual: Mutex::new(EventualApi::new(nid.clone())),
+        eventual: Arc::new(Mutex::new(EventualApi::new(nid.clone()))),
         certified: Arc::new(Mutex::new(CertifiedApi::new(nid, Arc::clone(&namespace)))),
         namespace,
         metrics: Arc::new(RuntimeMetrics::default()),

--- a/tests/http_server.rs
+++ b/tests/http_server.rs
@@ -30,7 +30,7 @@ fn test_state() -> Arc<AppState> {
     let namespace = Arc::new(RwLock::new(ns));
 
     Arc::new(AppState {
-        eventual: Mutex::new(EventualApi::new(node_id.clone())),
+        eventual: Arc::new(Mutex::new(EventualApi::new(node_id.clone()))),
         certified: Arc::new(Mutex::new(CertifiedApi::new(
             node_id,
             Arc::clone(&namespace),

--- a/tests/node_join_leave.rs
+++ b/tests/node_join_leave.rs
@@ -58,7 +58,7 @@ async fn spawn_node_with_peers(
     ));
 
     let state = Arc::new(AppState {
-        eventual: Mutex::new(EventualApi::new(nid.clone())),
+        eventual: Arc::new(Mutex::new(EventualApi::new(nid.clone()))),
         certified: Arc::new(Mutex::new(CertifiedApi::new(nid, Arc::clone(&namespace)))),
         namespace,
         metrics: Arc::new(RuntimeMetrics::default()),


### PR DESCRIPTION
## Summary
- `AppState.eventual` の型を `Mutex<EventualApi>` から `Arc<Mutex<EventualApi>>` に変更
- `main.rs` で `EventualApi` を `Arc<Mutex<>>` で生成し、`AppState` と `NodeRunner` の両方に共有
- `NodeRunner` に `set_eventual_api()` メソッドを追加し、HTTP 経由の書き込みが anti-entropy sync に正しく反映されるようにした
- 全テスト・CI gate 通過確認済み

Closes #128

## Test plan
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo test` passes (593 unit tests + integration tests)
- [x] All existing AppState construction sites in tests updated to use `Arc::new(Mutex::new(...))`

🤖 Generated with [Claude Code](https://claude.com/claude-code)