### PR TITLE
fix: clamp PN counter min and harden FrontierSyncClient init

### DIFF
--- a/src/crdt/pn_counter.rs
+++ b/src/crdt/pn_counter.rs
@@ -63,7 +63,13 @@ impl PnCounter {
         if pos >= neg {
             (pos - neg).min(i64::MAX as u64) as i64
         } else {
-            -((neg - pos).min(i64::MAX as u64) as i64)
+            let diff = neg - pos;
+            let min_mag = (i64::MAX as u64) + 1;
+            if diff >= min_mag {
+                i64::MIN
+            } else {
+                -(diff as i64)
+            }
         }
     }
 
@@ -389,8 +395,8 @@ mod tests {
         let mut counter = PnCounter::new();
         counter.n.insert(node("a"), i64::MAX as u64);
         counter.n.insert(node("b"), 1);
-        // neg = i64::MAX + 1, pos = 0, so result should saturate to -i64::MAX
-        assert_eq!(counter.value(), -i64::MAX);
+        // neg = i64::MAX + 1, pos = 0, so result should saturate to i64::MIN
+        assert_eq!(counter.value(), i64::MIN);
     }
 
     #[test]
@@ -407,19 +413,18 @@ mod tests {
         let mut counter = PnCounter::new();
         counter.p.insert(node("a"), 0);
         counter.n.insert(node("b"), u64::MAX);
-        // neg - pos = u64::MAX, clamped to -i64::MAX
-        assert_eq!(counter.value(), -i64::MAX);
+        // neg - pos = u64::MAX, clamped to i64::MIN
+        assert_eq!(counter.value(), i64::MIN);
     }
 
     #[test]
     fn from_value_i64_min_roundtrips() {
         // i64::MIN has unsigned_abs() = i64::MAX + 1, which exceeds i64::MAX.
-        // value() should saturate to -i64::MAX (not overflow).
+        // value() should round-trip to i64::MIN (not overflow).
         let n = node("node-a");
         let counter = PnCounter::from_value(&n, i64::MIN);
         // The internal n map has value i64::MAX + 1 = 9223372036854775808.
-        // value() computes -(min(9223372036854775808, i64::MAX)) = -i64::MAX.
-        assert_eq!(counter.value(), -i64::MAX);
+        assert_eq!(counter.value(), i64::MIN);
     }
 
     #[test]

--- a/src/network/frontier_sync.rs
+++ b/src/network/frontier_sync.rs
@@ -45,7 +45,7 @@ impl FrontierSyncClient {
             http_client: reqwest::Client::builder()
                 .timeout(Duration::from_secs(5))
                 .build()
-                .unwrap_or_default(),
+                .expect("failed to build FrontierSyncClient HTTP client"),
         }
     }
 


### PR DESCRIPTION
## Summary
- `PnCounter::value()` の負側オーバーフロー時を `i64::MIN` に正しくクランプ
- `from_value(i64::MIN)` 関連テスト期待値を更新
- `FrontierSyncClient::new()` の HTTP client builder 失敗時に `unwrap_or_default()` で握りつぶさず `expect(...)` で失敗を顕在化

## Verification
- cargo fmt --all -- --check
- cargo test crdt::pn_counter::tests:: -- --nocapture
- cargo test network::frontier_sync::tests:: -- --nocapture
- cargo clippy --all-targets --all-features -- -D warnings
