### PR TITLE
test: compound E2E for authority reconfig × key rotation × delta sync

### DIFF
--- a/src/ops/metrics.rs
+++ b/src/ops/metrics.rs
@@ -118,6 +118,9 @@ pub struct RuntimeMetrics {
 
     /// Cumulative sync attempt count.
     pub sync_attempt_total: AtomicU64,
+
+    /// Cumulative count of delta-fail -> full-sync fallback events.
+    pub sync_fallback_total: AtomicU64,
 }
 
 impl RuntimeMetrics {

--- a/src/runtime/node_runner.rs
+++ b/src/runtime/node_runner.rs
@@ -243,6 +243,15 @@ impl NodeRunner {
         self.eventual_api = Some(api);
     }
 
+    /// Inject a peer frontier for testing purposes.
+    ///
+    /// This forces the next sync cycle to attempt delta sync first for
+    /// the given peer address, which is useful for testing the
+    /// delta-fail -> full-sync fallback path.
+    pub fn inject_peer_frontier(&mut self, peer_addr: &str, frontier: HlcTimestamp) {
+        self.peer_frontiers.insert(peer_addr.to_string(), frontier);
+    }
+
     /// Return a reference to the node ID.
     pub fn node_id(&self) -> &NodeId {
         &self.node_id
@@ -697,6 +706,9 @@ impl NodeRunner {
                     peer = %peer.node_id.0,
                     "delta sync failed, falling back to full sync"
                 );
+                self.metrics
+                    .sync_fallback_total
+                    .fetch_add(1, Ordering::Relaxed);
             }
 
             // Full sync fallback: pull all keys from peer.

--- a/tests/compound_e2e.rs
+++ b/tests/compound_e2e.rs
@@ -1216,6 +1216,8 @@ async fn node_runner_delta_fail_falls_back_to_full_sync() {
         sync_interval: Some(Duration::from_millis(20)),
     };
 
+    let metrics = Arc::new(RuntimeMetrics::default());
+
     let mut runner = NodeRunner::with_sync(
         node_id("local"),
         certified_api.clone(),
@@ -1223,16 +1225,20 @@ async fn node_runner_delta_fail_falls_back_to_full_sync() {
         config,
         sync_client,
         local_api.clone(),
-        default_metrics(),
+        metrics.clone(),
     )
     .await;
 
-    // Run NodeRunner for enough time to complete at least one sync cycle.
-    // The runner will:
-    //   1. See no peer frontier → skip delta, go to full sync → data arrives.
-    //   OR if peer frontier gets set after first full sync:
-    //   2. Try delta pull → 404 → retry → 404 → fall back to full sync.
+    // Inject a stale peer frontier so the runner *tries* delta first.
+    // This forces the delta-fail -> full-sync fallback path because the
+    // legacy server has no /api/internal/sync/delta endpoint.
+    runner.inject_peer_frontier(&legacy_addr.to_string(), hlc(1, 0, "stale"));
+
+    // Run NodeRunner; the sync cycle will:
+    //   1. See injected peer frontier → try delta pull → 404 → retry → 404
+    //   2. Fall back to full sync via /api/internal/keys → data arrives
     let shutdown = runner.shutdown_handle();
+    let metrics_check = metrics.clone();
     tokio::spawn(async move {
         // Poll until local node has the data from legacy peer.
         let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
@@ -1263,6 +1269,15 @@ async fn node_runner_delta_fail_falls_back_to_full_sync() {
                 other => panic!("expected Set with val-a, got {other:?}"),
             }
         }
+
+        // Verify the fallback path was actually taken via metrics.
+        let fallback_count = metrics_check
+            .sync_fallback_total
+            .load(std::sync::atomic::Ordering::Relaxed);
+        assert!(
+            fallback_count > 0,
+            "sync_fallback_total should be > 0, proving delta-fail -> full-sync path was taken"
+        );
 
         let _ = shutdown.send(true);
     });


### PR DESCRIPTION
## Summary
- Add `tests/compound_e2e.rs` with 4 integration tests exercising all three v0.1.3 features (authority auto-reconfiguration, key rotation/epoch management, and HLC-frontier delta sync) working together in compound scenarios
- Validates eventual data convergence, certified judgment correctness, expired keyset rejection, and delta sync continuity across reconfigurations
- Follows existing test patterns from `authority_auto_reconfig.rs`, `key_rotation_epoch.rs`, and `delta_sync.rs`

Closes #134

## Test plan
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] All 4 new compound E2E tests pass
- [x] Full test suite (598+ tests) passes with no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)