### PR TITLE
fix: update Dockerfile Rust version to 1.93

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.85 AS builder
+FROM rust:1.93 AS builder
 WORKDIR /app
 COPY . .
 RUN cargo build --release


### PR DESCRIPTION
## Summary
- Dockerfile の Rust ベースイメージを `rust:1.85` → `rust:1.93` に更新
- Rust 1.85 では let-chains (`if let ... && ...`) と `is_multiple_of()` がまだ unstable で、Netem Integration Tests の Docker ビルドが失敗していた
- ローカルの toolchain (`rustc 1.93.1`) に合わせることで解消

## Affected CI
- `Netem Integration Tests` (nightly schedule) が `Build Docker image` ステップで5個のコンパイルエラーを出していた:
  - `src/runtime/node_runner.rs:328` — let-chain
  - `src/crdt/or_map.rs:76` — let-chain
  - `src/api/status.rs:156` — let-chain
  - `src/authority/certificate.rs:37,77` — `unsigned_is_multiple_of`

## Test plan
- [ ] Netem Integration Tests CI が `Build Docker image` を通過すること
- [ ] 通常の CI (fmt/lint/test/build) が引き続き通ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)