### PR TITLE
feat: require majority consensus for control-plane updates

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -144,9 +144,11 @@ cargo run
 | `GET` | `/api/certified/{key}` | Certified read (ステータス付き) |
 | `GET` | `/api/status/{key}` | 認証ステータス確認 |
 | `GET` | `/api/metrics` | ランタイムメトリクス取得 |
-| `GET/PUT` | `/api/control-plane/authorities` | Authority 定義の一覧/更新 |
+| `PUT` | `/api/control-plane/authorities` | Authority 定義の設定 (要過半数承認) |
+| `GET` | `/api/control-plane/authorities` | Authority 定義の一覧 |
 | `GET` | `/api/control-plane/authorities/{prefix}` | Authority 定義の取得 |
-| `GET/PUT` | `/api/control-plane/policies` | 配置ポリシーの一覧/更新 |
+| `PUT` | `/api/control-plane/policies` | 配置ポリシーの設定 (要過半数承認) |
+| `GET` | `/api/control-plane/policies` | 配置ポリシーの一覧 |
 | `GET/DELETE` | `/api/control-plane/policies/{prefix}` | 配置ポリシーの取得/削除 |
 | `GET` | `/api/control-plane/versions` | ポリシーバージョン履歴 |
 
@@ -269,94 +271,86 @@ curl http://localhost:3000/api/certified/sensor%2Ftemp
 
 ### 3.3 System Namespace でポリシー設定
 
-System Namespace は HTTP API または Rust API で設定できます。
+System Namespace は HTTP API または Rust API 経由で設定します。すべての更新には Authority ノード群の過半数承認 (`approvals`) が必要です (FR-009)。
 
-HTTP API 例:
+#### HTTP API での設定
+
+**Authority 定義の設定:**
 
 ```bash
-# Authority 定義を更新
 curl -X PUT http://localhost:3000/api/control-plane/authorities \
   -H "Content-Type: application/json" \
   -d '{
-    "key_range_prefix":"sensor/",
-    "authority_nodes":["auth-1","auth-2","auth-3"]
+    "key_range_prefix": "sensor/",
+    "authority_nodes": ["auth-1", "auth-2", "auth-3"],
+    "approvals": ["auth-1", "auth-2"]
   }'
+# => {"key_range_prefix":"sensor/","authority_nodes":["auth-1","auth-2","auth-3"]}
+```
 
-# 配置ポリシーを更新
+**配置ポリシーの設定:**
+
+```bash
 curl -X PUT http://localhost:3000/api/control-plane/policies \
   -H "Content-Type: application/json" \
   -d '{
-    "key_range_prefix":"sensor/",
-    "replica_count":3,
-    "required_tags":["region:us-east"],
-    "forbidden_tags":[],
-    "allow_local_write_on_partition":true,
-    "certified":true
+    "key_range_prefix": "sensor/",
+    "replica_count": 3,
+    "required_tags": ["region:us-east"],
+    "certified": true,
+    "approvals": ["auth-1", "auth-2"]
   }'
+# => {"key_range_prefix":"sensor/","version":3,"replica_count":3,...}
 ```
 
-Rust API 例:
+承認が過半数に達しない場合は `403 POLICY_DENIED` が返されます:
+
+```bash
+curl -X PUT http://localhost:3000/api/control-plane/policies \
+  -H "Content-Type: application/json" \
+  -d '{
+    "key_range_prefix": "sensor/",
+    "replica_count": 3,
+    "approvals": ["auth-1"]
+  }'
+# => 403 {"error_code":"POLICY_DENIED","message":"insufficient approvals for policy update"}
+```
+
+#### Rust API での設定
 
 ```rust
 use asteroidb_poc::control_plane::system_namespace::{AuthorityDefinition, SystemNamespace};
+use asteroidb_poc::control_plane::consensus::ControlPlaneConsensus;
 use asteroidb_poc::placement::PlacementPolicy;
 use asteroidb_poc::types::{KeyRange, NodeId, PolicyVersion};
 
-// System Namespace の作成
-let mut ns = SystemNamespace::new();
+// Authority ノードのリストで ControlPlaneConsensus を作成
+let authority_nodes = vec![
+    NodeId("auth-1".into()),
+    NodeId("auth-2".into()),
+    NodeId("auth-3".into()),
+];
+let mut consensus = ControlPlaneConsensus::new(authority_nodes);
 
-// Authority 定義: "sensor/" プレフィックスのキーに対する Authority ノード群
-ns.set_authority_definition(AuthorityDefinition {
+// Authority 定義の更新を提案 (過半数の承認が必要)
+let def = AuthorityDefinition {
     key_range: KeyRange { prefix: "sensor/".into() },
     authority_nodes: vec![
         NodeId("auth-1".into()),
         NodeId("auth-2".into()),
         NodeId("auth-3".into()),
     ],
-});
+};
+let approvals = [NodeId("auth-1".into()), NodeId("auth-2".into())];
+consensus.propose_authority_update(def, &approvals).unwrap();
 
-// 配置ポリシー: レプリカ数3、認証対象
+// 配置ポリシーの更新を提案
 let policy = PlacementPolicy::new(
-    PolicyVersion(1),
-    KeyRange { prefix: "sensor/".into() },
-    3,  // replica_count
-)
-.with_certified(true)
-.with_required_tags(vec!["region:us-east".into()])
-.with_local_write_on_partition(true);
-
-ns.set_placement_policy(policy);
-
-// ポリシーの確認
-let p = ns.get_placement_policy("sensor/").unwrap();
-println!("Replica count: {}", p.replica_count);
-
-// キーに対する Authority の解決 (最長プレフィックスマッチ)
-let auth = ns.get_authorities_for_key("sensor/temp").unwrap();
-println!("Authority nodes: {:?}", auth.authority_nodes);
-```
-
-Control-plane ポリシー更新の合意:
-
-```rust
-use asteroidb_poc::control_plane::consensus::ControlPlaneConsensus;
-
-// Control-plane consensus で配置ポリシーの更新を提案
-let mut consensus = ControlPlaneConsensus::new(ns);
-let new_policy = PlacementPolicy::new(
     PolicyVersion(2),
     KeyRange { prefix: "sensor/".into() },
     5,  // レプリカ数を 5 に変更
 );
-
-// Authority ノード群の過半数承認を集めて適用
-let result = consensus.propose_policy_update(
-    new_policy,
-    vec![
-        NodeId("auth-1".into()),
-        NodeId("auth-2".into()),
-    ],
-);
+let result = consensus.propose_policy_update(policy, &approvals);
 // majority (2/3) に達していれば Ok(())
 ```
 

--- a/src/http/handlers.rs
+++ b/src/http/handlers.rs
@@ -7,6 +7,7 @@ use tokio::sync::Mutex;
 
 use crate::api::certified::{CertifiedApi, OnTimeout};
 use crate::api::eventual::EventualApi;
+use crate::control_plane::consensus::ControlPlaneConsensus;
 use crate::control_plane::system_namespace::{AuthorityDefinition, SystemNamespace};
 use crate::crdt::pn_counter::PnCounter;
 use crate::error::CrdtError;
@@ -42,6 +43,8 @@ pub struct AppState {
     /// File path to persist the peer registry to on join/leave.
     /// `None` disables persistence (e.g. unit tests).
     pub peer_persist_path: Option<PathBuf>,
+    /// Control-plane consensus for gating namespace updates (FR-009).
+    pub consensus: Arc<Mutex<ControlPlaneConsensus>>,
 }
 
 // ---------------------------------------------------------------
@@ -262,11 +265,11 @@ pub async fn get_authority_definition(
 /// `PUT /api/control-plane/authorities`
 ///
 /// Sets an authority definition in the system namespace.
+/// Requires majority approval from authority nodes (FR-009).
 pub async fn set_authority_definition(
     State(state): State<Arc<AppState>>,
     Json(req): Json<SetAuthorityDefinitionRequest>,
-) -> Json<AuthorityDefinitionResponse> {
-    let mut ns = state.namespace.write().unwrap();
+) -> Result<Json<AuthorityDefinitionResponse>, ApiError> {
     let def = AuthorityDefinition {
         key_range: KeyRange {
             prefix: req.key_range_prefix.clone(),
@@ -277,11 +280,24 @@ pub async fn set_authority_definition(
             .map(|n| NodeId(n.clone()))
             .collect(),
     };
-    ns.set_authority_definition(def);
-    Json(AuthorityDefinitionResponse {
+    let approvals: Vec<NodeId> = req.approvals.iter().map(|a| NodeId(a.clone())).collect();
+
+    // Validate majority consensus (FR-009).
+    {
+        let mut consensus = state.consensus.lock().await;
+        consensus.propose_authority_update(def.clone(), &approvals)?;
+    }
+
+    // Apply to shared namespace for read handlers and CertifiedApi.
+    {
+        let mut ns = state.namespace.write().unwrap();
+        ns.set_authority_definition(def);
+    }
+
+    Ok(Json(AuthorityDefinitionResponse {
         key_range_prefix: req.key_range_prefix,
         authority_nodes: req.authority_nodes,
-    })
+    }))
 }
 
 /// `GET /api/control-plane/policies`
@@ -334,39 +350,46 @@ pub async fn get_policy(
 /// `PUT /api/control-plane/policies`
 ///
 /// Sets a placement policy in the system namespace.
+/// Requires majority approval from authority nodes (FR-009).
 pub async fn set_placement_policy(
     State(state): State<Arc<AppState>>,
     Json(req): Json<SetPlacementPolicyRequest>,
-) -> Json<PlacementPolicyResponse> {
-    let mut ns = state.namespace.write().unwrap();
-    let current_version = ns.version().0;
+) -> Result<Json<PlacementPolicyResponse>, ApiError> {
+    let approvals: Vec<NodeId> = req.approvals.iter().map(|a| NodeId(a.clone())).collect();
 
-    let mut policy = PlacementPolicy::new(
-        PolicyVersion(current_version + 1),
-        KeyRange {
-            prefix: req.key_range_prefix.clone(),
-        },
-        req.replica_count,
-    );
+    // Read current version from shared namespace.
+    let policy = {
+        let ns = state.namespace.read().unwrap();
+        let current_version = ns.version().0;
 
-    if !req.required_tags.is_empty() {
-        policy = policy.with_required_tags(
-            req.required_tags
-                .iter()
-                .map(|t| crate::types::Tag(t.clone()))
-                .collect(),
+        let mut policy = PlacementPolicy::new(
+            PolicyVersion(current_version + 1),
+            KeyRange {
+                prefix: req.key_range_prefix.clone(),
+            },
+            req.replica_count,
         );
-    }
-    if !req.forbidden_tags.is_empty() {
-        policy = policy.with_forbidden_tags(
-            req.forbidden_tags
-                .iter()
-                .map(|t| crate::types::Tag(t.clone()))
-                .collect(),
-        );
-    }
-    policy = policy.with_local_write_on_partition(req.allow_local_write_on_partition);
-    policy = policy.with_certified(req.certified);
+
+        if !req.required_tags.is_empty() {
+            policy = policy.with_required_tags(
+                req.required_tags
+                    .iter()
+                    .map(|t| crate::types::Tag(t.clone()))
+                    .collect(),
+            );
+        }
+        if !req.forbidden_tags.is_empty() {
+            policy = policy.with_forbidden_tags(
+                req.forbidden_tags
+                    .iter()
+                    .map(|t| crate::types::Tag(t.clone()))
+                    .collect(),
+            );
+        }
+        policy = policy.with_local_write_on_partition(req.allow_local_write_on_partition);
+        policy = policy.with_certified(req.certified);
+        policy
+    };
 
     let resp = PlacementPolicyResponse {
         key_range_prefix: policy.key_range.prefix.clone(),
@@ -378,8 +401,19 @@ pub async fn set_placement_policy(
         certified: policy.certified,
     };
 
-    ns.set_placement_policy(policy);
-    Json(resp)
+    // Validate majority consensus (FR-009).
+    {
+        let mut consensus = state.consensus.lock().await;
+        consensus.propose_policy_update(policy.clone(), &approvals)?;
+    }
+
+    // Apply to shared namespace for read handlers and CertifiedApi.
+    {
+        let mut ns = state.namespace.write().unwrap();
+        ns.set_placement_policy(policy);
+    }
+
+    Ok(Json(resp))
 }
 
 /// `DELETE /api/control-plane/policies/{prefix}`

--- a/src/http/routes.rs
+++ b/src/http/routes.rs
@@ -98,6 +98,13 @@ mod tests {
             metrics: Arc::new(RuntimeMetrics::default()),
             peers: None,
             peer_persist_path: None,
+            consensus: Arc::new(Mutex::new(
+                crate::control_plane::consensus::ControlPlaneConsensus::new(vec![
+                    NodeId("auth-1".into()),
+                    NodeId("auth-2".into()),
+                    NodeId("auth-3".into()),
+                ]),
+            )),
         })
     }
 
@@ -587,13 +594,13 @@ mod tests {
         let state = test_state();
         let app = router(state);
 
-        // Set a new authority definition
+        // Set a new authority definition (majority: 2 of 3 approvals)
         let req = Request::builder()
             .method("PUT")
             .uri("/api/control-plane/authorities")
             .header("content-type", "application/json")
             .body(Body::from(
-                r#"{"key_range_prefix":"user/","authority_nodes":["auth-u1","auth-u2"]}"#,
+                r#"{"key_range_prefix":"user/","authority_nodes":["auth-u1","auth-u2"],"approvals":["auth-1","auth-2"]}"#,
             ))
             .unwrap();
 
@@ -654,13 +661,13 @@ mod tests {
         let state = test_state();
         let app = router(state);
 
-        // Set a placement policy
+        // Set a placement policy (majority: 2 of 3 approvals)
         let req = Request::builder()
             .method("PUT")
             .uri("/api/control-plane/policies")
             .header("content-type", "application/json")
             .body(Body::from(
-                r#"{"key_range_prefix":"user/","replica_count":3,"required_tags":["dc:tokyo"],"certified":true}"#,
+                r#"{"key_range_prefix":"user/","replica_count":3,"required_tags":["dc:tokyo"],"certified":true,"approvals":["auth-1","auth-2"]}"#,
             ))
             .unwrap();
 
@@ -712,13 +719,13 @@ mod tests {
         let state = test_state();
         let app = router(state);
 
-        // First set a policy
+        // First set a policy (with majority approvals)
         let req = Request::builder()
             .method("PUT")
             .uri("/api/control-plane/policies")
             .header("content-type", "application/json")
             .body(Body::from(
-                r#"{"key_range_prefix":"data/","replica_count":5}"#,
+                r#"{"key_range_prefix":"data/","replica_count":5,"approvals":["auth-1","auth-2"]}"#,
             ))
             .unwrap();
         app.clone().oneshot(req).await.unwrap();
@@ -791,7 +798,7 @@ mod tests {
             .uri("/api/control-plane/policies")
             .header("content-type", "application/json")
             .body(Body::from(
-                r#"{"key_range_prefix":"test/","replica_count":1}"#,
+                r#"{"key_range_prefix":"test/","replica_count":1,"approvals":["auth-1","auth-2"]}"#,
             ))
             .unwrap();
         app.clone().oneshot(req).await.unwrap();
@@ -821,7 +828,7 @@ mod tests {
                 .uri("/api/control-plane/policies")
                 .header("content-type", "application/json")
                 .body(Body::from(format!(
-                    r#"{{"key_range_prefix":"data/","replica_count":{}}}"#,
+                    r#"{{"key_range_prefix":"data/","replica_count":{},"approvals":["auth-1","auth-2"]}}"#,
                     i + 1
                 )))
                 .unwrap();
@@ -839,6 +846,155 @@ mod tests {
         // initial(1) + auth_def(2) + policy_set(3) + policy_set(4)
         assert_eq!(versions.current_version, 4);
         assert_eq!(versions.history.len(), 4);
+    }
+
+    // ---------------------------------------------------------------
+    // Control-plane: Consensus enforcement (FR-009)
+    // ---------------------------------------------------------------
+
+    #[tokio::test]
+    async fn control_plane_authority_without_majority_returns_403() {
+        let state = test_state();
+        let app = router(state);
+
+        // Only 1 approval (need 2 of 3 for majority)
+        let req = Request::builder()
+            .method("PUT")
+            .uri("/api/control-plane/authorities")
+            .header("content-type", "application/json")
+            .body(Body::from(
+                r#"{"key_range_prefix":"denied/","authority_nodes":["a1"],"approvals":["auth-1"]}"#,
+            ))
+            .unwrap();
+
+        let resp = app.clone().oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+
+        let body = body_string(resp.into_body()).await;
+        let err: serde_json::Value = serde_json::from_str(&body).unwrap();
+        assert_eq!(err["error_code"], "POLICY_DENIED");
+
+        // Verify it was not applied
+        let req = Request::builder()
+            .uri("/api/control-plane/authorities/denied%2F")
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn control_plane_policy_without_majority_returns_403() {
+        let state = test_state();
+        let app = router(state);
+
+        // Empty approvals (need 2 of 3 for majority)
+        let req = Request::builder()
+            .method("PUT")
+            .uri("/api/control-plane/policies")
+            .header("content-type", "application/json")
+            .body(Body::from(
+                r#"{"key_range_prefix":"denied/","replica_count":3,"approvals":[]}"#,
+            ))
+            .unwrap();
+
+        let resp = app.clone().oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+
+        let body = body_string(resp.into_body()).await;
+        let err: serde_json::Value = serde_json::from_str(&body).unwrap();
+        assert_eq!(err["error_code"], "POLICY_DENIED");
+
+        // Verify it was not applied
+        let req = Request::builder()
+            .uri("/api/control-plane/policies/denied%2F")
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn control_plane_authority_with_majority_succeeds() {
+        let state = test_state();
+        let app = router(state);
+
+        // 2 of 3 approvals = majority
+        let req = Request::builder()
+            .method("PUT")
+            .uri("/api/control-plane/authorities")
+            .header("content-type", "application/json")
+            .body(Body::from(
+                r#"{"key_range_prefix":"ok/","authority_nodes":["a1","a2"],"approvals":["auth-1","auth-3"]}"#,
+            ))
+            .unwrap();
+
+        let resp = app.clone().oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        // Verify it was applied
+        let req = Request::builder()
+            .uri("/api/control-plane/authorities/ok%2F")
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let body = body_string(resp.into_body()).await;
+        let def: AuthorityDefinitionResponse = serde_json::from_str(&body).unwrap();
+        assert_eq!(def.key_range_prefix, "ok/");
+        assert_eq!(def.authority_nodes, vec!["a1", "a2"]);
+    }
+
+    #[tokio::test]
+    async fn control_plane_policy_with_majority_succeeds() {
+        let state = test_state();
+        let app = router(state);
+
+        // All 3 approvals
+        let req = Request::builder()
+            .method("PUT")
+            .uri("/api/control-plane/policies")
+            .header("content-type", "application/json")
+            .body(Body::from(
+                r#"{"key_range_prefix":"ok/","replica_count":5,"approvals":["auth-1","auth-2","auth-3"]}"#,
+            ))
+            .unwrap();
+
+        let resp = app.clone().oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        // Verify it was applied
+        let req = Request::builder()
+            .uri("/api/control-plane/policies/ok%2F")
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let body = body_string(resp.into_body()).await;
+        let policy: PlacementPolicyResponse = serde_json::from_str(&body).unwrap();
+        assert_eq!(policy.key_range_prefix, "ok/");
+        assert_eq!(policy.replica_count, 5);
+    }
+
+    #[tokio::test]
+    async fn control_plane_non_authority_approvals_rejected() {
+        let state = test_state();
+        let app = router(state);
+
+        // 2 approvals but from non-authority nodes
+        let req = Request::builder()
+            .method("PUT")
+            .uri("/api/control-plane/policies")
+            .header("content-type", "application/json")
+            .body(Body::from(
+                r#"{"key_range_prefix":"bad/","replica_count":3,"approvals":["unknown-1","unknown-2"]}"#,
+            ))
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
     }
 
     // ---------------------------------------------------------------

--- a/src/http/types.rs
+++ b/src/http/types.rs
@@ -189,13 +189,19 @@ pub struct StatusResponse {
 // ---------------------------------------------------------------
 
 /// Request body for `PUT /api/control-plane/authorities`.
+///
+/// Requires majority approval from authority nodes (FR-009).
 #[derive(Debug, Deserialize)]
 pub struct SetAuthorityDefinitionRequest {
     pub key_range_prefix: String,
     pub authority_nodes: Vec<String>,
+    /// Node IDs that have approved this update.
+    pub approvals: Vec<String>,
 }
 
 /// Request body for `PUT /api/control-plane/policies`.
+///
+/// Requires majority approval from authority nodes (FR-009).
 #[derive(Debug, Deserialize)]
 pub struct SetPlacementPolicyRequest {
     pub key_range_prefix: String,
@@ -208,6 +214,8 @@ pub struct SetPlacementPolicyRequest {
     pub allow_local_write_on_partition: bool,
     #[serde(default)]
     pub certified: bool,
+    /// Node IDs that have approved this update.
+    pub approvals: Vec<String>,
 }
 
 // ---------------------------------------------------------------

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ use tokio::sync::Mutex;
 use asteroidb_poc::api::certified::CertifiedApi;
 use asteroidb_poc::api::eventual::EventualApi;
 use asteroidb_poc::compaction::CompactionEngine;
+use asteroidb_poc::control_plane::consensus::ControlPlaneConsensus;
 use asteroidb_poc::control_plane::system_namespace::{AuthorityDefinition, SystemNamespace};
 use asteroidb_poc::http::handlers::AppState;
 use asteroidb_poc::http::routes::router;
@@ -121,6 +122,13 @@ async fn main() {
         (Arc::new(Mutex::new(registry)), has)
     };
 
+    // Build control-plane consensus with the same authority nodes (FR-009).
+    let consensus = Arc::new(Mutex::new(ControlPlaneConsensus::new(vec![
+        NodeId("auth-1".into()),
+        NodeId("auth-2".into()),
+        NodeId("auth-3".into()),
+    ])));
+
     // Build shared HTTP state.
     let state = Arc::new(AppState {
         eventual: Arc::clone(&eventual_api),
@@ -129,6 +137,7 @@ async fn main() {
         metrics: Arc::clone(&metrics),
         peers: Some(Arc::clone(&shared_peers)),
         peer_persist_path: Some(peer_persist_path),
+        consensus,
     });
 
     let app = router(state);

--- a/tests/anti_entropy_convergence.rs
+++ b/tests/anti_entropy_convergence.rs
@@ -9,6 +9,7 @@ use std::time::Duration;
 
 use asteroidb_poc::api::certified::CertifiedApi;
 use asteroidb_poc::api::eventual::EventualApi;
+use asteroidb_poc::control_plane::consensus::ControlPlaneConsensus;
 use asteroidb_poc::control_plane::system_namespace::{AuthorityDefinition, SystemNamespace};
 use asteroidb_poc::crdt::pn_counter::PnCounter;
 use asteroidb_poc::http::handlers::AppState;
@@ -63,6 +64,7 @@ async fn two_node_anti_entropy_convergence() {
         metrics: Arc::new(RuntimeMetrics::default()),
         peers: None,
         peer_persist_path: None,
+        consensus: Arc::new(Mutex::new(ControlPlaneConsensus::new(vec![]))),
     });
 
     // Build state for node 2.
@@ -77,6 +79,7 @@ async fn two_node_anti_entropy_convergence() {
         metrics: Arc::new(RuntimeMetrics::default()),
         peers: None,
         peer_persist_path: None,
+        consensus: Arc::new(Mutex::new(ControlPlaneConsensus::new(vec![]))),
     });
 
     // Write some data to node 1.
@@ -257,6 +260,7 @@ async fn pull_based_sync() {
         metrics: Arc::new(RuntimeMetrics::default()),
         peers: None,
         peer_persist_path: None,
+        consensus: Arc::new(Mutex::new(ControlPlaneConsensus::new(vec![]))),
     });
 
     {
@@ -314,6 +318,7 @@ async fn sync_endpoint_partial_failure() {
         metrics: Arc::new(RuntimeMetrics::default()),
         peers: None,
         peer_persist_path: None,
+        consensus: Arc::new(Mutex::new(ControlPlaneConsensus::new(vec![]))),
     });
 
     // Pre-populate with a counter at "k".
@@ -406,6 +411,7 @@ async fn three_node_convergence_via_sync() {
             metrics: Arc::new(RuntimeMetrics::default()),
             peers: None,
             peer_persist_path: None,
+            consensus: Arc::new(Mutex::new(ControlPlaneConsensus::new(vec![]))),
         });
         states.push(state);
     }
@@ -514,6 +520,7 @@ async fn internal_keys_endpoint() {
         metrics: Arc::new(RuntimeMetrics::default()),
         peers: None,
         peer_persist_path: None,
+        consensus: Arc::new(Mutex::new(ControlPlaneConsensus::new(vec![]))),
     });
 
     {
@@ -580,6 +587,7 @@ async fn full_sync_records_remote_frontier_not_local() {
         metrics: Arc::new(RuntimeMetrics::default()),
         peers: None,
         peer_persist_path: None,
+        consensus: Arc::new(Mutex::new(ControlPlaneConsensus::new(vec![]))),
     });
 
     // Write data to the remote node.

--- a/tests/compound_e2e.rs
+++ b/tests/compound_e2e.rs
@@ -24,6 +24,7 @@ use asteroidb_poc::authority::certificate::{
 };
 use asteroidb_poc::authority::verifier::verify_proof_with_registry;
 use asteroidb_poc::compaction::CompactionEngine;
+use asteroidb_poc::control_plane::consensus::ControlPlaneConsensus;
 use asteroidb_poc::control_plane::system_namespace::{AuthorityDefinition, SystemNamespace};
 use asteroidb_poc::crdt::pn_counter::PnCounter;
 use asteroidb_poc::hlc::HlcTimestamp;
@@ -145,6 +146,7 @@ fn test_state_with_ns(nid: NodeId, ns: Arc<RwLock<SystemNamespace>>) -> Arc<AppS
         metrics: Arc::new(RuntimeMetrics::default()),
         peers: None,
         peer_persist_path: None,
+        consensus: Arc::new(Mutex::new(ControlPlaneConsensus::new(vec![]))),
     })
 }
 
@@ -1163,6 +1165,7 @@ async fn node_runner_delta_fail_falls_back_to_full_sync() {
         metrics: Arc::new(RuntimeMetrics::default()),
         peers: None,
         peer_persist_path: None,
+        consensus: Arc::new(Mutex::new(ControlPlaneConsensus::new(vec![]))),
     });
 
     // Write data to the legacy peer.

--- a/tests/delta_sync.rs
+++ b/tests/delta_sync.rs
@@ -8,6 +8,7 @@ use std::sync::RwLock;
 
 use asteroidb_poc::api::certified::CertifiedApi;
 use asteroidb_poc::api::eventual::EventualApi;
+use asteroidb_poc::control_plane::consensus::ControlPlaneConsensus;
 use asteroidb_poc::control_plane::system_namespace::{AuthorityDefinition, SystemNamespace};
 use asteroidb_poc::hlc::HlcTimestamp;
 use asteroidb_poc::http::handlers::AppState;
@@ -55,6 +56,7 @@ fn test_state() -> Arc<AppState> {
         metrics: Arc::new(RuntimeMetrics::default()),
         peers: None,
         peer_persist_path: None,
+        consensus: Arc::new(Mutex::new(ControlPlaneConsensus::new(vec![]))),
     })
 }
 

--- a/tests/e2e_multiprocess.rs
+++ b/tests/e2e_multiprocess.rs
@@ -16,6 +16,7 @@ use std::time::Duration;
 use asteroidb_poc::api::certified::CertifiedApi;
 use asteroidb_poc::api::eventual::EventualApi;
 use asteroidb_poc::authority::ack_frontier::AckFrontier;
+use asteroidb_poc::control_plane::consensus::ControlPlaneConsensus;
 use asteroidb_poc::control_plane::system_namespace::{AuthorityDefinition, SystemNamespace};
 use asteroidb_poc::hlc::HlcTimestamp;
 use asteroidb_poc::http::handlers::AppState;
@@ -59,6 +60,7 @@ async fn spawn_node(name: &str) -> (Arc<AppState>, SocketAddr, JoinHandle<()>) {
         metrics: Arc::new(RuntimeMetrics::default()),
         peers: None,
         peer_persist_path: None,
+        consensus: Arc::new(Mutex::new(ControlPlaneConsensus::new(vec![]))),
     });
 
     let app = router(state.clone());

--- a/tests/http_server.rs
+++ b/tests/http_server.rs
@@ -5,6 +5,7 @@ use std::time::Duration;
 
 use asteroidb_poc::api::certified::CertifiedApi;
 use asteroidb_poc::api::eventual::EventualApi;
+use asteroidb_poc::control_plane::consensus::ControlPlaneConsensus;
 use asteroidb_poc::control_plane::system_namespace::{AuthorityDefinition, SystemNamespace};
 use asteroidb_poc::http::handlers::AppState;
 use asteroidb_poc::http::routes::router;
@@ -29,6 +30,12 @@ fn test_state() -> Arc<AppState> {
 
     let namespace = Arc::new(RwLock::new(ns));
 
+    let consensus = Arc::new(Mutex::new(ControlPlaneConsensus::new(vec![
+        NodeId("auth-1".into()),
+        NodeId("auth-2".into()),
+        NodeId("auth-3".into()),
+    ])));
+
     Arc::new(AppState {
         eventual: Arc::new(Mutex::new(EventualApi::new(node_id.clone()))),
         certified: Arc::new(Mutex::new(CertifiedApi::new(
@@ -39,6 +46,7 @@ fn test_state() -> Arc<AppState> {
         metrics: Arc::new(RuntimeMetrics::default()),
         peers: None,
         peer_persist_path: None,
+        consensus,
     })
 }
 

--- a/tests/node_join_leave.rs
+++ b/tests/node_join_leave.rs
@@ -13,6 +13,7 @@ use std::time::Duration;
 
 use asteroidb_poc::api::certified::CertifiedApi;
 use asteroidb_poc::api::eventual::EventualApi;
+use asteroidb_poc::control_plane::consensus::ControlPlaneConsensus;
 use asteroidb_poc::control_plane::system_namespace::{AuthorityDefinition, SystemNamespace};
 use asteroidb_poc::http::handlers::AppState;
 use asteroidb_poc::http::routes::router;
@@ -64,6 +65,7 @@ async fn spawn_node_with_peers(
         metrics: Arc::new(RuntimeMetrics::default()),
         peers: Some(peer_registry),
         peer_persist_path: None,
+        consensus: Arc::new(Mutex::new(ControlPlaneConsensus::new(vec![]))),
     });
 
     let app = router(state.clone());


### PR DESCRIPTION
Closes #143

## Summary

- Wire `PUT /api/control-plane/authorities` and `PUT /api/control-plane/policies` through `ControlPlaneConsensus` so that namespace mutations require majority approval from authority nodes (FR-009)
- Add `approvals: Vec<String>` field to `SetAuthorityDefinitionRequest` and `SetPlacementPolicyRequest`
- Add `consensus: Arc<Mutex<ControlPlaneConsensus>>` to `AppState`
- Return 403 `POLICY_DENIED` when approvals are insufficient
- Add 5 new tests for consensus enforcement (majority success, minority rejection, non-authority rejection)
- Update `docs/getting-started.md` with HTTP API examples including the `approvals` field

## Test plan

- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] All 822 tests pass (603 lib + 219 integration, 0 failures)
- [x] New tests verify 403 rejection with insufficient approvals
- [x] New tests verify 200 success with majority approvals
- [x] Existing control-plane tests updated with valid approvals