### PR TITLE
feat: support config file loading via ASTEROIDB_CONFIG

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -99,6 +99,34 @@ Authority ノード群の過半数合意 (majority consensus) により、Eventu
 
 ### ノードの起動
 
+**方法 1: 設定ファイルを使用する（推奨）**
+
+`ASTEROIDB_CONFIG` 環境変数に設定ファイルのパスを指定して起動します。設定ファイルにはノード ID、バインドアドレス、ピア情報がすべて含まれるため、マルチノード構成を簡単に管理できます。
+
+```bash
+ASTEROIDB_CONFIG=configs/node-1.json cargo run
+```
+
+設定ファイルの例 (`configs/node-1.json`):
+
+```json
+{
+  "node": { "id": "node-1", "mode": "Both", "tags": [] },
+  "bind_addr": "0.0.0.0:3000",
+  "peers": {
+    "self_id": "node-1",
+    "peers": {
+      "node-2": { "node_id": "node-2", "addr": "127.0.0.1:3001" },
+      "node-3": { "node_id": "node-3", "addr": "127.0.0.1:3002" }
+    }
+  }
+}
+```
+
+ピアが設定ファイルに定義されている場合、ノード間の anti-entropy sync が自動的に有効化されます。
+
+**方法 2: 環境変数を使用する**
+
 ```bash
 cargo run
 ```

--- a/src/http/handlers.rs
+++ b/src/http/handlers.rs
@@ -552,18 +552,12 @@ pub async fn internal_join(
     Json(req): Json<JoinRequest>,
 ) -> Result<Json<JoinResponse>, ApiError> {
     use crate::network::PeerConfig;
-    use std::net::SocketAddr;
 
     let peers_registry = state.peers.as_ref().ok_or_else(|| {
         ApiError(CrdtError::Internal(
             "peer registry not configured".to_string(),
         ))
     })?;
-
-    let addr: SocketAddr = req
-        .address
-        .parse()
-        .map_err(|e| ApiError(CrdtError::InvalidArgument(format!("invalid address: {e}"))))?;
 
     let joining_node_id = NodeId(req.node_id.clone());
 
@@ -573,7 +567,7 @@ pub async fn internal_join(
         registry
             .add_peer(PeerConfig {
                 node_id: joining_node_id.clone(),
-                addr,
+                addr: req.address.clone(),
             })
             .map_err(|e| ApiError(CrdtError::InvalidArgument(e.to_string())))?;
     }
@@ -588,7 +582,7 @@ pub async fn internal_join(
             .into_iter()
             .map(|p| PeerInfo {
                 node_id: p.node_id.0,
-                address: p.addr.to_string(),
+                address: p.addr.clone(),
             })
             .collect();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,20 +8,39 @@ use asteroidb_poc::compaction::CompactionEngine;
 use asteroidb_poc::control_plane::system_namespace::{AuthorityDefinition, SystemNamespace};
 use asteroidb_poc::http::handlers::AppState;
 use asteroidb_poc::http::routes::router;
+use asteroidb_poc::network::sync::SyncClient;
+use asteroidb_poc::network::{NodeConfig, PeerRegistry};
 use asteroidb_poc::ops::metrics::RuntimeMetrics;
 use asteroidb_poc::runtime::{NodeRunner, NodeRunnerConfig};
 use asteroidb_poc::types::{KeyRange, NodeId};
 
 #[tokio::main]
 async fn main() {
-    let bind_addr =
-        std::env::var("ASTEROIDB_BIND_ADDR").unwrap_or_else(|_| "127.0.0.1:3000".into());
+    // Load configuration: either from a config file or from individual env vars.
+    let (node_id, bind_addr, peer_registry) = match std::env::var("ASTEROIDB_CONFIG") {
+        Ok(config_path) => match NodeConfig::load(&config_path) {
+            Ok(config) => {
+                let node_id = config.node.id;
+                let bind_addr = config.bind_addr.to_string();
+                let peer_registry = config.peers;
+                (node_id, bind_addr, Some(peer_registry))
+            }
+            Err(e) => {
+                eprintln!("error: failed to load config file '{config_path}': {e}");
+                std::process::exit(1);
+            }
+        },
+        Err(_) => {
+            let bind_addr =
+                std::env::var("ASTEROIDB_BIND_ADDR").unwrap_or_else(|_| "127.0.0.1:3000".into());
+            let node_id_str =
+                std::env::var("ASTEROIDB_NODE_ID").unwrap_or_else(|_| "node-1".into());
+            let node_id = NodeId(node_id_str);
+            (node_id, bind_addr, None)
+        }
+    };
 
-    let node_id_str = std::env::var("ASTEROIDB_NODE_ID").unwrap_or_else(|_| "node-1".into());
-
-    println!("AsteroidDB starting... (node_id={node_id_str})");
-
-    let node_id = NodeId(node_id_str);
+    println!("AsteroidDB starting... (node_id={})", node_id.0);
 
     let mut ns = SystemNamespace::new();
     ns.set_authority_definition(AuthorityDefinition {
@@ -47,18 +66,16 @@ async fn main() {
         Arc::clone(&namespace),
     )));
 
-    // Build a peer registry for the node (initially empty; nodes join
-    // dynamically via POST /api/internal/join).
-    let peer_registry = {
-        use asteroidb_poc::network::PeerRegistry;
-        Arc::new(Mutex::new(
-            PeerRegistry::new(node_id.clone(), vec![]).expect("empty peer list is always valid"),
-        ))
-    };
-
     // Share a single EventualApi between HTTP handlers and NodeRunner
     // so that HTTP writes are visible to the anti-entropy sync loop.
     let eventual_api = Arc::new(Mutex::new(EventualApi::new(node_id.clone())));
+
+    // Build peer registry: from config file or empty (nodes join dynamically
+    // via POST /api/internal/join).
+    let has_peers = peer_registry.as_ref().is_some_and(|r| r.peer_count() > 0);
+    let shared_peers = Arc::new(Mutex::new(peer_registry.unwrap_or_else(|| {
+        PeerRegistry::new(node_id.clone(), vec![]).expect("empty peer list is always valid")
+    })));
 
     // Build shared HTTP state.
     let state = Arc::new(AppState {
@@ -66,7 +83,7 @@ async fn main() {
         certified: Arc::clone(&certified_api),
         namespace: Arc::clone(&namespace),
         metrics: Arc::clone(&metrics),
-        peers: Some(peer_registry),
+        peers: Some(Arc::clone(&shared_peers)),
     });
 
     let app = router(state);
@@ -74,15 +91,32 @@ async fn main() {
     // NodeRunner uses the same CertifiedApi and EventualApi instances
     // for background processing, ensuring sync sees HTTP writes.
     let engine = CompactionEngine::with_defaults();
-    let mut runner = NodeRunner::new(
-        node_id,
-        Arc::clone(&certified_api),
-        engine,
-        NodeRunnerConfig::default(),
-        Arc::clone(&metrics),
-    )
-    .await;
-    runner.set_eventual_api(eventual_api);
+    let mut runner = if has_peers {
+        // Config file provided peers — enable anti-entropy sync.
+        let sync_registry = shared_peers.lock().await.clone();
+        let sync_client = SyncClient::new(sync_registry);
+        NodeRunner::with_sync(
+            node_id,
+            Arc::clone(&certified_api),
+            engine,
+            NodeRunnerConfig::default(),
+            sync_client,
+            Arc::clone(&eventual_api),
+            Arc::clone(&metrics),
+        )
+        .await
+    } else {
+        let mut r = NodeRunner::new(
+            node_id,
+            Arc::clone(&certified_api),
+            engine,
+            NodeRunnerConfig::default(),
+            Arc::clone(&metrics),
+        )
+        .await;
+        r.set_eventual_api(eventual_api);
+        r
+    };
     let shutdown_handle = runner.shutdown_handle();
 
     // Bind the TCP listener.

--- a/src/network/frontier_sync.rs
+++ b/src/network/frontier_sync.rs
@@ -1,4 +1,3 @@
-use std::net::SocketAddr;
 use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
@@ -59,7 +58,7 @@ impl FrontierSyncClient {
     /// Returns the number of frontiers accepted by the peer.
     pub async fn push_frontiers(
         &self,
-        peer_addr: SocketAddr,
+        peer_addr: &str,
         frontiers: Vec<AckFrontier>,
     ) -> Result<FrontierPushResponse, reqwest::Error> {
         let url = format!("http://{peer_addr}/api/internal/frontiers");
@@ -81,7 +80,7 @@ impl FrontierSyncClient {
     /// The returned frontiers can be applied locally via `AckFrontierSet::update()`.
     pub async fn pull_frontiers(
         &self,
-        peer_addr: SocketAddr,
+        peer_addr: &str,
     ) -> Result<FrontierPullResponse, reqwest::Error> {
         let url = format!("http://{peer_addr}/api/internal/frontiers");
 

--- a/src/network/peer.rs
+++ b/src/network/peer.rs
@@ -36,8 +36,11 @@ pub enum PeerError {
 pub struct PeerConfig {
     /// Unique identifier of the remote node.
     pub node_id: NodeId,
-    /// Socket address (ip:port) the remote node is listening on.
-    pub addr: SocketAddr,
+    /// Address (host:port) the remote node is listening on.
+    ///
+    /// Accepts both IP:port (e.g., `"127.0.0.1:3000"`) and hostname:port
+    /// (e.g., `"asteroidb-node-2:3000"`) formats.
+    pub addr: String,
 }
 
 /// Registry that holds validated peer configurations.
@@ -212,26 +215,25 @@ impl NodeConfig {
 pub fn generate_cluster_configs(count: usize, base_port: u16) -> Vec<NodeConfig> {
     use crate::types::NodeMode;
 
-    // Pre-build the (node_id, addr) pairs.
-    let entries: Vec<(NodeId, SocketAddr)> = (0..count)
+    // Pre-build the (node_id, bind_addr, peer_addr_str) tuples.
+    let entries: Vec<(NodeId, SocketAddr, String)> = (0..count)
         .map(|i| {
             let id = NodeId(format!("node-{}", i + 1));
-            let addr: SocketAddr = format!("127.0.0.1:{}", base_port + i as u16)
-                .parse()
-                .expect("valid socket addr");
-            (id, addr)
+            let addr_str = format!("127.0.0.1:{}", base_port + i as u16);
+            let bind_addr: SocketAddr = addr_str.parse().expect("valid socket addr");
+            (id, bind_addr, addr_str)
         })
         .collect();
 
     entries
         .iter()
-        .map(|(self_id, bind_addr)| {
+        .map(|(self_id, bind_addr, _)| {
             let peers: Vec<PeerConfig> = entries
                 .iter()
-                .filter(|(id, _)| id != self_id)
-                .map(|(id, addr)| PeerConfig {
+                .filter(|(id, _, _)| id != self_id)
+                .map(|(id, _, addr_str)| PeerConfig {
                     node_id: id.clone(),
-                    addr: *addr,
+                    addr: addr_str.clone(),
                 })
                 .collect();
 
@@ -259,7 +261,7 @@ mod tests {
     fn peer(id: &str, addr: &str) -> PeerConfig {
         PeerConfig {
             node_id: nid(id),
-            addr: addr.parse().unwrap(),
+            addr: addr.to_string(),
         }
     }
 
@@ -424,6 +426,23 @@ mod tests {
         }
     }
 
+    #[test]
+    fn node_config_load_project_config_files() {
+        // Verify that the shipped configs/node-*.json files are loadable.
+        for i in 1..=3 {
+            let path = format!("configs/node-{i}.json");
+            let config = NodeConfig::load(&path).unwrap_or_else(|e| {
+                panic!("failed to load {path}: {e}");
+            });
+            let expected_id = format!("node-{i}");
+            assert_eq!(config.node.id, nid(&expected_id));
+            assert_eq!(config.node.mode, NodeMode::Both);
+            // Each node has 2 peers (the other two nodes).
+            assert_eq!(config.peers.peer_count(), 2);
+            assert_eq!(config.peers.self_id(), &nid(&expected_id));
+        }
+    }
+
     // ---- generate_cluster_configs ----
 
     #[test]
@@ -467,10 +486,10 @@ mod tests {
         // Cross-reference: node-1's peer entry for node-2 should have the
         // same addr as node-2's bind_addr.
         let p12 = configs[0].peers.get_peer(&nid("node-2")).unwrap();
-        assert_eq!(p12.addr, configs[1].bind_addr);
+        assert_eq!(p12.addr, configs[1].bind_addr.to_string());
 
         let p13 = configs[0].peers.get_peer(&nid("node-3")).unwrap();
-        assert_eq!(p13.addr, configs[2].bind_addr);
+        assert_eq!(p13.addr, configs[2].bind_addr.to_string());
     }
 
     #[test]

--- a/src/network/sync.rs
+++ b/src/network/sync.rs
@@ -1,5 +1,4 @@
 use std::collections::HashMap;
-use std::net::SocketAddr;
 use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
@@ -173,7 +172,7 @@ impl SyncClient {
     /// Sends `GET /api/internal/keys` to the peer and returns the
     /// full [`KeyDumpResponse`] including entries and the remote
     /// peer's frontier. Returns `None` on failure.
-    pub async fn pull_all_keys(&self, peer_addr: &std::net::SocketAddr) -> Option<KeyDumpResponse> {
+    pub async fn pull_all_keys(&self, peer_addr: &str) -> Option<KeyDumpResponse> {
         let url = format!("http://{}/api/internal/keys", peer_addr);
 
         match self.http_client.get(&url).send().await {
@@ -223,7 +222,7 @@ impl SyncClient {
     /// Returns `None` on failure.
     pub async fn pull_delta(
         &self,
-        peer_addr: &SocketAddr,
+        peer_addr: &str,
         sender: &str,
         frontier: &HlcTimestamp,
     ) -> Option<DeltaSyncResponse> {
@@ -264,7 +263,7 @@ impl SyncClient {
     /// Returns `true` on success.
     pub async fn push_delta(
         &self,
-        peer_addr: &SocketAddr,
+        peer_addr: &str,
         entries: HashMap<String, CrdtValue>,
         sender_id: &str,
     ) -> bool {
@@ -377,7 +376,7 @@ mod tests {
             nid("node-1"),
             vec![PeerConfig {
                 node_id: nid("node-2"),
-                addr: "127.0.0.1:8001".parse().unwrap(),
+                addr: "127.0.0.1:8001".to_string(),
             }],
         )
         .unwrap();
@@ -392,7 +391,7 @@ mod tests {
             nid("node-1"),
             vec![PeerConfig {
                 node_id: nid("node-2"),
-                addr: "127.0.0.1:8001".parse().unwrap(),
+                addr: "127.0.0.1:8001".to_string(),
             }],
         )
         .unwrap();
@@ -409,7 +408,7 @@ mod tests {
             vec![PeerConfig {
                 node_id: nid("node-2"),
                 // Unreachable address.
-                addr: "127.0.0.1:1".parse().unwrap(),
+                addr: "127.0.0.1:1".to_string(),
             }],
         )
         .unwrap();
@@ -440,8 +439,7 @@ mod tests {
             .unwrap();
         let client = SyncClient::with_client(registry, http_client);
 
-        let addr: std::net::SocketAddr = "127.0.0.1:1".parse().unwrap();
-        let result = client.pull_all_keys(&addr).await;
+        let result = client.pull_all_keys("127.0.0.1:1").await;
         assert!(result.is_none());
     }
 
@@ -518,8 +516,9 @@ mod tests {
             .unwrap();
         let client = SyncClient::with_client(registry, http_client);
 
-        let addr: SocketAddr = "127.0.0.1:1".parse().unwrap();
-        let result = client.pull_delta(&addr, "node-1", &hlc(0, 0, "")).await;
+        let result = client
+            .pull_delta("127.0.0.1:1", "node-1", &hlc(0, 0, ""))
+            .await;
         assert!(result.is_none());
     }
 
@@ -528,8 +527,9 @@ mod tests {
         let registry = PeerRegistry::new(nid("node-1"), vec![]).unwrap();
         let client = SyncClient::new(registry);
 
-        let addr: SocketAddr = "127.0.0.1:1".parse().unwrap();
-        let result = client.push_delta(&addr, HashMap::new(), "node-1").await;
+        let result = client
+            .push_delta("127.0.0.1:1", HashMap::new(), "node-1")
+            .await;
         assert!(result);
     }
 }

--- a/src/runtime/node_runner.rs
+++ b/src/runtime/node_runner.rs
@@ -639,7 +639,7 @@ impl NodeRunner {
         let mut any_success = false;
 
         for peer in &peers {
-            let peer_key = peer.addr.to_string();
+            let peer_key = peer.addr.clone();
 
             // Try delta sync if we have a frontier for this peer.
             if let Some(frontier) = self.peer_frontiers.get(&peer_key) {

--- a/tests/anti_entropy_convergence.rs
+++ b/tests/anti_entropy_convergence.rs
@@ -117,7 +117,7 @@ async fn two_node_anti_entropy_convergence() {
         node_id("node-1"),
         vec![PeerConfig {
             node_id: node_id("node-2"),
-            addr: addr2,
+            addr: addr2.to_string(),
         }],
     )
     .unwrap();
@@ -139,7 +139,7 @@ async fn two_node_anti_entropy_convergence() {
         node_id("node-2"),
         vec![PeerConfig {
             node_id: node_id("node-1"),
-            addr: addr1,
+            addr: addr1.to_string(),
         }],
     )
     .unwrap();
@@ -274,7 +274,7 @@ async fn pull_based_sync() {
     let registry = PeerRegistry::new(node_id("puller"), vec![]).unwrap();
     let sync_client = SyncClient::new(registry);
 
-    let pulled = sync_client.pull_all_keys(&addr).await;
+    let pulled = sync_client.pull_all_keys(&addr.to_string()).await;
     assert!(pulled.is_some(), "pull should succeed");
 
     let dump = pulled.unwrap();
@@ -449,7 +449,7 @@ async fn three_node_convergence_via_sync() {
                 .filter(|&j| j != i)
                 .map(|j| PeerConfig {
                     node_id: node_id(&format!("node-{}", j + 1)),
-                    addr: addrs[j],
+                    addr: addrs[j].to_string(),
                 })
                 .collect();
 
@@ -600,7 +600,7 @@ async fn full_sync_records_remote_frontier_not_local() {
     let registry = PeerRegistry::new(node_id("local"), vec![]).unwrap();
     let sync_client = SyncClient::new(registry);
 
-    let dump = sync_client.pull_all_keys(&remote_addr).await;
+    let dump = sync_client.pull_all_keys(&remote_addr.to_string()).await;
     assert!(dump.is_some(), "pull should succeed");
 
     let dump = dump.unwrap();

--- a/tests/compound_e2e.rs
+++ b/tests/compound_e2e.rs
@@ -1201,7 +1201,7 @@ async fn node_runner_delta_fail_falls_back_to_full_sync() {
         node_id("local"),
         vec![PeerConfig {
             node_id: node_id("legacy"),
-            addr: legacy_addr,
+            addr: legacy_addr.to_string(),
         }],
     )
     .unwrap();


### PR DESCRIPTION
Closes #145

## Summary

- Add `ASTEROIDB_CONFIG` env var support to `main.rs` for loading node configuration from a JSON file
- When config file provides peers, anti-entropy sync is automatically enabled via `NodeRunner::with_sync`
- Without `ASTEROIDB_CONFIG`, existing env var behavior (`ASTEROIDB_BIND_ADDR`, `ASTEROIDB_NODE_ID`) is preserved for backwards compatibility
- Change `PeerConfig.addr` from `SocketAddr` to `String` to support both IP:port and hostname:port formats (needed for Docker Compose hostnames like `asteroidb-node-2:3000`)
- Add test for loading project config files (`configs/node-*.json`)
- Update `docs/getting-started.md` with config file usage instructions

## Test plan

- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] All 818 tests pass (599 lib + 219 integration/e2e)
- [x] New test `node_config_load_project_config_files` verifies configs/node-*.json are loadable
- [ ] Manual verification: `ASTEROIDB_CONFIG=configs/node-1.json cargo run` starts successfully
- [ ] Manual verification: `cargo run` (no env var) preserves existing behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)