### PR TITLE
feat: add Bearer token auth for internal API

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
     environment:
       ASTEROIDB_BIND_ADDR: "0.0.0.0:3000"
       ASTEROIDB_NODE_ID: "node-1"
+      ASTEROIDB_INTERNAL_TOKEN: "${ASTEROIDB_INTERNAL_TOKEN}"
     networks:
       - asteroidb
 
@@ -22,6 +23,7 @@ services:
     environment:
       ASTEROIDB_BIND_ADDR: "0.0.0.0:3000"
       ASTEROIDB_NODE_ID: "node-2"
+      ASTEROIDB_INTERNAL_TOKEN: "${ASTEROIDB_INTERNAL_TOKEN}"
     networks:
       - asteroidb
 
@@ -35,6 +37,7 @@ services:
     environment:
       ASTEROIDB_BIND_ADDR: "0.0.0.0:3000"
       ASTEROIDB_NODE_ID: "node-3"
+      ASTEROIDB_INTERNAL_TOKEN: "${ASTEROIDB_INTERNAL_TOKEN}"
     networks:
       - asteroidb
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -133,6 +133,16 @@ cargo run
 
 起動すると、HTTP サーバーが `127.0.0.1:3000` で起動し、3 つの Authority ノード (`auth-1`, `auth-2`, `auth-3`) を含むデフォルト構成でバックグラウンド処理を開始します。バインドアドレスは環境変数 `ASTEROIDB_BIND_ADDR` で、ノード ID は `ASTEROIDB_NODE_ID` で変更可能です。`Ctrl-C` で停止します。
 
+**Internal API 認証 (オプション)**
+
+`ASTEROIDB_INTERNAL_TOKEN` 環境変数を設定すると、`/api/internal/*` エンドポイントに Bearer トークン認証が適用されます。すべてのクラスタノードに同じトークンを設定してください。
+
+```bash
+ASTEROIDB_INTERNAL_TOKEN=my-secret-token cargo run
+```
+
+トークンが設定されている場合、ノード間通信 (SyncClient, FrontierSyncClient) は自動的に `Authorization: Bearer <token>` ヘッダを付与します。トークンが未設定の場合、認証なしで動作します (後方互換性あり)。
+
 ### HTTP API エンドポイント一覧
 
 #### Client API

--- a/src/http/auth.rs
+++ b/src/http/auth.rs
@@ -1,0 +1,128 @@
+use axum::body::Body;
+use axum::extract::Request;
+use axum::http::StatusCode;
+use axum::middleware::Next;
+use axum::response::{IntoResponse, Response};
+
+/// Axum middleware that validates Bearer token authentication.
+///
+/// Extracts the `Authorization` header and checks that it contains a
+/// valid `Bearer <token>` value matching the expected token. Returns
+/// `401 Unauthorized` if the header is missing, malformed, or contains
+/// the wrong token.
+pub async fn require_bearer_token(
+    request: Request<Body>,
+    next: Next,
+    expected_token: String,
+) -> Response {
+    let auth_header = request
+        .headers()
+        .get("authorization")
+        .and_then(|v| v.to_str().ok());
+
+    match auth_header {
+        Some(header) => match header.strip_prefix("Bearer ") {
+            Some(token) if token == expected_token => next.run(request).await,
+            _ => StatusCode::UNAUTHORIZED.into_response(),
+        },
+        None => StatusCode::UNAUTHORIZED.into_response(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::Router;
+    use axum::body::Body;
+    use axum::http::{Request, StatusCode};
+    use axum::middleware;
+    use axum::routing::get;
+    use http_body_util::BodyExt;
+    use tower::ServiceExt;
+
+    async fn ok_handler() -> &'static str {
+        "ok"
+    }
+
+    fn test_app(token: &str) -> Router {
+        let token = token.to_string();
+        Router::new()
+            .route("/protected", get(ok_handler))
+            .layer(middleware::from_fn(move |req, next| {
+                let t = token.clone();
+                require_bearer_token(req, next, t)
+            }))
+    }
+
+    #[tokio::test]
+    async fn request_with_correct_token_succeeds() {
+        let app = test_app("secret-token");
+
+        let req = Request::builder()
+            .uri("/protected")
+            .header("authorization", "Bearer secret-token")
+            .body(Body::empty())
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let body = resp.into_body().collect().await.unwrap().to_bytes();
+        assert_eq!(&body[..], b"ok");
+    }
+
+    #[tokio::test]
+    async fn request_without_token_returns_401() {
+        let app = test_app("secret-token");
+
+        let req = Request::builder()
+            .uri("/protected")
+            .body(Body::empty())
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn request_with_wrong_token_returns_401() {
+        let app = test_app("secret-token");
+
+        let req = Request::builder()
+            .uri("/protected")
+            .header("authorization", "Bearer wrong-token")
+            .body(Body::empty())
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn request_with_malformed_header_returns_401() {
+        let app = test_app("secret-token");
+
+        let req = Request::builder()
+            .uri("/protected")
+            .header("authorization", "Basic secret-token")
+            .body(Body::empty())
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn request_with_bearer_no_space_returns_401() {
+        let app = test_app("secret-token");
+
+        let req = Request::builder()
+            .uri("/protected")
+            .header("authorization", "Bearersecret-token")
+            .body(Body::empty())
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
+}

--- a/src/http/handlers.rs
+++ b/src/http/handlers.rs
@@ -45,6 +45,10 @@ pub struct AppState {
     pub peer_persist_path: Option<PathBuf>,
     /// Control-plane consensus for gating namespace updates (FR-009).
     pub consensus: Arc<Mutex<ControlPlaneConsensus>>,
+    /// Optional shared token for authenticating internal API requests.
+    /// When `Some`, all `/api/internal/*` routes require a matching
+    /// `Authorization: Bearer <token>` header.
+    pub internal_token: Option<String>,
 }
 
 // ---------------------------------------------------------------

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -1,3 +1,4 @@
+pub(crate) mod auth;
 pub mod handlers;
 pub mod routes;
 pub mod types;

--- a/src/http/routes.rs
+++ b/src/http/routes.rs
@@ -12,14 +12,13 @@ use super::handlers::{
 };
 
 /// Build the HTTP API router with all endpoints.
+///
+/// When `AppState::internal_token` is `Some`, the `/api/internal/*`
+/// routes are protected by Bearer token authentication. When `None`,
+/// all routes are open (backwards-compatible).
 pub fn router(state: Arc<AppState>) -> Router {
-    Router::new()
-        .route("/api/eventual/write", post(eventual_write))
-        .route("/api/eventual/{key}", get(get_eventual))
-        .route("/api/certified/write", post(certified_write))
-        .route("/api/certified/verify", post(verify_proof))
-        .route("/api/certified/{key}", get(get_certified))
-        .route("/api/status/{key}", get(get_certification_status))
+    // Internal routes sub-router. Conditionally wrapped with auth middleware.
+    let internal_routes = Router::new()
         .route(
             "/api/internal/frontiers",
             post(post_internal_frontiers).get(get_internal_frontiers),
@@ -28,7 +27,26 @@ pub fn router(state: Arc<AppState>) -> Router {
         .route("/api/internal/sync/delta", post(internal_delta_sync))
         .route("/api/internal/keys", get(internal_keys))
         .route("/api/internal/join", post(internal_join))
-        .route("/api/internal/leave", post(internal_leave))
+        .route("/api/internal/leave", post(internal_leave));
+
+    let internal_routes = if let Some(ref token) = state.internal_token {
+        let token = token.clone();
+        internal_routes.layer(axum::middleware::from_fn(move |req, next| {
+            let t = token.clone();
+            super::auth::require_bearer_token(req, next, t)
+        }))
+    } else {
+        internal_routes
+    };
+
+    Router::new()
+        .route("/api/eventual/write", post(eventual_write))
+        .route("/api/eventual/{key}", get(get_eventual))
+        .route("/api/certified/write", post(certified_write))
+        .route("/api/certified/verify", post(verify_proof))
+        .route("/api/certified/{key}", get(get_certified))
+        .route("/api/status/{key}", get(get_certification_status))
+        .merge(internal_routes)
         // Control-plane endpoints
         .route(
             "/api/control-plane/authorities",
@@ -72,6 +90,10 @@ mod tests {
     use tower::ServiceExt;
 
     fn test_state() -> Arc<AppState> {
+        test_state_with_token(None)
+    }
+
+    fn test_state_with_token(token: Option<String>) -> Arc<AppState> {
         let node_id = NodeId("test-node".into());
 
         let mut ns = SystemNamespace::new();
@@ -105,6 +127,7 @@ mod tests {
                     NodeId("auth-3".into()),
                 ]),
             )),
+            internal_token: token,
         })
     }
 
@@ -1358,5 +1381,83 @@ mod tests {
         let body = body_string(resp.into_body()).await;
         let result: FrontierPushResponse = serde_json::from_str(&body).unwrap();
         assert_eq!(result.accepted, 1, "newer frontier should be accepted");
+    }
+
+    // ---------------------------------------------------------------
+    // Internal API auth tests
+    // ---------------------------------------------------------------
+
+    #[tokio::test]
+    async fn internal_route_without_token_config_allows_all() {
+        // No internal_token configured -> all requests pass without auth.
+        let state = test_state_with_token(None);
+        let app = router(state);
+
+        let req = Request::builder()
+            .uri("/api/internal/keys")
+            .body(Body::empty())
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn internal_route_rejects_missing_token() {
+        let state = test_state_with_token(Some("test-secret".into()));
+        let app = router(state);
+
+        let req = Request::builder()
+            .uri("/api/internal/keys")
+            .body(Body::empty())
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn internal_route_rejects_wrong_token() {
+        let state = test_state_with_token(Some("test-secret".into()));
+        let app = router(state);
+
+        let req = Request::builder()
+            .uri("/api/internal/keys")
+            .header("authorization", "Bearer wrong-secret")
+            .body(Body::empty())
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn internal_route_accepts_correct_token() {
+        let state = test_state_with_token(Some("test-secret".into()));
+        let app = router(state);
+
+        let req = Request::builder()
+            .uri("/api/internal/keys")
+            .header("authorization", "Bearer test-secret")
+            .body(Body::empty())
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn public_route_unaffected_by_internal_token() {
+        // Even with internal_token configured, public routes remain open.
+        let state = test_state_with_token(Some("test-secret".into()));
+        let app = router(state);
+
+        let req = Request::builder()
+            .uri("/api/eventual/nonexistent")
+            .body(Body::empty())
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -129,6 +129,9 @@ async fn main() {
         NodeId("auth-3".into()),
     ])));
 
+    // Optional shared token for authenticating internal API requests.
+    let internal_token = std::env::var("ASTEROIDB_INTERNAL_TOKEN").ok();
+
     // Build shared HTTP state.
     let state = Arc::new(AppState {
         eventual: Arc::clone(&eventual_api),
@@ -138,6 +141,7 @@ async fn main() {
         peers: Some(Arc::clone(&shared_peers)),
         peer_persist_path: Some(peer_persist_path),
         consensus,
+        internal_token: internal_token.clone(),
     });
 
     let app = router(state);
@@ -148,7 +152,11 @@ async fn main() {
     let mut runner = if has_peers {
         // Config file provided peers — enable anti-entropy sync.
         let sync_registry = shared_peers.lock().await.clone();
-        let sync_client = SyncClient::new(sync_registry);
+        let sync_client = if let Some(ref token) = internal_token {
+            SyncClient::with_token(sync_registry, token.clone())
+        } else {
+            SyncClient::new(sync_registry)
+        };
         NodeRunner::with_sync(
             node_id,
             Arc::clone(&certified_api),

--- a/src/network/frontier_sync.rs
+++ b/src/network/frontier_sync.rs
@@ -35,6 +35,8 @@ pub struct FrontierPullResponse {
 /// deduplication) is handled by `AckFrontierSet::update()`.
 pub struct FrontierSyncClient {
     http_client: reqwest::Client,
+    /// Optional Bearer token added to all outbound requests for internal API auth.
+    auth_token: Option<String>,
 }
 
 impl FrontierSyncClient {
@@ -45,7 +47,37 @@ impl FrontierSyncClient {
                 .timeout(Duration::from_secs(5))
                 .build()
                 .expect("failed to build FrontierSyncClient HTTP client"),
+            auth_token: None,
         }
+    }
+
+    /// Create a sync client that attaches a Bearer token to all requests.
+    pub fn with_token(token: String) -> Self {
+        Self {
+            http_client: reqwest::Client::builder()
+                .timeout(Duration::from_secs(5))
+                .build()
+                .expect("failed to build FrontierSyncClient HTTP client"),
+            auth_token: Some(token),
+        }
+    }
+
+    /// Return a POST request builder with optional Bearer token header.
+    fn authorized_post(&self, url: &str) -> reqwest::RequestBuilder {
+        let mut builder = self.http_client.post(url);
+        if let Some(ref token) = self.auth_token {
+            builder = builder.header("authorization", format!("Bearer {token}"));
+        }
+        builder
+    }
+
+    /// Return a GET request builder with optional Bearer token header.
+    fn authorized_get(&self, url: &str) -> reqwest::RequestBuilder {
+        let mut builder = self.http_client.get(url);
+        if let Some(ref token) = self.auth_token {
+            builder = builder.header("authorization", format!("Bearer {token}"));
+        }
+        builder
     }
 
     /// Push frontier updates to a remote peer.
@@ -64,8 +96,7 @@ impl FrontierSyncClient {
         let url = format!("http://{peer_addr}/api/internal/frontiers");
         let body = FrontierPushRequest { frontiers };
 
-        self.http_client
-            .post(&url)
+        self.authorized_post(&url)
             .json(&body)
             .send()
             .await?
@@ -84,8 +115,7 @@ impl FrontierSyncClient {
     ) -> Result<FrontierPullResponse, reqwest::Error> {
         let url = format!("http://{peer_addr}/api/internal/frontiers");
 
-        self.http_client
-            .get(&url)
+        self.authorized_get(&url)
             .send()
             .await?
             .error_for_status()?

--- a/src/network/sync.rs
+++ b/src/network/sync.rs
@@ -89,6 +89,8 @@ pub struct DeltaSyncResponse {
 pub struct SyncClient {
     peer_registry: PeerRegistry,
     http_client: reqwest::Client,
+    /// Optional Bearer token added to all outbound requests for internal API auth.
+    auth_token: Option<String>,
 }
 
 impl SyncClient {
@@ -101,6 +103,20 @@ impl SyncClient {
         Self {
             peer_registry,
             http_client,
+            auth_token: None,
+        }
+    }
+
+    /// Create a `SyncClient` that attaches a Bearer token to all requests.
+    pub fn with_token(peer_registry: PeerRegistry, token: String) -> Self {
+        let http_client = reqwest::Client::builder()
+            .timeout(Duration::from_secs(5))
+            .build()
+            .expect("failed to build HTTP client");
+        Self {
+            peer_registry,
+            http_client,
+            auth_token: Some(token),
         }
     }
 
@@ -109,7 +125,26 @@ impl SyncClient {
         Self {
             peer_registry,
             http_client,
+            auth_token: None,
         }
+    }
+
+    /// Return a request builder with optional Bearer token header.
+    fn authorized_get(&self, url: &str) -> reqwest::RequestBuilder {
+        let mut builder = self.http_client.get(url);
+        if let Some(ref token) = self.auth_token {
+            builder = builder.header("authorization", format!("Bearer {token}"));
+        }
+        builder
+    }
+
+    /// Return a POST request builder with optional Bearer token header.
+    fn authorized_post(&self, url: &str) -> reqwest::RequestBuilder {
+        let mut builder = self.http_client.post(url);
+        if let Some(ref token) = self.auth_token {
+            builder = builder.header("authorization", format!("Bearer {token}"));
+        }
+        builder
     }
 
     /// Push all key-value pairs from the local store to every peer.
@@ -138,7 +173,7 @@ impl SyncClient {
         for peer in self.peer_registry.all_peers() {
             let url = format!("http://{}/api/internal/sync", peer.addr);
 
-            match self.http_client.post(&url).json(&request).send().await {
+            match self.authorized_post(&url).json(&request).send().await {
                 Ok(resp) => {
                     if resp.status().is_success() {
                         success_count += 1;
@@ -175,7 +210,7 @@ impl SyncClient {
     pub async fn pull_all_keys(&self, peer_addr: &str) -> Option<KeyDumpResponse> {
         let url = format!("http://{}/api/internal/keys", peer_addr);
 
-        match self.http_client.get(&url).send().await {
+        match self.authorized_get(&url).send().await {
             Ok(resp) => {
                 if resp.status().is_success() {
                     match resp.json::<KeyDumpResponse>().await {
@@ -232,7 +267,7 @@ impl SyncClient {
             frontier: frontier.clone(),
         };
 
-        match self.http_client.post(&url).json(&req).send().await {
+        match self.authorized_post(&url).json(&req).send().await {
             Ok(resp) => {
                 if resp.status().is_success() {
                     match resp.json::<DeltaSyncResponse>().await {
@@ -277,7 +312,7 @@ impl SyncClient {
             entries,
         };
 
-        match self.http_client.post(&url).json(&request).send().await {
+        match self.authorized_post(&url).json(&request).send().await {
             Ok(resp) => {
                 if resp.status().is_success() {
                     tracing::debug!("delta push succeeded");

--- a/src/runtime/node_runner.rs
+++ b/src/runtime/node_runner.rs
@@ -243,6 +243,14 @@ impl NodeRunner {
         self.eventual_api = Some(api);
     }
 
+    /// Replace the sync client used for anti-entropy replication.
+    ///
+    /// Useful for injecting a token-enabled `SyncClient` after
+    /// construction when the token is not known at `NodeRunner` creation time.
+    pub fn set_sync_client(&mut self, client: SyncClient) {
+        self.sync_client = Some(client);
+    }
+
     /// Inject a peer frontier for testing purposes.
     ///
     /// This forces the next sync cycle to attempt delta sync first for

--- a/tests/anti_entropy_convergence.rs
+++ b/tests/anti_entropy_convergence.rs
@@ -65,6 +65,7 @@ async fn two_node_anti_entropy_convergence() {
         peers: None,
         peer_persist_path: None,
         consensus: Arc::new(Mutex::new(ControlPlaneConsensus::new(vec![]))),
+        internal_token: None,
     });
 
     // Build state for node 2.
@@ -80,6 +81,7 @@ async fn two_node_anti_entropy_convergence() {
         peers: None,
         peer_persist_path: None,
         consensus: Arc::new(Mutex::new(ControlPlaneConsensus::new(vec![]))),
+        internal_token: None,
     });
 
     // Write some data to node 1.
@@ -261,6 +263,7 @@ async fn pull_based_sync() {
         peers: None,
         peer_persist_path: None,
         consensus: Arc::new(Mutex::new(ControlPlaneConsensus::new(vec![]))),
+        internal_token: None,
     });
 
     {
@@ -319,6 +322,7 @@ async fn sync_endpoint_partial_failure() {
         peers: None,
         peer_persist_path: None,
         consensus: Arc::new(Mutex::new(ControlPlaneConsensus::new(vec![]))),
+        internal_token: None,
     });
 
     // Pre-populate with a counter at "k".
@@ -412,6 +416,7 @@ async fn three_node_convergence_via_sync() {
             peers: None,
             peer_persist_path: None,
             consensus: Arc::new(Mutex::new(ControlPlaneConsensus::new(vec![]))),
+            internal_token: None,
         });
         states.push(state);
     }
@@ -521,6 +526,7 @@ async fn internal_keys_endpoint() {
         peers: None,
         peer_persist_path: None,
         consensus: Arc::new(Mutex::new(ControlPlaneConsensus::new(vec![]))),
+        internal_token: None,
     });
 
     {
@@ -588,6 +594,7 @@ async fn full_sync_records_remote_frontier_not_local() {
         peers: None,
         peer_persist_path: None,
         consensus: Arc::new(Mutex::new(ControlPlaneConsensus::new(vec![]))),
+        internal_token: None,
     });
 
     // Write data to the remote node.

--- a/tests/compound_e2e.rs
+++ b/tests/compound_e2e.rs
@@ -147,6 +147,7 @@ fn test_state_with_ns(nid: NodeId, ns: Arc<RwLock<SystemNamespace>>) -> Arc<AppS
         peers: None,
         peer_persist_path: None,
         consensus: Arc::new(Mutex::new(ControlPlaneConsensus::new(vec![]))),
+        internal_token: None,
     })
 }
 
@@ -1166,6 +1167,7 @@ async fn node_runner_delta_fail_falls_back_to_full_sync() {
         peers: None,
         peer_persist_path: None,
         consensus: Arc::new(Mutex::new(ControlPlaneConsensus::new(vec![]))),
+        internal_token: None,
     });
 
     // Write data to the legacy peer.

--- a/tests/delta_sync.rs
+++ b/tests/delta_sync.rs
@@ -57,6 +57,7 @@ fn test_state() -> Arc<AppState> {
         peers: None,
         peer_persist_path: None,
         consensus: Arc::new(Mutex::new(ControlPlaneConsensus::new(vec![]))),
+        internal_token: None,
     })
 }
 

--- a/tests/e2e_multiprocess.rs
+++ b/tests/e2e_multiprocess.rs
@@ -61,6 +61,7 @@ async fn spawn_node(name: &str) -> (Arc<AppState>, SocketAddr, JoinHandle<()>) {
         peers: None,
         peer_persist_path: None,
         consensus: Arc::new(Mutex::new(ControlPlaneConsensus::new(vec![]))),
+        internal_token: None,
     });
 
     let app = router(state.clone());

--- a/tests/http_server.rs
+++ b/tests/http_server.rs
@@ -47,6 +47,7 @@ fn test_state() -> Arc<AppState> {
         peers: None,
         peer_persist_path: None,
         consensus,
+        internal_token: None,
     })
 }
 

--- a/tests/node_join_leave.rs
+++ b/tests/node_join_leave.rs
@@ -66,6 +66,7 @@ async fn spawn_node_with_peers(
         peers: Some(peer_registry),
         peer_persist_path: None,
         consensus: Arc::new(Mutex::new(ControlPlaneConsensus::new(vec![]))),
+        internal_token: None,
     });
 
     let app = router(state.clone());


### PR DESCRIPTION
Closes #146

## Summary
- Add ASTEROIDB_INTERNAL_TOKEN env var for shared-token auth on /api/internal/* routes
- Protect /api/internal/* with Bearer token middleware (axum middleware layer)
- SyncClient/FrontierSyncClient automatically send token in outbound requests
- Backwards compatible: no token configured = no auth required
- NodeRunner gains set_sync_client() for post-construction token injection
- docker-compose.yml passes ASTEROIDB_INTERNAL_TOKEN from host environment
- docs/getting-started.md updated with configuration instructions

## Test plan
- [x] Request without token -> 401
- [x] Request with wrong token -> 401
- [x] Request with correct token -> success
- [x] No token configured -> all requests pass
- [x] Public routes unaffected by internal token config
- [x] cargo fmt --check passes
- [x] cargo clippy -- -D warnings passes
- [x] cargo test passes (all 800+ tests)
