### PR TITLE
feat: optimize delta sync with batching, compression, and backoff

### DIFF
--- a/src/network/sync.rs
+++ b/src/network/sync.rs
@@ -156,7 +156,8 @@ impl PeerBackoff {
     /// with a random jitter of up to 25% of the computed delay.
     pub fn record_failure(&mut self) {
         self.consecutive_failures = self.consecutive_failures.saturating_add(1);
-        let base = Self::INITIAL_BACKOFF.saturating_mul(1u32 << self.consecutive_failures.min(5));
+        let base = Self::INITIAL_BACKOFF
+            .saturating_mul(1u32 << self.consecutive_failures.saturating_sub(1).min(5));
         let capped = base.min(Self::MAX_BACKOFF);
 
         // Add jitter: up to 25% of the capped delay.
@@ -187,7 +188,8 @@ impl PeerBackoff {
         if self.consecutive_failures == 0 {
             return Duration::ZERO;
         }
-        let base = Self::INITIAL_BACKOFF.saturating_mul(1u32 << self.consecutive_failures.min(5));
+        let base = Self::INITIAL_BACKOFF
+            .saturating_mul(1u32 << self.consecutive_failures.saturating_sub(1).min(5));
         base.min(Self::MAX_BACKOFF)
     }
 }
@@ -497,46 +499,6 @@ impl SyncClient {
             }
         }
     }
-
-    /// Push changed entries to a peer using batched delta sync.
-    ///
-    /// This is a convenience wrapper around [`Self::push_changed_keys`]
-    /// using the [`DEFAULT_BATCH_SIZE`].
-    ///
-    /// Returns `true` on success.
-    #[allow(dead_code)]
-    pub async fn push_delta(
-        &self,
-        peer_addr: &str,
-        entries: HashMap<String, CrdtValue>,
-        sender_id: &str,
-    ) -> bool {
-        if entries.is_empty() {
-            return true;
-        }
-
-        let url = format!("http://{peer_addr}/api/internal/sync");
-        let request = SyncRequest {
-            sender: sender_id.to_string(),
-            entries,
-        };
-
-        match self.authorized_post(&url).json(&request).send().await {
-            Ok(resp) => {
-                if resp.status().is_success() {
-                    tracing::debug!("delta push succeeded");
-                    true
-                } else {
-                    tracing::warn!(status = %resp.status(), "delta push received non-success status");
-                    false
-                }
-            }
-            Err(e) => {
-                tracing::warn!(error = %e, "delta push failed");
-                false
-            }
-        }
-    }
 }
 
 #[cfg(test)]
@@ -798,17 +760,6 @@ mod tests {
         assert!(result.is_none());
     }
 
-    #[tokio::test]
-    async fn push_delta_empty_entries_returns_true() {
-        let registry = shared_registry(vec![]);
-        let client = SyncClient::new(registry);
-
-        let result = client
-            .push_delta("127.0.0.1:1", HashMap::new(), "node-1")
-            .await;
-        assert!(result);
-    }
-
     // ---------------------------------------------------------------
     // push_changed_keys tests
     // ---------------------------------------------------------------
@@ -905,6 +856,14 @@ mod tests {
         // Immediately after failure, the backoff should gate retries
         // (ready_at is in the future).
         assert!(!b.is_ready());
+    }
+
+    #[test]
+    fn backoff_first_failure_uses_initial_delay() {
+        let mut b = PeerBackoff::new();
+        b.record_failure();
+        // First failure should use INITIAL_BACKOFF (1s), not 2x.
+        assert_eq!(b.base_delay(), PeerBackoff::INITIAL_BACKOFF);
     }
 
     #[test]

--- a/src/runtime/node_runner.rs
+++ b/src/runtime/node_runner.rs
@@ -731,13 +731,31 @@ impl NodeRunner {
                                 total_changed = changed_count,
                                 "delta push succeeded"
                             );
+                            // Update peer frontier so next cycle only sends
+                            // entries newer than this point.
+                            let api = eventual_api.lock().await;
+                            if let Some(local_frontier) = api.store().current_frontier() {
+                                self.peer_frontiers.insert(peer_key.clone(), local_frontier);
+                            }
+                            drop(api);
                         }
                         Err(e) => {
                             tracing::warn!(
                                 peer = %peer.node_id.0,
                                 error = %e,
+                                pushed = e.pushed,
                                 "delta push failed"
                             );
+                            // Even on partial failure, if some entries were
+                            // pushed we advance the frontier so they are not
+                            // re-sent on the next cycle.
+                            if e.pushed > 0 {
+                                let api = eventual_api.lock().await;
+                                if let Some(local_frontier) = api.store().current_frontier() {
+                                    self.peer_frontiers.insert(peer_key.clone(), local_frontier);
+                                }
+                                drop(api);
+                            }
                             // Record failure and move to next peer.
                             self.peer_backoffs
                                 .entry(peer_key.clone())


### PR DESCRIPTION
## Summary

- `push_changed_keys()` メソッド追加: frontier ベースの差分抽出 + バッチ分割（100キー/リクエスト）
- per-peer 指数バックオフ（初回1秒、最大30秒、ジッター付き）
- push 成功後に `peer_frontiers` を更新し、再送を防止
- partial push 時も成功分の frontier を進める
- dead code `push_delta` を削除
- テスト11件追加

Closes #169

## Review Notes

- Claude review: P1×2 (frontier未更新、partial push) → 修正済み
- Claude P2 (backoff off-by-one、dead code) → 修正済み

## Test plan

- [x] `cargo test` 全テストパス
- [x] バックオフ初回が INITIAL_BACKOFF であることを確認するテスト
- [x] 動的ピア追加/削除の可視性テスト
- [x] バッチ分割テスト

🤖 Generated with [Claude Code](https://claude.com/claude-code)