### PR TITLE
fix: correct topology test variables, fix clippy, remove dead code

### DIFF
--- a/src/authority/bls.rs
+++ b/src/authority/bls.rs
@@ -292,7 +292,7 @@ mod tests {
         let kp = make_keypair(60);
         let msg = b"single aggregate";
         let sig = sign_message(kp.secret_key(), msg);
-        let agg = aggregate_signatures(&[sig.clone()]);
+        let agg = aggregate_signatures(std::slice::from_ref(&sig));
 
         // Aggregating a single signature should produce a valid aggregate.
         assert!(aggregate_verify(&[kp.public_key], msg, &agg));

--- a/src/network/peer.rs
+++ b/src/network/peer.rs
@@ -14,10 +14,6 @@ pub enum PeerError {
     #[error("duplicate node_id: {0}")]
     DuplicateNodeId(String),
 
-    /// A peer address could not be parsed as a valid [`SocketAddr`].
-    #[error("invalid address for node {node_id}: {reason}")]
-    InvalidAddress { node_id: String, reason: String },
-
     /// The local node's own ID appears in the peer list.
     #[error("self_id {0} must not appear in the peer list")]
     SelfInPeerList(String),
@@ -700,12 +696,6 @@ mod tests {
     fn peer_error_display() {
         let err = PeerError::DuplicateNodeId("node-x".into());
         assert_eq!(err.to_string(), "duplicate node_id: node-x");
-
-        let err = PeerError::InvalidAddress {
-            node_id: "node-y".into(),
-            reason: "bad port".into(),
-        };
-        assert_eq!(err.to_string(), "invalid address for node node-y: bad port");
 
         let err = PeerError::SelfInPeerList("node-z".into());
         assert_eq!(

--- a/src/placement/topology.rs
+++ b/src/placement/topology.rs
@@ -161,11 +161,11 @@ mod tests {
         assert_eq!(topo.total_nodes, 3);
         assert_eq!(topo.regions.len(), 2);
 
-        let us = topo.regions.iter().find(|r| r.name == "eu-west").unwrap();
-        assert_eq!(us.node_count, 1);
+        let us = topo.regions.iter().find(|r| r.name == "us-east").unwrap();
+        assert_eq!(us.node_count, 2);
 
-        let eu = topo.regions.iter().find(|r| r.name == "us-east").unwrap();
-        assert_eq!(eu.node_count, 2);
+        let eu = topo.regions.iter().find(|r| r.name == "eu-west").unwrap();
+        assert_eq!(eu.node_count, 1);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes #195 — minor cleanups found during full codebase review.

- **topology.rs**: Fix swapped `us`/`eu` variable names in tests (were passing by coincidence)
- **bls.rs**: Fix `clippy::cloned_ref_to_slice_refs` — use `std::slice::from_ref` instead of `&[sig.clone()]`
- **peer.rs**: Remove dead `PeerError::InvalidAddress` variant and its display test

## Test plan

- [x] `cargo test` — all pass
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)