### PR TITLE
fix: advance peer frontier to batch max HLC, not current_frontier

### DIFF
--- a/src/runtime/node_runner.rs
+++ b/src/runtime/node_runner.rs
@@ -996,11 +996,17 @@ impl NodeRunner {
             // --- Push phase: send only changed local keys to peer ---
             if let Some(frontier) = self.peer_frontiers.get(&peer_key) {
                 let api = eventual_api.lock().await;
-                let changed: Vec<(String, crate::store::kv::CrdtValue)> = api
-                    .store()
-                    .entries_since(frontier)
-                    .into_iter()
-                    .map(|(key, value, _hlc)| (key, value))
+                // entries_since returns entries sorted by HLC; preserve the
+                // per-entry HLC so we can compute the correct frontier to
+                // advance to after a (possibly partial) push.
+                let entries_with_hlc: Vec<(
+                    String,
+                    crate::store::kv::CrdtValue,
+                    crate::hlc::HlcTimestamp,
+                )> = api.store().entries_since(frontier);
+                let changed: Vec<(String, crate::store::kv::CrdtValue)> = entries_with_hlc
+                    .iter()
+                    .map(|(key, value, _hlc)| (key.clone(), value.clone()))
                     .collect();
                 let changed_count = changed.len();
                 drop(api);
@@ -1018,13 +1024,13 @@ impl NodeRunner {
                                 total_changed = changed_count,
                                 "delta push succeeded"
                             );
-                            // Update peer frontier so next cycle only sends
-                            // entries newer than this point.
-                            let api = eventual_api.lock().await;
-                            if let Some(local_frontier) = api.store().current_frontier() {
-                                self.peer_frontiers.insert(peer_key.clone(), local_frontier);
+                            // Advance peer frontier to the max HLC of the
+                            // pushed batch — NOT current_frontier(), which may
+                            // have advanced past unpushed concurrent writes.
+                            if let Some((_key, _val, max_hlc)) = entries_with_hlc.last() {
+                                self.peer_frontiers
+                                    .insert(peer_key.clone(), max_hlc.clone());
                             }
-                            drop(api);
                         }
                         Err(e) => {
                             tracing::warn!(
@@ -1033,15 +1039,16 @@ impl NodeRunner {
                                 pushed = e.pushed,
                                 "delta push failed"
                             );
-                            // Even on partial failure, if some entries were
-                            // pushed we advance the frontier so they are not
-                            // re-sent on the next cycle.
-                            if e.pushed > 0 {
-                                let api = eventual_api.lock().await;
-                                if let Some(local_frontier) = api.store().current_frontier() {
-                                    self.peer_frontiers.insert(peer_key.clone(), local_frontier);
-                                }
-                                drop(api);
+                            // On partial failure, advance the frontier only to
+                            // the HLC of the last successfully pushed entry.
+                            // entries_with_hlc is sorted by HLC, so index
+                            // `pushed - 1` is the last entry that was sent.
+                            if e.pushed > 0
+                                && let Some((_key, _val, last_pushed_hlc)) =
+                                    entries_with_hlc.get(e.pushed - 1)
+                            {
+                                self.peer_frontiers
+                                    .insert(peer_key.clone(), last_pushed_hlc.clone());
                             }
                             // Record failure and move to next peer.
                             self.peer_backoffs

--- a/src/store/kv.rs
+++ b/src/store/kv.rs
@@ -1148,6 +1148,120 @@ mod tests {
         );
     }
 
+    // ---------------------------------------------------------------
+    // Batch frontier computation (#193)
+    // ---------------------------------------------------------------
+
+    /// Verify that the max HLC of a batch from entries_since corresponds to
+    /// the last element (entries are sorted by HLC).  This is the property
+    /// relied upon by the delta push fix: we advance the peer frontier to
+    /// the batch max, not the store's current_frontier().
+    #[test]
+    fn entries_since_batch_max_hlc_equals_last_entry() {
+        let mut store = Store::new();
+
+        store.put("a".into(), CrdtValue::Counter(PnCounter::new()));
+        store.record_change("a", ts(100, 0, "N1"));
+
+        store.put("b".into(), CrdtValue::Counter(PnCounter::new()));
+        store.record_change("b", ts(200, 0, "N1"));
+
+        store.put("c".into(), CrdtValue::Counter(PnCounter::new()));
+        store.record_change("c", ts(300, 0, "N1"));
+
+        let frontier = ts(0, 0, "");
+        let entries = store.entries_since(&frontier);
+
+        // The last entry should have the max HLC of the batch.
+        let batch_max_hlc = entries.last().map(|(_, _, hlc)| hlc.clone());
+        assert_eq!(batch_max_hlc, Some(ts(300, 0, "N1")));
+
+        // This batch max is NOT necessarily equal to current_frontier()
+        // if new writes occur concurrently. Simulate that:
+        store.put("d".into(), CrdtValue::Counter(PnCounter::new()));
+        store.record_change("d", ts(400, 0, "N1"));
+
+        // current_frontier now is ts(400), but our batch max was ts(300).
+        assert_eq!(store.current_frontier(), Some(ts(400, 0, "N1")));
+        // The batch we already captured still has max ts(300).
+        assert_eq!(entries.last().unwrap().2, ts(300, 0, "N1"));
+    }
+
+    /// Verify that on a partial push (only first N entries succeed),
+    /// the correct frontier is the HLC of entry at index N-1.
+    #[test]
+    fn entries_since_partial_batch_frontier() {
+        let mut store = Store::new();
+
+        store.put("a".into(), CrdtValue::Counter(PnCounter::new()));
+        store.record_change("a", ts(100, 0, "N1"));
+
+        store.put("b".into(), CrdtValue::Counter(PnCounter::new()));
+        store.record_change("b", ts(200, 0, "N1"));
+
+        store.put("c".into(), CrdtValue::Counter(PnCounter::new()));
+        store.record_change("c", ts(300, 0, "N1"));
+
+        store.put("d".into(), CrdtValue::Counter(PnCounter::new()));
+        store.record_change("d", ts(400, 0, "N1"));
+
+        let frontier = ts(0, 0, "");
+        let entries = store.entries_since(&frontier);
+        assert_eq!(entries.len(), 4);
+
+        // If only 2 entries were pushed successfully, the frontier
+        // should advance to the HLC of entry at index 1 (0-based).
+        let pushed = 2;
+        let partial_frontier = &entries[pushed - 1].2;
+        assert_eq!(*partial_frontier, ts(200, 0, "N1"));
+
+        // Entries after this frontier should include the unpushed ones.
+        let remaining = store.entries_since(partial_frontier);
+        assert_eq!(remaining.len(), 2);
+        assert_eq!(remaining[0].0, "c");
+        assert_eq!(remaining[1].0, "d");
+    }
+
+    /// Concurrent writes during a push window must not be skipped.
+    /// The batch captured before the push should have a max HLC that
+    /// does NOT cover writes that occur during the push.
+    #[test]
+    fn concurrent_writes_during_push_not_skipped() {
+        let mut store = Store::new();
+
+        // Pre-existing entries (the "batch" to push).
+        store.put("x".into(), CrdtValue::Counter(PnCounter::new()));
+        store.record_change("x", ts(100, 0, "N1"));
+
+        store.put("y".into(), CrdtValue::Counter(PnCounter::new()));
+        store.record_change("y", ts(200, 0, "N1"));
+
+        // Capture the batch.
+        let frontier = ts(0, 0, "");
+        let batch = store.entries_since(&frontier);
+        let batch_max = batch.last().unwrap().2.clone();
+        assert_eq!(batch_max, ts(200, 0, "N1"));
+
+        // Simulate a concurrent write that occurs DURING the push.
+        store.put("z".into(), CrdtValue::Counter(PnCounter::new()));
+        store.record_change("z", ts(250, 0, "N1"));
+
+        // If we advance the frontier to batch_max (200), the concurrent
+        // write (250) will be picked up in the next cycle.
+        let next_batch = store.entries_since(&batch_max);
+        assert_eq!(next_batch.len(), 1);
+        assert_eq!(next_batch[0].0, "z");
+
+        // But if we had used current_frontier (250), we'd skip "z" forever!
+        let bad_frontier = store.current_frontier().unwrap();
+        assert_eq!(bad_frontier, ts(250, 0, "N1"));
+        let skipped = store.entries_since(&bad_frontier);
+        assert!(
+            skipped.is_empty(),
+            "using current_frontier would skip the concurrent write"
+        );
+    }
+
     #[test]
     fn migration_chain_v1_to_current_applied_on_load() {
         let dir = tempfile::tempdir().unwrap();

--- a/tests/delta_sync.rs
+++ b/tests/delta_sync.rs
@@ -405,3 +405,112 @@ async fn delta_sync_frontier_advances_correctly() {
     assert_eq!(delta2.entries.len(), 1);
     assert_eq!(delta2.entries[0].key, "key-2");
 }
+
+// ---------------------------------------------------------------
+// Frontier must use batch max HLC, not current_frontier (#193)
+// ---------------------------------------------------------------
+
+/// Verify that writes happening after entries_since is called are NOT
+/// skipped when the peer frontier is advanced to the batch's max HLC
+/// rather than the store's current_frontier.
+#[tokio::test]
+async fn concurrent_writes_during_push_are_not_skipped() {
+    let state = test_state();
+
+    // Phase 1: write initial entries and capture the batch.
+    {
+        let mut api = state.eventual.lock().await;
+        api.eventual_counter_inc("batch-key-1").unwrap();
+        api.eventual_counter_inc("batch-key-2").unwrap();
+    }
+
+    // Capture entries_since(zero) — this is the "batch" that would be pushed.
+    let batch = {
+        let api = state.eventual.lock().await;
+        api.store().entries_since(&hlc(0, 0, ""))
+    };
+    assert_eq!(batch.len(), 2);
+    let batch_max_hlc = batch.last().unwrap().2.clone();
+
+    // Phase 2: a concurrent write happens AFTER the batch was captured
+    // but BEFORE the push completes (simulated by writing now).
+    {
+        let mut api = state.eventual.lock().await;
+        api.eventual_counter_inc("concurrent-key").unwrap();
+    }
+
+    // The store's current_frontier now includes the concurrent write.
+    let current_frontier = {
+        let api = state.eventual.lock().await;
+        api.store().current_frontier().unwrap()
+    };
+    assert!(
+        current_frontier > batch_max_hlc,
+        "current_frontier should be ahead of batch max"
+    );
+
+    // If we advance the peer frontier to batch_max_hlc (correct behavior),
+    // the concurrent write is picked up next cycle.
+    let next_delta = {
+        let api = state.eventual.lock().await;
+        api.store().entries_since(&batch_max_hlc)
+    };
+    assert_eq!(
+        next_delta.len(),
+        1,
+        "using batch max HLC should leave 1 entry for next cycle"
+    );
+    assert_eq!(next_delta[0].0, "concurrent-key");
+
+    // If we had used current_frontier (the bug), the concurrent write
+    // would be permanently skipped.
+    let bad_delta = {
+        let api = state.eventual.lock().await;
+        api.store().entries_since(&current_frontier)
+    };
+    assert!(
+        bad_delta.is_empty(),
+        "using current_frontier would skip the concurrent write (the bug)"
+    );
+}
+
+/// Verify that on partial push failure, advancing the frontier to the
+/// last successfully pushed entry's HLC preserves unpushed entries.
+#[tokio::test]
+async fn partial_failure_does_not_skip_entries() {
+    let state = test_state();
+
+    // Write 4 entries with distinct timestamps.
+    {
+        let mut api = state.eventual.lock().await;
+        api.eventual_counter_inc("entry-1").unwrap();
+        api.eventual_counter_inc("entry-2").unwrap();
+        api.eventual_counter_inc("entry-3").unwrap();
+        api.eventual_counter_inc("entry-4").unwrap();
+    }
+
+    // Capture the batch (sorted by HLC).
+    let batch = {
+        let api = state.eventual.lock().await;
+        api.store().entries_since(&hlc(0, 0, ""))
+    };
+    assert_eq!(batch.len(), 4);
+
+    // Simulate partial failure: only first 2 entries were pushed.
+    let pushed = 2;
+    let partial_frontier = batch[pushed - 1].2.clone();
+
+    // The remaining entries (3 and 4) should be returned on next cycle.
+    let remaining = {
+        let api = state.eventual.lock().await;
+        api.store().entries_since(&partial_frontier)
+    };
+    assert_eq!(
+        remaining.len(),
+        2,
+        "2 unpushed entries should remain after partial push"
+    );
+    let remaining_keys: Vec<&str> = remaining.iter().map(|(k, _, _)| k.as_str()).collect();
+    assert!(remaining_keys.contains(&"entry-3"));
+    assert!(remaining_keys.contains(&"entry-4"));
+}


### PR DESCRIPTION
## Summary

Fixes #193 — delta push was advancing `peer_frontiers` to `current_frontier()` after success or partial failure. Since `current_frontier()` reflects writes that occurred *during* the push, concurrent entries could be permanently skipped for that peer.

**Changes:**
- Preserve per-entry HLC from `entries_since()` instead of discarding with `_hlc`
- On full success: advance frontier to max HLC of the pushed batch
- On partial failure: advance to HLC of last successfully pushed entry (`entries_with_hlc[pushed - 1]`)
- Removes unnecessary lock re-acquisition of `current_frontier()` post-push

**Tests added:**
- 3 unit tests in `store/kv.rs` for batch HLC computation
- 2 integration tests in `tests/delta_sync.rs` for concurrent writes and partial failure

## Test plan

- [x] `cargo test` — all 793+ tests pass
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)