### PR TITLE
fix: reject proof bundles without certificate and deduplicate authorities

### DIFF
--- a/src/api/certified.rs
+++ b/src/api/certified.rs
@@ -1589,7 +1589,7 @@ mod tests {
     }
 
     #[test]
-    fn proof_bundle_verifiable_with_verifier() {
+    fn proof_without_certificate_rejected_by_verifier() {
         use crate::authority::verifier;
 
         let mut api = CertifiedApi::new(node("node-1"), default_namespace());
@@ -1606,9 +1606,11 @@ mod tests {
         let result = api.get_certified("key1");
         let proof = result.proof.unwrap();
 
+        // Proofs without a certificate must be rejected to prevent forged proofs.
         let verification = verifier::verify_proof(&proof);
-        assert!(verification.valid);
+        assert!(!verification.valid);
         assert!(verification.has_majority);
+        assert!(verification.signatures_valid.is_none());
         assert_eq!(verification.contributing_count, 2);
         assert_eq!(verification.required_count, 2); // 3/2+1 = 2
     }

--- a/src/authority/verifier.rs
+++ b/src/authority/verifier.rs
@@ -37,23 +37,34 @@ pub struct VerificationResult {
 /// the node that returned the proof.
 pub fn verify_proof(bundle: &ProofBundle) -> VerificationResult {
     let required = bundle.total_authorities / 2 + 1;
-    let has_majority = bundle.contributing_authorities.len() >= required;
 
-    let signatures_valid = bundle.certificate.as_ref().map(|cert| {
-        let message = create_certificate_message(
-            &bundle.key_range,
-            &bundle.frontier_hlc,
-            &bundle.policy_version,
-        );
-        cert.verify_signatures(&message).is_ok()
-    });
+    // Deduplicate contributing authorities before counting.
+    let unique_authorities: std::collections::HashSet<&crate::types::NodeId> =
+        bundle.contributing_authorities.iter().collect();
+    let contributing_count = unique_authorities.len();
 
-    let valid = has_majority && signatures_valid.unwrap_or(true);
+    let has_majority = contributing_count >= required;
+
+    // A proof without a certificate is always invalid — a caller could
+    // fabricate a "valid" proof by simply listing enough authority IDs.
+    let signatures_valid = match bundle.certificate.as_ref() {
+        Some(cert) => {
+            let message = create_certificate_message(
+                &bundle.key_range,
+                &bundle.frontier_hlc,
+                &bundle.policy_version,
+            );
+            Some(cert.verify_signatures(&message).is_ok())
+        }
+        None => None,
+    };
+
+    let valid = has_majority && signatures_valid == Some(true);
 
     VerificationResult {
         valid,
         has_majority,
-        contributing_count: bundle.contributing_authorities.len(),
+        contributing_count,
         required_count: required,
         signatures_valid,
     }
@@ -76,24 +87,41 @@ pub fn verify_proof_with_registry(
     epoch_config: &EpochConfig,
 ) -> VerificationResult {
     let required = bundle.total_authorities / 2 + 1;
-    let has_majority = bundle.contributing_authorities.len() >= required;
 
-    let signatures_valid = bundle.certificate.as_ref().map(|cert| {
-        let message = create_certificate_message(
-            &bundle.key_range,
-            &bundle.frontier_hlc,
-            &bundle.policy_version,
-        );
-        cert.verify_signatures_with_registry(&message, registry, current_epoch, epoch_config)
-            .is_ok()
-    });
+    // Deduplicate contributing authorities before counting.
+    let unique_authorities: std::collections::HashSet<&crate::types::NodeId> =
+        bundle.contributing_authorities.iter().collect();
+    let contributing_count = unique_authorities.len();
 
-    let valid = has_majority && signatures_valid.unwrap_or(true);
+    let has_majority = contributing_count >= required;
+
+    // A proof without a certificate is always invalid.
+    let signatures_valid = match bundle.certificate.as_ref() {
+        Some(cert) => {
+            let message = create_certificate_message(
+                &bundle.key_range,
+                &bundle.frontier_hlc,
+                &bundle.policy_version,
+            );
+            Some(
+                cert.verify_signatures_with_registry(
+                    &message,
+                    registry,
+                    current_epoch,
+                    epoch_config,
+                )
+                .is_ok(),
+            )
+        }
+        None => None,
+    };
+
+    let valid = has_majority && signatures_valid == Some(true);
 
     VerificationResult {
         valid,
         has_majority,
-        contributing_count: bundle.contributing_authorities.len(),
+        contributing_count,
         required_count: required,
         signatures_valid,
     }
@@ -111,7 +139,13 @@ pub fn verify_proof_with_registry_detailed(
     epoch_config: &EpochConfig,
 ) -> Result<VerificationResult, CertError> {
     let required = bundle.total_authorities / 2 + 1;
-    let has_majority = bundle.contributing_authorities.len() >= required;
+
+    // Deduplicate contributing authorities before counting.
+    let unique_authorities: std::collections::HashSet<&crate::types::NodeId> =
+        bundle.contributing_authorities.iter().collect();
+    let contributing_count = unique_authorities.len();
+
+    let has_majority = contributing_count >= required;
 
     let signatures_valid = if let Some(cert) = &bundle.certificate {
         let message = create_certificate_message(
@@ -129,12 +163,12 @@ pub fn verify_proof_with_registry_detailed(
         None
     };
 
-    let valid = has_majority && signatures_valid.unwrap_or(true);
+    let valid = has_majority && signatures_valid == Some(true);
 
     Ok(VerificationResult {
         valid,
         has_majority,
-        contributing_count: bundle.contributing_authorities.len(),
+        contributing_count,
         required_count: required,
         signatures_valid,
     })
@@ -217,11 +251,13 @@ mod tests {
     }
 
     #[test]
-    fn valid_proof_passes_verification() {
+    fn proof_without_certificate_is_rejected() {
+        // Even with enough contributing authorities, a proof without a
+        // certificate must be rejected to prevent forged proofs.
         let proof = make_proof(3, 5, false);
         let result = verify_proof(&proof);
 
-        assert!(result.valid);
+        assert!(!result.valid);
         assert!(result.has_majority);
         assert_eq!(result.contributing_count, 3);
         assert_eq!(result.required_count, 3); // 5/2+1 = 3
@@ -230,7 +266,7 @@ mod tests {
 
     #[test]
     fn proof_with_insufficient_authorities_fails() {
-        let proof = make_proof(2, 5, false);
+        let proof = make_proof(2, 5, true);
         let result = verify_proof(&proof);
 
         assert!(!result.valid);
@@ -240,23 +276,19 @@ mod tests {
     }
 
     #[test]
-    fn tampered_proof_detected() {
-        let mut proof = make_proof(3, 5, false);
+    fn duplicate_authorities_are_deduplicated() {
+        let mut proof = make_proof(2, 5, true);
 
-        // Tamper: add an extra fake authority to inflate the count.
-        proof
-            .contributing_authorities
-            .push(NodeId("fake-auth".into()));
-        // But total_authorities stays at 5, so this still passes majority check.
-        let result = verify_proof(&proof);
-        assert!(result.valid);
-        assert_eq!(result.contributing_count, 4);
+        // Duplicate an existing authority ID in contributing_authorities.
+        let dup = proof.contributing_authorities[0].clone();
+        proof.contributing_authorities.push(dup);
 
-        // Now tamper the other way: reduce contributing below majority.
-        proof.contributing_authorities.truncate(2);
+        // Raw length is 3, but unique count should still be 2 (below majority).
         let result = verify_proof(&proof);
         assert!(!result.valid);
         assert!(!result.has_majority);
+        assert_eq!(result.contributing_count, 2);
+        assert_eq!(result.required_count, 3);
     }
 
     #[test]
@@ -288,16 +320,16 @@ mod tests {
 
     #[test]
     fn exact_majority_threshold() {
-        // 1 of 1 = majority
-        let proof = make_proof(1, 1, false);
+        // 1 of 1 = majority (with valid certificate)
+        let proof = make_proof(1, 1, true);
         assert!(verify_proof(&proof).valid);
 
-        // 2 of 3 = majority (3/2+1 = 2)
-        let proof = make_proof(2, 3, false);
+        // 2 of 3 = majority (3/2+1 = 2) (with valid certificate)
+        let proof = make_proof(2, 3, true);
         assert!(verify_proof(&proof).valid);
 
         // 1 of 3 = not majority
-        let proof = make_proof(1, 3, false);
+        let proof = make_proof(1, 3, true);
         assert!(!verify_proof(&proof).valid);
     }
 

--- a/src/http/handlers.rs
+++ b/src/http/handlers.rs
@@ -169,20 +169,53 @@ pub async fn get_certified(
         node_id: f.node_id,
     });
 
-    let proof = read.proof.map(|p| ProofBundleJson {
-        key_range_prefix: p.key_range.prefix,
-        frontier: FrontierJson {
-            physical: p.frontier_hlc.physical,
-            logical: p.frontier_hlc.logical,
-            node_id: p.frontier_hlc.node_id,
-        },
-        policy_version: p.policy_version.0,
-        contributing_authorities: p
-            .contributing_authorities
-            .into_iter()
-            .map(|n| n.0)
-            .collect(),
-        total_authorities: p.total_authorities,
+    let proof = read.proof.map(|p| {
+        let certificate = p.certificate.map(|cert| {
+            use super::types::{AuthoritySignatureJson, CertificateJson};
+            CertificateJson {
+                keyset_version: cert.keyset_version.0,
+                signatures: cert
+                    .signatures
+                    .iter()
+                    .map(|s| {
+                        let pk_hex: String = s
+                            .public_key
+                            .as_bytes()
+                            .iter()
+                            .map(|b| format!("{b:02x}"))
+                            .collect();
+                        let sig_hex: String = s
+                            .signature
+                            .to_bytes()
+                            .iter()
+                            .map(|b| format!("{b:02x}"))
+                            .collect();
+                        AuthoritySignatureJson {
+                            authority_id: s.authority_id.0.clone(),
+                            public_key: pk_hex,
+                            signature: sig_hex,
+                            keyset_version: s.keyset_version.0,
+                        }
+                    })
+                    .collect(),
+            }
+        });
+        ProofBundleJson {
+            key_range_prefix: p.key_range.prefix,
+            frontier: FrontierJson {
+                physical: p.frontier_hlc.physical,
+                logical: p.frontier_hlc.logical,
+                node_id: p.frontier_hlc.node_id,
+            },
+            policy_version: p.policy_version.0,
+            contributing_authorities: p
+                .contributing_authorities
+                .into_iter()
+                .map(|n| n.0)
+                .collect(),
+            total_authorities: p.total_authorities,
+            certificate,
+        }
     });
 
     Json(CertifiedReadResponse {
@@ -484,27 +517,55 @@ pub async fn get_version_history(
 /// proof bundle represents genuine Authority consensus.
 pub async fn verify_proof(Json(req): Json<VerifyProofRequest>) -> Json<VerifyProofResponse> {
     use crate::api::certified::ProofBundle;
+    use crate::authority::certificate::{AuthoritySignature, KeysetVersion, MajorityCertificate};
     use crate::authority::verifier;
     use crate::hlc::HlcTimestamp;
     use crate::types::{KeyRange, NodeId, PolicyVersion};
 
+    let key_range = KeyRange {
+        prefix: req.key_range_prefix,
+    };
+    let frontier_hlc = HlcTimestamp {
+        physical: req.frontier.physical,
+        logical: req.frontier.logical,
+        node_id: req.frontier.node_id,
+    };
+    let policy_version = PolicyVersion(req.policy_version);
+
+    // Reconstruct the certificate from the HTTP payload, if provided.
+    let certificate = req.certificate.and_then(|cert_json| {
+        let mut cert = MajorityCertificate::new(
+            key_range.clone(),
+            frontier_hlc.clone(),
+            policy_version,
+            KeysetVersion(cert_json.keyset_version),
+        );
+        for sig_json in &cert_json.signatures {
+            let pk_bytes = hex_to_bytes_32(&sig_json.public_key)?;
+            let sig_bytes = hex_to_bytes_64(&sig_json.signature)?;
+            let public_key = ed25519_dalek::VerifyingKey::from_bytes(&pk_bytes).ok()?;
+            let signature = ed25519_dalek::Signature::from_bytes(&sig_bytes);
+            cert.add_signature(AuthoritySignature {
+                authority_id: NodeId(sig_json.authority_id.clone()),
+                public_key,
+                signature,
+                keyset_version: KeysetVersion(sig_json.keyset_version),
+            });
+        }
+        Some(cert)
+    });
+
     let bundle = ProofBundle {
-        key_range: KeyRange {
-            prefix: req.key_range_prefix,
-        },
-        frontier_hlc: HlcTimestamp {
-            physical: req.frontier.physical,
-            logical: req.frontier.logical,
-            node_id: req.frontier.node_id,
-        },
-        policy_version: PolicyVersion(req.policy_version),
+        key_range,
+        frontier_hlc,
+        policy_version,
         contributing_authorities: req
             .contributing_authorities
             .into_iter()
             .map(NodeId)
             .collect(),
         total_authorities: req.total_authorities,
-        certificate: None,
+        certificate,
     };
 
     let result = verifier::verify_proof(&bundle);
@@ -515,6 +576,29 @@ pub async fn verify_proof(Json(req): Json<VerifyProofRequest>) -> Json<VerifyPro
         contributing_count: result.contributing_count,
         required_count: result.required_count,
     })
+}
+
+/// Decode a hex string into a 32-byte array. Returns `None` on failure.
+fn hex_to_bytes_32(hex: &str) -> Option<[u8; 32]> {
+    let bytes = hex_to_bytes(hex)?;
+    bytes.try_into().ok()
+}
+
+/// Decode a hex string into a 64-byte array. Returns `None` on failure.
+fn hex_to_bytes_64(hex: &str) -> Option<[u8; 64]> {
+    let bytes = hex_to_bytes(hex)?;
+    bytes.try_into().ok()
+}
+
+/// Decode a hex string into a byte vector. Returns `None` on failure.
+fn hex_to_bytes(hex: &str) -> Option<Vec<u8>> {
+    if !hex.len().is_multiple_of(2) {
+        return None;
+    }
+    (0..hex.len())
+        .step_by(2)
+        .map(|i| u8::from_str_radix(&hex[i..i + 2], 16).ok())
+        .collect()
 }
 
 // ---------------------------------------------------------------

--- a/src/http/routes.rs
+++ b/src/http/routes.rs
@@ -1305,11 +1305,82 @@ mod tests {
 
     #[tokio::test]
     async fn verify_proof_valid() {
+        use crate::authority::certificate::{create_certificate_message, sign_message};
+        use crate::http::types::VerifyProofResponse;
+        use crate::types::PolicyVersion;
+        use ed25519_dalek::SigningKey;
+        use rand::rngs::OsRng;
+
+        // Build a real certificate with valid Ed25519 signatures.
+        let kr = KeyRange {
+            prefix: "user/".into(),
+        };
+        let hlc = crate::hlc::HlcTimestamp {
+            physical: 1000,
+            logical: 0,
+            node_id: "auth-1".into(),
+        };
+        let pv = PolicyVersion(1);
+        let message = create_certificate_message(&kr, &hlc, &pv);
+
+        let auth_ids = ["auth-1", "auth-2", "auth-3"];
+        let mut sigs_json = Vec::new();
+        for auth_id in &auth_ids {
+            let sk = SigningKey::generate(&mut OsRng);
+            let vk = sk.verifying_key();
+            let sig = sign_message(&sk, &message);
+            let pk_hex: String = vk.as_bytes().iter().map(|b| format!("{b:02x}")).collect();
+            let sig_hex: String = sig.to_bytes().iter().map(|b| format!("{b:02x}")).collect();
+            sigs_json.push(serde_json::json!({
+                "authority_id": auth_id,
+                "public_key": pk_hex,
+                "signature": sig_hex,
+                "keyset_version": 1
+            }));
+        }
+
+        let body_json = serde_json::json!({
+            "key_range_prefix": "user/",
+            "frontier": {"physical": 1000, "logical": 0, "node_id": "auth-1"},
+            "policy_version": 1,
+            "contributing_authorities": auth_ids,
+            "total_authorities": 5,
+            "certificate": {
+                "keyset_version": 1,
+                "signatures": sigs_json
+            }
+        });
+
+        let state = test_state();
+        let app = router(state);
+
+        let req = Request::builder()
+            .method("POST")
+            .uri("/api/certified/verify")
+            .header("content-type", "application/json")
+            .body(Body::from(body_json.to_string()))
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let body = body_string(resp.into_body()).await;
+        let result: VerifyProofResponse = serde_json::from_str(&body).unwrap();
+        assert!(result.valid);
+        assert!(result.has_majority);
+        assert_eq!(result.contributing_count, 3);
+        assert_eq!(result.required_count, 3); // 5/2+1 = 3
+    }
+
+    #[tokio::test]
+    async fn verify_proof_without_certificate_rejected() {
         use crate::http::types::VerifyProofResponse;
 
         let state = test_state();
         let app = router(state);
 
+        // A proof without a certificate must be rejected even when
+        // enough contributing authorities are listed.
         let req = Request::builder()
             .method("POST")
             .uri("/api/certified/verify")
@@ -1330,10 +1401,10 @@ mod tests {
 
         let body = body_string(resp.into_body()).await;
         let result: VerifyProofResponse = serde_json::from_str(&body).unwrap();
-        assert!(result.valid);
+        assert!(!result.valid);
         assert!(result.has_majority);
         assert_eq!(result.contributing_count, 3);
-        assert_eq!(result.required_count, 3); // 5/2+1 = 3
+        assert_eq!(result.required_count, 3);
     }
 
     #[tokio::test]

--- a/src/http/types.rs
+++ b/src/http/types.rs
@@ -124,6 +124,28 @@ pub struct FrontierJson {
     pub node_id: String,
 }
 
+/// JSON-friendly representation of an individual authority signature.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AuthoritySignatureJson {
+    /// The authority node ID that produced this signature.
+    pub authority_id: String,
+    /// Hex-encoded Ed25519 public key (32 bytes).
+    pub public_key: String,
+    /// Hex-encoded Ed25519 signature (64 bytes).
+    pub signature: String,
+    /// The keyset version under which this signature was produced.
+    pub keyset_version: u64,
+}
+
+/// JSON-friendly representation of a majority certificate.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CertificateJson {
+    /// The keyset version used for signing.
+    pub keyset_version: u64,
+    /// Individual authority signatures.
+    pub signatures: Vec<AuthoritySignatureJson>,
+}
+
 /// JSON-friendly representation of a verifiable proof bundle.
 ///
 /// Included in certified read responses so that external clients can
@@ -141,6 +163,10 @@ pub struct ProofBundleJson {
     pub contributing_authorities: Vec<String>,
     /// Total number of authorities in the set.
     pub total_authorities: usize,
+    /// The majority certificate with cryptographic signatures.
+    /// Must be present for the proof to be considered valid.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub certificate: Option<CertificateJson>,
 }
 
 /// Response for `POST /api/certified/write`.
@@ -162,6 +188,10 @@ pub struct VerifyProofRequest {
     pub contributing_authorities: Vec<String>,
     /// Total number of authorities in the set.
     pub total_authorities: usize,
+    /// The majority certificate with cryptographic signatures.
+    /// Must be present for the proof to be considered valid.
+    #[serde(default)]
+    pub certificate: Option<CertificateJson>,
 }
 
 /// Response for `POST /api/certified/verify`.


### PR DESCRIPTION
## Summary

Fixes #194 — HTTP proof bundles could be forged because `verify_proof` treated `certificate: None` as valid and didn't deduplicate authority IDs.

**Security fixes:**
- All three verify functions now reject proofs where `certificate` is `None` (`unwrap_or(true)` → `== Some(true)`)
- `contributing_authorities` deduplicated via `HashSet` before quorum counting
- HTTP types now include `CertificateJson`/`AuthoritySignatureJson` for round-tripping certificate material
- Certified read handler serializes signatures into proof response
- Verify endpoint reconstructs `MajorityCertificate` from hex-encoded HTTP payload

**Tests:**
- `proof_without_certificate_is_rejected` — verifies None cert is invalid
- `duplicate_authorities_are_deduplicated` — verifies inflated count is caught
- `verify_proof_valid` route test now uses real Ed25519 signatures
- `verify_proof_without_certificate_rejected` route test added

## Test plan

- [x] `cargo test` — 791+ tests pass
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)