### PR TITLE
fix: track per-addition success to prevent rebalance offset skip

### DIFF
--- a/src/placement/rebalance.rs
+++ b/src/placement/rebalance.rs
@@ -143,6 +143,16 @@ impl RebalancePlan {
 /// Default maximum number of keys to migrate per sync cycle.
 pub const DEFAULT_REBALANCE_BATCH_SIZE: usize = 50;
 
+/// Compute how far the additions offset can advance given per-item success flags.
+///
+/// Returns the length of the longest contiguous prefix of `true` values in
+/// `succeeded`.  This ensures that the offset only advances past items that
+/// actually completed, preventing later successes from causing earlier
+/// failures to be skipped.
+pub fn contiguous_success_count(succeeded: &[bool]) -> usize {
+    succeeded.iter().take_while(|&&ok| ok).count()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -385,5 +395,184 @@ mod tests {
         };
 
         assert!(plan.additions_batch(0, 10).is_empty());
+    }
+
+    // --- contiguous_success_count ---
+
+    #[test]
+    fn contiguous_success_all_succeed() {
+        // All items succeed → offset advances by full batch size.
+        assert_eq!(contiguous_success_count(&[true, true, true]), 3);
+    }
+
+    #[test]
+    fn contiguous_success_all_fail() {
+        // All items fail → offset does not advance.
+        assert_eq!(contiguous_success_count(&[false, false, false]), 0);
+    }
+
+    #[test]
+    fn contiguous_success_sparse_failure_at_start() {
+        // Item 0 fails, items 1 and 2 succeed → offset stays at 0.
+        assert_eq!(contiguous_success_count(&[false, true, true]), 0);
+    }
+
+    #[test]
+    fn contiguous_success_sparse_failure_in_middle() {
+        // Items 0,2 succeed but 1 fails → offset advances by 1 only.
+        assert_eq!(contiguous_success_count(&[true, false, true]), 1);
+    }
+
+    #[test]
+    fn contiguous_success_failure_at_end() {
+        // Items 0,1 succeed, item 2 fails → offset advances by 2.
+        assert_eq!(contiguous_success_count(&[true, true, false]), 2);
+    }
+
+    #[test]
+    fn contiguous_success_empty() {
+        // Empty batch → no advancement.
+        assert_eq!(contiguous_success_count(&[]), 0);
+    }
+
+    #[test]
+    fn contiguous_success_single_success() {
+        assert_eq!(contiguous_success_count(&[true]), 1);
+    }
+
+    #[test]
+    fn contiguous_success_single_failure() {
+        assert_eq!(contiguous_success_count(&[false]), 0);
+    }
+
+    // --- Offset tracking integration scenarios ---
+
+    /// Simulates the offset advancement pattern used by the rebalance executor.
+    /// Given a plan and a sequence of batch results (each a Vec<bool> of
+    /// per-addition success flags), returns the final offset.
+    fn simulate_offset_advancement(
+        plan: &RebalancePlan,
+        batch_size: usize,
+        batch_results: &[Vec<bool>],
+    ) -> usize {
+        let mut offset = 0;
+        for result in batch_results {
+            let batch = plan.additions_batch(offset, batch_size);
+            assert_eq!(
+                batch.len(),
+                result.len(),
+                "batch size mismatch at offset {offset}"
+            );
+            offset += contiguous_success_count(result);
+        }
+        offset
+    }
+
+    #[test]
+    fn offset_tracking_sparse_failures_no_skip() {
+        // 5 additions: batch_size=5, items 0,2 succeed but 1,3,4 fail.
+        // Offset should advance to 1 (only item 0 is contiguously successful).
+        let plan = RebalancePlan {
+            key_range: key_range("data/"),
+            additions: (0..5)
+                .map(|i| RebalanceAddition {
+                    key: format!("data/k{i}"),
+                    target_node: nid(&format!("n{}", i % 2)),
+                })
+                .collect(),
+            removals: vec![],
+        };
+
+        let offset =
+            simulate_offset_advancement(&plan, 5, &[vec![true, false, true, false, false]]);
+        assert_eq!(
+            offset, 1,
+            "offset should only advance past contiguous successes"
+        );
+
+        // Next batch starts at offset=1, items 1-4. If all succeed:
+        let batch = plan.additions_batch(1, 5);
+        assert_eq!(batch.len(), 4);
+        assert_eq!(batch[0].key, "data/k1"); // failed item is retried
+    }
+
+    #[test]
+    fn offset_tracking_all_fail_no_advance() {
+        let plan = RebalancePlan {
+            key_range: key_range("data/"),
+            additions: (0..3)
+                .map(|i| RebalanceAddition {
+                    key: format!("data/k{i}"),
+                    target_node: nid("n1"),
+                })
+                .collect(),
+            removals: vec![],
+        };
+
+        let offset = simulate_offset_advancement(&plan, 3, &[vec![false, false, false]]);
+        assert_eq!(offset, 0, "offset must not advance when all items fail");
+
+        // Retry should see the same batch.
+        let batch = plan.additions_batch(0, 3);
+        assert_eq!(batch.len(), 3);
+        assert_eq!(batch[0].key, "data/k0");
+    }
+
+    #[test]
+    fn offset_tracking_all_succeed_full_advance() {
+        let plan = RebalancePlan {
+            key_range: key_range("data/"),
+            additions: (0..6)
+                .map(|i| RebalanceAddition {
+                    key: format!("data/k{i}"),
+                    target_node: nid("n1"),
+                })
+                .collect(),
+            removals: vec![],
+        };
+
+        // Two batches of 3, all succeed.
+        let offset = simulate_offset_advancement(
+            &plan,
+            3,
+            &[vec![true, true, true], vec![true, true, true]],
+        );
+        assert_eq!(
+            offset, 6,
+            "offset should advance by full batch when all succeed"
+        );
+
+        // Past the end.
+        let batch = plan.additions_batch(6, 3);
+        assert!(batch.is_empty());
+    }
+
+    #[test]
+    fn offset_tracking_gradual_progress_with_retries() {
+        // 4 additions, batch_size=4.
+        // Cycle 1: [true, false, false, false] → offset=1
+        // Cycle 2: [true, true, false]          → offset=3  (batch is items 1,2,3)
+        // Cycle 3: [true]                        → offset=4  (batch is item 3)
+        let plan = RebalancePlan {
+            key_range: key_range("data/"),
+            additions: (0..4)
+                .map(|i| RebalanceAddition {
+                    key: format!("data/k{i}"),
+                    target_node: nid("n1"),
+                })
+                .collect(),
+            removals: vec![],
+        };
+
+        let offset = simulate_offset_advancement(
+            &plan,
+            4,
+            &[
+                vec![true, false, false, false],
+                vec![true, true, false],
+                vec![true],
+            ],
+        );
+        assert_eq!(offset, 4, "should complete after gradual retries");
     }
 }

--- a/src/runtime/node_runner.rs
+++ b/src/runtime/node_runner.rs
@@ -17,7 +17,9 @@ use crate::network::sync::{DEFAULT_BATCH_SIZE, PeerBackoff, SyncClient};
 use crate::node::Node;
 use crate::ops::metrics::RuntimeMetrics;
 use crate::placement::PlacementPolicy;
-use crate::placement::rebalance::{DEFAULT_REBALANCE_BATCH_SIZE, RebalancePlan};
+use crate::placement::rebalance::{
+    DEFAULT_REBALANCE_BATCH_SIZE, RebalancePlan, contiguous_success_count,
+};
 use crate::types::{CertificationStatus, KeyRange, NodeId, PolicyVersion};
 
 /// Configuration for the background processing intervals of [`NodeRunner`].
@@ -593,45 +595,67 @@ impl NodeRunner {
                 continue;
             }
 
-            // Group additions by target node.
-            let mut by_target: HashMap<&NodeId, Vec<&str>> = HashMap::new();
-            for addition in batch {
+            // Group additions by target node, tracking each entry's batch index
+            // so we can determine exactly which additions succeeded after push.
+            let batch_len = batch.len();
+            let mut by_target: HashMap<&NodeId, Vec<(usize, &str)>> = HashMap::new();
+            for (batch_idx, addition) in batch.iter().enumerate() {
                 by_target
                     .entry(&addition.target_node)
                     .or_default()
-                    .push(&addition.key);
+                    .push((batch_idx, &addition.key));
             }
 
+            let mut succeeded = vec![false; batch_len];
             let mut migrated = 0u64;
             let mut failed = 0u64;
 
             // Look up peer addresses from the registry.
             let peers = sync_client.peer_registry().lock().await.all_peers_owned();
 
-            for (target_node, keys) in &by_target {
+            for (target_node, indexed_keys) in &by_target {
                 // Find the peer address for this target node.
                 let peer = peers.iter().find(|p| p.node_id == **target_node);
                 let Some(peer) = peer else {
                     // Target node not in peer registry; count as failed.
-                    failed += keys.len() as u64;
+                    failed += indexed_keys.len() as u64;
                     continue;
                 };
 
-                // Collect entries to push.
+                // Collect entries to push (preserving group order).
                 let api = eventual_api.lock().await;
-                let entries: Vec<(String, crate::store::kv::CrdtValue)> = keys
+                let resolved: Vec<(usize, String, crate::store::kv::CrdtValue)> = indexed_keys
                     .iter()
-                    .filter_map(|k| api.store().get(k).map(|v| (k.to_string(), v.clone())))
+                    .filter_map(|(idx, k)| {
+                        api.store().get(k).map(|v| (*idx, k.to_string(), v.clone()))
+                    })
                     .collect();
                 drop(api);
 
-                if entries.is_empty() {
+                if resolved.is_empty() {
                     continue;
                 }
+
+                let entries: Vec<(String, crate::store::kv::CrdtValue)> = resolved
+                    .iter()
+                    .map(|(_, k, v)| (k.clone(), v.clone()))
+                    .collect();
 
                 let push_result = sync_client
                     .push_changed_keys(&peer.addr, entries, &self.node_id.0, DEFAULT_BATCH_SIZE)
                     .await;
+
+                let pushed_count = match &push_result {
+                    Ok(pushed) => *pushed,
+                    Err(e) => e.pushed,
+                };
+
+                // Mark the first `pushed_count` entries in this group as succeeded.
+                for (group_pos, (batch_idx, _, _)) in resolved.iter().enumerate() {
+                    if group_pos < pushed_count {
+                        succeeded[*batch_idx] = true;
+                    }
+                }
 
                 match push_result {
                     Ok(pushed) => {
@@ -639,7 +663,7 @@ impl NodeRunner {
                     }
                     Err(e) => {
                         migrated += e.pushed as u64;
-                        failed += (keys.len() - e.pushed) as u64;
+                        failed += (resolved.len() - e.pushed) as u64;
                         tracing::warn!(
                             target_node = %target_node.0,
                             error = %e,
@@ -652,10 +676,12 @@ impl NodeRunner {
             self.metrics
                 .record_rebalance_progress(prefix, migrated, failed);
 
-            // Advance the offset only by successfully migrated keys.
-            let advanced = migrated as usize;
+            // Advance the offset only past the contiguous block of successful
+            // additions from the start of the batch.  This prevents skipping
+            // failed additions that appear before later successes.
+            let contiguous_ok = contiguous_success_count(&succeeded);
             if let Some(rebalance) = self.active_rebalance_plans.get_mut(prefix) {
-                rebalance.additions_offset += advanced;
+                rebalance.additions_offset += contiguous_ok;
 
                 // Check if we just finished.
                 if rebalance.additions_offset >= rebalance.plan.additions.len() {


### PR DESCRIPTION
## Summary

Fixes #201 — rebalance offset could skip failed additions when failures were sparse within a batch.

**Core fix:**
- Track per-addition success via `succeeded: Vec<bool>` bitvector indexed by batch position
- `contiguous_success_count()` computes longest contiguous prefix of successes
- Offset advances only past the contiguous block, not aggregate success count
- Failed additions in the middle of a batch are retried on next cycle

**Tests added (12):**
- 8 unit tests for `contiguous_success_count` (all succeed/fail, sparse, edge cases)
- 4 integration-style tests with `simulate_offset_advancement`

## Test plan

- [x] `cargo test` — all tests pass
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)