### PR TITLE
feat: add CLI E2E tests and docker-compose E2E script

### DIFF
--- a/scripts/e2e-docker.sh
+++ b/scripts/e2e-docker.sh
@@ -1,0 +1,186 @@
+#!/usr/bin/env bash
+# Multi-node E2E integration test using docker-compose.
+#
+# Brings up a 3-node AsteroidDB cluster, writes data via one node,
+# and verifies convergence by reading from the other nodes.
+#
+# Usage:
+#   ./scripts/e2e-docker.sh
+#
+# Prerequisites:
+#   - docker and docker compose must be available
+#   - The project root must contain docker-compose.yml and configs/
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+COMPOSE_FILE="$PROJECT_DIR/docker-compose.yml"
+
+NODES=("localhost:3001" "localhost:3002" "localhost:3003")
+NODE_NAMES=("node-1" "node-2" "node-3")
+
+# Maximum seconds to wait for a node to become healthy.
+HEALTH_TIMEOUT=120
+# Seconds between polls.
+POLL_INTERVAL=2
+
+# Track whether we should clean up on exit.
+CLEANUP=true
+
+cleanup() {
+    if $CLEANUP; then
+        echo ""
+        echo "==> Cleaning up: stopping cluster..."
+        docker compose -f "$COMPOSE_FILE" down --timeout 10 2>/dev/null || true
+    fi
+}
+trap cleanup EXIT
+
+# ---------------------------------------------------------------
+# Step 1: Bring up the cluster
+# ---------------------------------------------------------------
+echo "==> Building and starting 3-node cluster..."
+docker compose -f "$COMPOSE_FILE" up -d --build
+
+# ---------------------------------------------------------------
+# Step 2: Wait for all nodes to become healthy
+# ---------------------------------------------------------------
+echo "==> Waiting for nodes to become healthy (timeout: ${HEALTH_TIMEOUT}s)..."
+
+wait_for_node() {
+    local addr="$1"
+    local name="$2"
+    local elapsed=0
+
+    while [ "$elapsed" -lt "$HEALTH_TIMEOUT" ]; do
+        # Use the eventual read endpoint as a health check (returns 200 even for
+        # nonexistent keys).
+        if curl -sf --max-time 3 "http://${addr}/api/eventual/__health" > /dev/null 2>&1; then
+            echo "  ${name} (${addr}): UP"
+            return 0
+        fi
+        sleep "$POLL_INTERVAL"
+        elapsed=$((elapsed + POLL_INTERVAL))
+    done
+
+    echo "  ${name} (${addr}): TIMEOUT after ${HEALTH_TIMEOUT}s"
+    return 1
+}
+
+all_healthy=true
+for i in "${!NODES[@]}"; do
+    if ! wait_for_node "${NODES[$i]}" "${NODE_NAMES[$i]}"; then
+        all_healthy=false
+    fi
+done
+
+if ! $all_healthy; then
+    echo "ERROR: Not all nodes became healthy. Aborting."
+    echo ""
+    echo "Docker compose logs:"
+    docker compose -f "$COMPOSE_FILE" logs --tail=50
+    exit 1
+fi
+
+echo ""
+echo "All nodes healthy."
+
+# ---------------------------------------------------------------
+# Step 3: Write data via node-1
+# ---------------------------------------------------------------
+echo ""
+echo "==> Writing key 'e2e-test' = 'hello-from-docker' to node-1..."
+
+write_resp=$(curl -sf -X POST "http://${NODES[0]}/api/eventual/write" \
+    -H "Content-Type: application/json" \
+    -d '{"type":"register_set","key":"e2e-test","value":"hello-from-docker"}')
+
+echo "  Write response: ${write_resp:-OK}"
+
+# Give the cluster a moment for anti-entropy sync to propagate.
+echo "  Waiting 5s for sync propagation..."
+sleep 5
+
+# ---------------------------------------------------------------
+# Step 4: Read from all nodes and verify convergence
+# ---------------------------------------------------------------
+echo ""
+echo "==> Verifying convergence across all nodes..."
+
+failures=0
+
+for i in "${!NODES[@]}"; do
+    addr="${NODES[$i]}"
+    name="${NODE_NAMES[$i]}"
+
+    resp=$(curl -sf "http://${addr}/api/eventual/e2e-test" 2>&1 || true)
+
+    if [ -z "$resp" ]; then
+        echo "  ${name}: FAIL (no response)"
+        failures=$((failures + 1))
+        continue
+    fi
+
+    # Check that the response contains the expected value.
+    # Using grep for basic validation (no jq dependency required).
+    if echo "$resp" | grep -q '"hello-from-docker"'; then
+        echo "  ${name}: OK (value = hello-from-docker)"
+    else
+        echo "  ${name}: FAIL (unexpected response: ${resp})"
+        failures=$((failures + 1))
+    fi
+done
+
+# ---------------------------------------------------------------
+# Step 5: Test metrics endpoint on each node
+# ---------------------------------------------------------------
+echo ""
+echo "==> Checking /api/metrics on all nodes..."
+
+for i in "${!NODES[@]}"; do
+    addr="${NODES[$i]}"
+    name="${NODE_NAMES[$i]}"
+
+    status=$(curl -s -o /dev/null -w "%{http_code}" --max-time 5 "http://${addr}/api/metrics" 2>/dev/null || echo "000")
+    if [ "$status" = "200" ]; then
+        echo "  ${name}: OK (HTTP 200)"
+    else
+        echo "  ${name}: FAIL (HTTP ${status})"
+        failures=$((failures + 1))
+    fi
+done
+
+# ---------------------------------------------------------------
+# Step 6: Cross-node write/read (write to node-2, read from node-3)
+# ---------------------------------------------------------------
+echo ""
+echo "==> Cross-node test: write to node-2, read from node-3..."
+
+curl -sf -X POST "http://${NODES[1]}/api/eventual/write" \
+    -H "Content-Type: application/json" \
+    -d '{"type":"register_set","key":"cross-node","value":"from-node-2"}' > /dev/null
+
+sleep 5
+
+resp=$(curl -sf "http://${NODES[2]}/api/eventual/cross-node" 2>&1 || true)
+if echo "$resp" | grep -q '"from-node-2"'; then
+    echo "  node-3 read: OK (converged from node-2)"
+else
+    echo "  node-3 read: FAIL (response: ${resp})"
+    failures=$((failures + 1))
+fi
+
+# ---------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------
+echo ""
+echo "==============================="
+if [ "$failures" -eq 0 ]; then
+    echo "E2E RESULT: ALL TESTS PASSED"
+    echo "==============================="
+    exit 0
+else
+    echo "E2E RESULT: ${failures} FAILURE(S)"
+    echo "==============================="
+    exit 1
+fi

--- a/tests/cli_e2e.rs
+++ b/tests/cli_e2e.rs
@@ -1,0 +1,330 @@
+//! End-to-end tests for the `asteroidb-cli` binary.
+//!
+//! Each test spawns a real HTTP server on an ephemeral port and invokes the
+//! CLI binary via `tokio::process::Command`, verifying stdout/stderr and exit
+//! codes for all major sub-commands (status, get, put, metrics, slo).
+//!
+//! We use `tokio::process::Command` (not `std::process::Command`) because the
+//! server runs as a tokio task in the same runtime. A blocking `Command::output()`
+//! would park the worker thread and prevent the server from processing the CLI's
+//! HTTP requests, causing a deadlock.
+
+use std::sync::{Arc, RwLock};
+use std::time::Duration;
+
+use asteroidb_poc::api::certified::CertifiedApi;
+use asteroidb_poc::api::eventual::EventualApi;
+use asteroidb_poc::control_plane::consensus::ControlPlaneConsensus;
+use asteroidb_poc::control_plane::system_namespace::{AuthorityDefinition, SystemNamespace};
+use asteroidb_poc::http::handlers::AppState;
+use asteroidb_poc::http::routes::router;
+use asteroidb_poc::ops::metrics::RuntimeMetrics;
+use asteroidb_poc::types::{KeyRange, NodeId};
+use tokio::sync::Mutex;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Build a minimal `AppState` suitable for CLI E2E tests.
+fn test_state() -> Arc<AppState> {
+    let node_id = NodeId("cli-test-node".into());
+
+    let mut ns = SystemNamespace::new();
+    ns.set_authority_definition(AuthorityDefinition {
+        key_range: KeyRange {
+            prefix: String::new(),
+        },
+        authority_nodes: vec![
+            NodeId("auth-1".into()),
+            NodeId("auth-2".into()),
+            NodeId("auth-3".into()),
+        ],
+        auto_generated: false,
+    });
+
+    let namespace = Arc::new(RwLock::new(ns));
+    let consensus = Arc::new(Mutex::new(ControlPlaneConsensus::new(vec![
+        NodeId("auth-1".into()),
+        NodeId("auth-2".into()),
+        NodeId("auth-3".into()),
+    ])));
+
+    Arc::new(AppState {
+        eventual: Arc::new(Mutex::new(EventualApi::new(node_id.clone()))),
+        certified: Arc::new(Mutex::new(CertifiedApi::new(
+            node_id,
+            Arc::clone(&namespace),
+        ))),
+        namespace,
+        metrics: Arc::new(RuntimeMetrics::default()),
+        peers: None,
+        peer_persist_path: None,
+        consensus,
+        internal_token: None,
+        self_node_id: None,
+        self_addr: None,
+        latency_model: None,
+        cluster_nodes: None,
+        slo_tracker: Arc::new(asteroidb_poc::ops::slo::SloTracker::new()),
+    })
+}
+
+/// Spawn an HTTP server on an ephemeral port and return the address.
+/// The server task handle is returned so the caller can abort it for cleanup.
+///
+/// Polls the server until it responds to an HTTP request (up to 5 s)
+/// before returning, so the caller can invoke the CLI immediately.
+async fn spawn_server() -> (std::net::SocketAddr, tokio::task::JoinHandle<()>) {
+    let state = test_state();
+    let app = router(state);
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    let handle = tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+
+    // Poll until the server accepts connections (up to 5 s).
+    let client = reqwest::Client::new();
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+    loop {
+        if let Ok(resp) = client
+            .get(format!("http://{addr}/api/eventual/__ready"))
+            .timeout(Duration::from_millis(200))
+            .send()
+            .await
+        {
+            if resp.status().is_success() {
+                break;
+            }
+        }
+        if tokio::time::Instant::now() > deadline {
+            panic!("server at {addr} did not become ready within 5 s");
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+
+    (addr, handle)
+}
+
+/// Return the path to the built `asteroidb-cli` binary.
+///
+/// We build it once via `cargo build --bin asteroidb-cli` and then reuse the
+/// debug binary for all tests. The build is guarded by a `std::sync::Once` to
+/// avoid redundant compilations when tests run in parallel.
+fn cli_bin() -> std::path::PathBuf {
+    static BUILD_ONCE: std::sync::Once = std::sync::Once::new();
+    BUILD_ONCE.call_once(|| {
+        let status = std::process::Command::new("cargo")
+            .args(["build", "--bin", "asteroidb-cli"])
+            .status()
+            .expect("failed to invoke cargo build");
+        assert!(status.success(), "cargo build --bin asteroidb-cli failed");
+    });
+
+    // Determine the target directory (respects CARGO_TARGET_DIR).
+    let target_dir = std::env::var("CARGO_TARGET_DIR")
+        .map(std::path::PathBuf::from)
+        .unwrap_or_else(|_| {
+            let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap_or_else(|_| ".".into());
+            std::path::PathBuf::from(manifest_dir).join("target")
+        });
+
+    target_dir.join("debug").join("asteroidb-cli")
+}
+
+/// Run the CLI with the given sub-command arguments against `host`.
+///
+/// Uses `tokio::process::Command` so the tokio runtime can continue driving
+/// the server task while the CLI process runs.
+async fn run_cli(host: &str, args: &[&str]) -> std::process::Output {
+    tokio::process::Command::new(cli_bin())
+        .arg("--host")
+        .arg(host)
+        .args(args)
+        .output()
+        .await
+        .expect("failed to execute asteroidb-cli")
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn cli_put_then_get() {
+    let (addr, server) = spawn_server().await;
+    let host = format!("127.0.0.1:{}", addr.port());
+
+    // Put a key.
+    let out = run_cli(&host, &["put", "greeting", "hello-world"]).await;
+    assert!(
+        out.status.success(),
+        "put should succeed, stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("OK"), "put stdout should contain 'OK'");
+
+    // Get the key back.
+    let out = run_cli(&host, &["get", "greeting"]).await;
+    assert!(
+        out.status.success(),
+        "get should succeed, stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let body: serde_json::Value =
+        serde_json::from_str(&stdout).expect("get output should be valid JSON");
+    assert_eq!(body["key"], "greeting");
+    assert_eq!(body["value"]["value"], "hello-world");
+
+    server.abort();
+}
+
+#[tokio::test]
+async fn cli_get_nonexistent_key() {
+    let (addr, server) = spawn_server().await;
+    let host = format!("127.0.0.1:{}", addr.port());
+
+    // Get a key that was never written.
+    let out = run_cli(&host, &["get", "no-such-key"]).await;
+    assert!(
+        out.status.success(),
+        "get of nonexistent key should succeed (returns null value), stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let body: serde_json::Value =
+        serde_json::from_str(&stdout).expect("get output should be valid JSON");
+    assert_eq!(body["key"], "no-such-key");
+    // The value should be null for a key that doesn't exist.
+    assert!(
+        body["value"].is_null(),
+        "nonexistent key should have null value, got: {}",
+        body["value"]
+    );
+
+    server.abort();
+}
+
+#[tokio::test]
+async fn cli_status_shows_node_info() {
+    let (addr, server) = spawn_server().await;
+    let host = format!("127.0.0.1:{}", addr.port());
+
+    let out = run_cli(&host, &["status"]).await;
+    assert!(
+        out.status.success(),
+        "status should succeed, stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("AsteroidDB Node Status"),
+        "status should print header, got: {stdout}"
+    );
+    // The status command reads /api/metrics and prints key fields.
+    assert!(
+        stdout.contains("Pending certifications:"),
+        "should contain pending certifications label"
+    );
+    assert!(
+        stdout.contains("Certified total:"),
+        "should contain certified total label"
+    );
+
+    server.abort();
+}
+
+#[tokio::test]
+async fn cli_metrics_returns_json() {
+    let (addr, server) = spawn_server().await;
+    let host = format!("127.0.0.1:{}", addr.port());
+
+    let out = run_cli(&host, &["metrics"]).await;
+    assert!(
+        out.status.success(),
+        "metrics should succeed, stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let body: serde_json::Value =
+        serde_json::from_str(&stdout).expect("metrics output should be valid JSON");
+    // RuntimeMetrics::default() produces a snapshot with known fields.
+    assert!(
+        body.get("pending_count").is_some(),
+        "metrics JSON should contain pending_count"
+    );
+    assert!(
+        body.get("certified_total").is_some(),
+        "metrics JSON should contain certified_total"
+    );
+
+    server.abort();
+}
+
+#[tokio::test]
+async fn cli_slo_returns_output() {
+    let (addr, server) = spawn_server().await;
+    let host = format!("127.0.0.1:{}", addr.port());
+
+    let out = run_cli(&host, &["slo"]).await;
+    assert!(
+        out.status.success(),
+        "slo should succeed, stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    // The SLO command should print either the table header or JSON output.
+    assert!(
+        stdout.contains("SLO Budget Status") || stdout.contains("budgets"),
+        "slo should print budget info, got: {stdout}"
+    );
+
+    server.abort();
+}
+
+#[tokio::test]
+async fn cli_put_then_get_multiple_keys() {
+    let (addr, server) = spawn_server().await;
+    let host = format!("127.0.0.1:{}", addr.port());
+
+    // Write two distinct keys.
+    let out = run_cli(&host, &["put", "key-a", "value-a"]).await;
+    assert!(out.status.success());
+    let out = run_cli(&host, &["put", "key-b", "value-b"]).await;
+    assert!(out.status.success());
+
+    // Read them back and verify independence.
+    let out = run_cli(&host, &["get", "key-a"]).await;
+    let body: serde_json::Value =
+        serde_json::from_str(&String::from_utf8_lossy(&out.stdout)).unwrap();
+    assert_eq!(body["key"], "key-a");
+    assert_eq!(body["value"]["value"], "value-a");
+
+    let out = run_cli(&host, &["get", "key-b"]).await;
+    let body: serde_json::Value =
+        serde_json::from_str(&String::from_utf8_lossy(&out.stdout)).unwrap();
+    assert_eq!(body["key"], "key-b");
+    assert_eq!(body["value"]["value"], "value-b");
+
+    server.abort();
+}
+
+#[tokio::test]
+async fn cli_connection_refused_exits_nonzero() {
+    // Attempt to connect to a port where nothing is listening.
+    let out = run_cli("127.0.0.1:1", &["status"]).await;
+    assert!(
+        !out.status.success(),
+        "connecting to a closed port should exit non-zero"
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("Error"),
+        "stderr should contain error message, got: {stderr}"
+    );
+}


### PR DESCRIPTION
## Summary

Closes #211 — adds E2E tests for the CLI binary and a docker-compose multi-node E2E script.

**`tests/cli_e2e.rs`** (7 tests):
- `cli_put_then_get` — write + read roundtrip
- `cli_get_nonexistent_key` — null value response
- `cli_status_shows_node_info` — status output verification
- `cli_metrics_returns_json` — metrics JSON structure
- `cli_slo_returns_output` — SLO budget output
- `cli_put_then_get_multiple_keys` — multi-key independence
- `cli_connection_refused_exits_nonzero` — error handling

Uses `tokio::process::Command` to avoid deadlock with the in-process server.

**`scripts/e2e-docker.sh`**: 3-node docker-compose E2E with health polling, write/read convergence, cross-node verification.

## Test plan

- [x] `cargo test` — 1093 tests pass
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)