### PR TITLE
feat: record SLO observations in HTTP handlers and runtime

### DIFF
--- a/src/http/handlers.rs
+++ b/src/http/handlers.rs
@@ -1,5 +1,6 @@
 use std::path::PathBuf;
 use std::sync::{Arc, RwLock};
+use std::time::Instant;
 
 use axum::Json;
 use axum::extract::{Path, State};
@@ -12,7 +13,7 @@ use crate::control_plane::system_namespace::{AuthorityDefinition, SystemNamespac
 use crate::crdt::pn_counter::PnCounter;
 use crate::error::CrdtError;
 use crate::ops::metrics::{MetricsSnapshot, RuntimeMetrics};
-use crate::ops::slo::{SloSnapshot, SloTracker};
+use crate::ops::slo::{SLO_CERTIFIED_READ_P99, SLO_EVENTUAL_READ_P99, SloSnapshot, SloTracker};
 use crate::placement::PlacementPolicy;
 use crate::placement::latency::LatencyModel;
 use crate::placement::topology::TopologyView;
@@ -117,8 +118,15 @@ pub async fn get_eventual(
     State(state): State<Arc<AppState>>,
     Path(key): Path<String>,
 ) -> Json<EventualReadResponse> {
+    let start = Instant::now();
     let api = state.eventual.lock().await;
     let value = api.get_eventual(&key).map(CrdtValueJson::from_crdt_value);
+    drop(api);
+
+    let elapsed_ms = start.elapsed().as_secs_f64() * 1000.0;
+    state
+        .slo_tracker
+        .record_observation(SLO_EVENTUAL_READ_P99, elapsed_ms);
 
     Json(EventualReadResponse { key, value })
 }
@@ -159,6 +167,7 @@ pub async fn get_certified(
     State(state): State<Arc<AppState>>,
     Path(key): Path<String>,
 ) -> Json<CertifiedReadResponse> {
+    let start = Instant::now();
     let api = state.certified.lock().await;
     let read = api.get_certified(&key);
 
@@ -217,6 +226,11 @@ pub async fn get_certified(
             certificate,
         }
     });
+
+    let elapsed_ms = start.elapsed().as_secs_f64() * 1000.0;
+    state
+        .slo_tracker
+        .record_observation(SLO_CERTIFIED_READ_P99, elapsed_ms);
 
     Json(CertifiedReadResponse {
         key,

--- a/src/main.rs
+++ b/src/main.rs
@@ -141,6 +141,9 @@ async fn main() {
     // Optional shared token for authenticating internal API requests.
     let internal_token = std::env::var("ASTEROIDB_INTERNAL_TOKEN").ok();
 
+    // SLO tracker shared between HTTP handlers and NodeRunner.
+    let slo_tracker = Arc::new(asteroidb_poc::ops::slo::SloTracker::new());
+
     // Build shared HTTP state.
     let state = Arc::new(AppState {
         eventual: Arc::clone(&eventual_api),
@@ -155,7 +158,7 @@ async fn main() {
         self_addr: Some(advertise_addr.clone()),
         latency_model: None,
         cluster_nodes: None,
-        slo_tracker: Arc::new(asteroidb_poc::ops::slo::SloTracker::new()),
+        slo_tracker: Arc::clone(&slo_tracker),
     });
 
     let app = router(state);
@@ -214,6 +217,7 @@ async fn main() {
         )
     };
     runner.set_membership_client(runner_membership_client);
+    runner.set_slo_tracker(slo_tracker);
 
     let shutdown_handle = runner.shutdown_handle();
 

--- a/src/network/membership.rs
+++ b/src/network/membership.rs
@@ -17,6 +17,17 @@ use crate::types::NodeId;
 /// Number of consecutive ping failures before a peer is automatically evicted.
 const MAX_PING_FAILURES: u32 = 3;
 
+/// Statistics returned from a [`MembershipClient::ping_all`] round.
+#[derive(Debug, Clone, Default)]
+pub struct PingStats {
+    /// Number of new peers discovered during this ping round.
+    pub discovered: usize,
+    /// Number of peers that responded successfully.
+    pub successes: usize,
+    /// Number of peers that failed to respond.
+    pub failures: usize,
+}
+
 /// Client for the membership protocol.
 ///
 /// Provides methods for fan-out announce (join/leave) and periodic
@@ -162,8 +173,8 @@ impl MembershipClient {
     /// Peers that fail to respond for [`MAX_PING_FAILURES`] consecutive
     /// rounds are automatically evicted from the registry.
     ///
-    /// Returns the number of new peers discovered through this exchange.
-    pub async fn ping_all(&mut self) -> usize {
+    /// Returns [`PingStats`] with discovered peers and per-peer success/failure counts.
+    pub async fn ping_all(&mut self) -> PingStats {
         let my_peers = {
             let registry = self.peer_registry.lock().await;
             let mut list: Vec<PeerInfo> = registry
@@ -192,7 +203,7 @@ impl MembershipClient {
         };
 
         let peers = self.peer_registry.lock().await.all_peers_owned();
-        let mut total_discovered = 0;
+        let mut stats = PingStats::default();
 
         for peer in &peers {
             let url = format!("http://{}/api/internal/ping", peer.addr);
@@ -203,9 +214,10 @@ impl MembershipClient {
                     if resp.status().is_success() {
                         // Reset failure count on successful response.
                         self.failed_ping_counts.remove(&peer_key);
+                        stats.successes += 1;
                         if let Ok(ping_resp) = resp.json::<PingResponse>().await {
                             let discovered = self.reconcile_peers(&ping_resp.known_peers).await;
-                            total_discovered += discovered;
+                            stats.discovered += discovered;
                         }
                     } else {
                         tracing::warn!(
@@ -216,6 +228,7 @@ impl MembershipClient {
                         // Treat non-success as a failure for eviction purposes.
                         let count = self.failed_ping_counts.entry(peer_key).or_insert(0);
                         *count += 1;
+                        stats.failures += 1;
                     }
                 }
                 Err(e) => {
@@ -226,6 +239,7 @@ impl MembershipClient {
                     );
                     let count = self.failed_ping_counts.entry(peer_key).or_insert(0);
                     *count += 1;
+                    stats.failures += 1;
                 }
             }
         }
@@ -264,7 +278,7 @@ impl MembershipClient {
             }
         }
 
-        total_discovered
+        stats
     }
 
     /// Reconcile a received peer list with the local registry.
@@ -342,8 +356,10 @@ mod tests {
         ));
         let mut client =
             MembershipClient::new(nid("node-1"), "127.0.0.1:3000".to_string(), registry);
-        let count = client.ping_all().await;
-        assert_eq!(count, 0);
+        let stats = client.ping_all().await;
+        assert_eq!(stats.discovered, 0);
+        assert_eq!(stats.successes, 0);
+        assert_eq!(stats.failures, 0);
     }
 
     #[tokio::test]

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -4,5 +4,5 @@ mod peer;
 pub mod sync;
 
 pub use frontier_sync::FrontierSyncClient;
-pub use membership::MembershipClient;
+pub use membership::{MembershipClient, PingStats};
 pub use peer::{NodeConfig, PeerConfig, PeerError, PeerRegistry, generate_cluster_configs};

--- a/src/runtime/node_runner.rs
+++ b/src/runtime/node_runner.rs
@@ -16,6 +16,7 @@ use crate::network::membership::MembershipClient;
 use crate::network::sync::{DEFAULT_BATCH_SIZE, PeerBackoff, SyncClient};
 use crate::node::Node;
 use crate::ops::metrics::RuntimeMetrics;
+use crate::ops::slo::{SLO_AUTHORITY_AVAILABILITY, SLO_REPLICATION_CONVERGENCE, SloTracker};
 use crate::placement::PlacementPolicy;
 use crate::placement::rebalance::{
     DEFAULT_REBALANCE_BATCH_SIZE, RebalancePlan, contiguous_success_count,
@@ -107,6 +108,8 @@ pub struct NodeRunner {
     tracked_cluster_generation: u64,
     /// Optional membership client for periodic peer list exchange (ping).
     membership_client: Option<MembershipClient>,
+    /// Optional SLO tracker for recording operational observations.
+    slo_tracker: Option<Arc<SloTracker>>,
     /// Active rebalance plans being executed, keyed by key range prefix.
     ///
     /// When a policy version change is detected, a [`RebalancePlan`] is
@@ -219,6 +222,7 @@ impl NodeRunner {
             // Use sentinel value to force initial recalculation on first tick.
             tracked_cluster_generation: u64::MAX,
             membership_client: None,
+            slo_tracker: None,
             active_rebalance_plans: HashMap::new(),
             tracked_policies,
         }
@@ -271,6 +275,7 @@ impl NodeRunner {
             cluster_nodes,
             tracked_cluster_generation: 0,
             membership_client: None,
+            slo_tracker: None,
             active_rebalance_plans: HashMap::new(),
             tracked_policies,
         }
@@ -279,6 +284,11 @@ impl NodeRunner {
     /// Set the membership client for periodic peer list exchange (ping).
     pub fn set_membership_client(&mut self, client: MembershipClient) {
         self.membership_client = Some(client);
+    }
+
+    /// Set the SLO tracker for recording operational observations.
+    pub fn set_slo_tracker(&mut self, tracker: Arc<SloTracker>) {
+        self.slo_tracker = Some(tracker);
     }
 
     /// Return a shutdown handle that can be used to signal graceful shutdown.
@@ -1050,6 +1060,18 @@ impl NodeRunner {
                                 total_changed = changed_count,
                                 "delta push succeeded"
                             );
+                            // Record replication convergence SLO: time from
+                            // entry write (HLC physical) to push completion.
+                            if let Some(slo) = &self.slo_tracker {
+                                let now_ms = self.clock.now().physical;
+                                for (_key, _val, hlc) in entries_with_hlc.iter().take(pushed) {
+                                    let convergence_ms = now_ms.saturating_sub(hlc.physical) as f64;
+                                    slo.record_observation(
+                                        SLO_REPLICATION_CONVERGENCE,
+                                        convergence_ms,
+                                    );
+                                }
+                            }
                             // Advance peer frontier to the max HLC of the
                             // pushed batch — NOT current_frontier(), which may
                             // have advanced past unpushed concurrent writes.
@@ -1239,11 +1261,23 @@ impl NodeRunner {
     /// Run one cycle of peer list exchange (membership gossip).
     async fn run_ping(&mut self) {
         if let Some(membership_client) = &mut self.membership_client {
-            let discovered = membership_client.ping_all().await;
-            if discovered > 0 {
+            let stats = membership_client.ping_all().await;
+
+            // Record authority availability SLO: 1.0 per successful ping,
+            // 0.0 per failed ping.
+            if let Some(slo) = &self.slo_tracker {
+                for _ in 0..stats.successes {
+                    slo.record_observation(SLO_AUTHORITY_AVAILABILITY, 100.0);
+                }
+                for _ in 0..stats.failures {
+                    slo.record_observation(SLO_AUTHORITY_AVAILABILITY, 0.0);
+                }
+            }
+
+            if stats.discovered > 0 {
                 tracing::info!(
                     node = %self.node_id.0,
-                    discovered,
+                    discovered = stats.discovered,
                     "peer list exchange discovered new peers"
                 );
             } else {
@@ -1300,6 +1334,7 @@ mod tests {
     use crate::crdt::pn_counter::PnCounter;
     use crate::hlc::HlcTimestamp;
     use crate::ops::metrics::RuntimeMetrics;
+    use crate::ops::slo::{SLO_REPLICATION_CONVERGENCE, SloTracker};
     use crate::store::kv::CrdtValue;
     use crate::types::{CertificationStatus, KeyRange, NodeId, PolicyVersion};
     use std::sync::{Arc, RwLock};
@@ -2558,6 +2593,43 @@ mod tests {
         assert!(
             !runner.active_rebalance_plans.contains_key("data/"),
             "rebalance plan should be cleared when policy is deleted"
+        );
+    }
+
+    #[tokio::test]
+    async fn set_slo_tracker_wires_tracker_to_runner() {
+        let api = wrap_api(CertifiedApi::new(node_id("node-1"), default_namespace()));
+        let engine = CompactionEngine::with_defaults();
+        let config = NodeRunnerConfig {
+            certification_interval: Duration::from_secs(60),
+            cleanup_interval: Duration::from_secs(60),
+            compaction_check_interval: Duration::from_secs(60),
+            frontier_report_interval: Duration::from_secs(60),
+            sync_interval: None,
+            ping_interval: None,
+        };
+
+        let slo_tracker = Arc::new(SloTracker::new());
+        let mut runner =
+            NodeRunner::new(node_id("node-1"), api, engine, config, default_metrics()).await;
+
+        // Before setting, tracker should be None.
+        assert!(runner.slo_tracker.is_none());
+
+        runner.set_slo_tracker(Arc::clone(&slo_tracker));
+        assert!(runner.slo_tracker.is_some());
+
+        // Manually record an observation through the runner's tracker
+        // to verify the wiring works end-to-end.
+        if let Some(slo) = &runner.slo_tracker {
+            slo.record_observation(SLO_REPLICATION_CONVERGENCE, 42.0);
+        }
+
+        let snap = slo_tracker.snapshot();
+        let budget = &snap.budgets[SLO_REPLICATION_CONVERGENCE];
+        assert_eq!(
+            budget.total_requests, 1,
+            "expected 1 convergence observation after recording through runner's tracker"
         );
     }
 }

--- a/tests/http_server.rs
+++ b/tests/http_server.rs
@@ -10,6 +10,7 @@ use asteroidb_poc::control_plane::system_namespace::{AuthorityDefinition, System
 use asteroidb_poc::http::handlers::AppState;
 use asteroidb_poc::http::routes::router;
 use asteroidb_poc::ops::metrics::RuntimeMetrics;
+use asteroidb_poc::ops::slo::{SLO_CERTIFIED_READ_P99, SLO_EVENTUAL_READ_P99, SloTracker};
 use asteroidb_poc::types::{KeyRange, NodeId};
 use tokio::sync::Mutex;
 
@@ -265,6 +266,127 @@ async fn certified_write_accepts_valid_on_timeout_values() {
         .await
         .unwrap();
     assert_eq!(resp.status(), 200);
+
+    server.abort();
+}
+
+/// Create a test state that also returns the shared SloTracker handle.
+fn test_state_with_slo() -> (Arc<AppState>, Arc<SloTracker>) {
+    let node_id = NodeId("test-node".into());
+
+    let mut ns = SystemNamespace::new();
+    ns.set_authority_definition(AuthorityDefinition {
+        key_range: KeyRange {
+            prefix: String::new(),
+        },
+        authority_nodes: vec![
+            NodeId("auth-1".into()),
+            NodeId("auth-2".into()),
+            NodeId("auth-3".into()),
+        ],
+        auto_generated: false,
+    });
+
+    let namespace = Arc::new(RwLock::new(ns));
+
+    let consensus = Arc::new(Mutex::new(ControlPlaneConsensus::new(vec![
+        NodeId("auth-1".into()),
+        NodeId("auth-2".into()),
+        NodeId("auth-3".into()),
+    ])));
+
+    let slo_tracker = Arc::new(SloTracker::new());
+
+    let state = Arc::new(AppState {
+        eventual: Arc::new(Mutex::new(EventualApi::new(node_id.clone()))),
+        certified: Arc::new(Mutex::new(CertifiedApi::new(
+            node_id,
+            Arc::clone(&namespace),
+        ))),
+        namespace,
+        metrics: Arc::new(RuntimeMetrics::default()),
+        peers: None,
+        peer_persist_path: None,
+        consensus,
+        internal_token: None,
+        self_node_id: None,
+        self_addr: None,
+        latency_model: None,
+        cluster_nodes: None,
+        slo_tracker: Arc::clone(&slo_tracker),
+    });
+
+    (state, slo_tracker)
+}
+
+#[tokio::test]
+async fn eventual_read_records_slo_observation() {
+    let (state, slo_tracker) = test_state_with_slo();
+    let app = router(state);
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    let server = tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    let client = reqwest::Client::new();
+
+    // Perform an eventual read.
+    let resp = client
+        .get(format!("http://{addr}/api/eventual/some_key"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+
+    // SLO snapshot should now show at least 1 observation for eventual read P99.
+    let snap = slo_tracker.snapshot();
+    let budget = &snap.budgets[SLO_EVENTUAL_READ_P99];
+    assert!(
+        budget.total_requests >= 1,
+        "expected at least 1 eventual read SLO observation, got {}",
+        budget.total_requests
+    );
+
+    server.abort();
+}
+
+#[tokio::test]
+async fn certified_read_records_slo_observation() {
+    let (state, slo_tracker) = test_state_with_slo();
+    let app = router(state);
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    let server = tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    let client = reqwest::Client::new();
+
+    // Perform a certified read.
+    let resp = client
+        .get(format!("http://{addr}/api/certified/some_key"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+
+    // SLO snapshot should now show at least 1 observation for certified read P99.
+    let snap = slo_tracker.snapshot();
+    let budget = &snap.budgets[SLO_CERTIFIED_READ_P99];
+    assert!(
+        budget.total_requests >= 1,
+        "expected at least 1 certified read SLO observation, got {}",
+        budget.total_requests
+    );
 
     server.abort();
 }

--- a/tests/membership_protocol.rs
+++ b/tests/membership_protocol.rs
@@ -357,9 +357,9 @@ async fn ping_exchange_reconciles_peer_lists() {
         Arc::clone(&peer_registry),
     );
 
-    let discovered = membership.ping_all().await;
+    let ping_stats = membership.ping_all().await;
     assert!(
-        discovered >= 1,
+        ping_stats.discovered >= 1,
         "node-2 should discover at least node-3 via ping"
     );
 


### PR DESCRIPTION
## Summary

Closes #210 — SloTracker was in AppState but never received observations. Now all 4 SLO metrics are populated with real data.

**Observations wired:**
- **Eventual read P99**: measured in `get_eventual` handler
- **Certified read P99**: measured in `get_certified` handler
- **Replication convergence**: recorded after delta push (entry age = now - HLC physical)
- **Authority availability**: recorded per ping result (100.0 success / 0.0 failure)

**Changes:**
- `handlers.rs`: timing + record_observation in read handlers
- `node_runner.rs`: SloTracker field, convergence + availability recording
- `membership.rs`: `ping_all()` returns `PingStats` (discovered/successes/failures)
- `main.rs`: share SloTracker between AppState and NodeRunner

**Tests:** 3 new (eventual read SLO, certified read SLO, tracker wiring)

## Test plan

- [x] `cargo test` — 836+ tests pass
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)