### PR TITLE
feat: add partition recovery time measurement scripts and tests

### DIFF
--- a/scripts/bench-partition-recovery.sh
+++ b/scripts/bench-partition-recovery.sh
@@ -1,0 +1,343 @@
+#!/usr/bin/env bash
+# Benchmark: partition recovery time measurement for AsteroidDB.
+#
+# Measures how long it takes for a partitioned node to fully converge
+# after the partition heals.  Outputs structured JSON with timing data,
+# suitable for inclusion in a research submission.
+#
+# Usage: ./scripts/bench-partition-recovery.sh [OPTIONS]
+#
+# Options:
+#   --baseline-keys N      Number of keys to write in baseline phase (default 100)
+#   --partition-keys N     Number of keys to write during partition (default 50)
+#   --partition-secs N     Seconds the partition is held (default 10)
+#   --convergence-timeout  Max seconds to wait for convergence (default 60)
+#   --help                 Show this help message
+#
+# Prerequisites:
+#   - Docker and docker compose available
+#   - jq and curl installed on the host
+#   - python3 available (for millisecond timestamps)
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+COMPOSE_FILE="${SCRIPT_DIR}/../docker-compose.yml"
+NETEM_DIR="${SCRIPT_DIR}/netem"
+
+source "${NETEM_DIR}/lib.sh"
+
+# --- Defaults ---
+BASELINE_KEYS=100
+PARTITION_KEYS=50
+PARTITION_SECS=10
+CONVERGENCE_TIMEOUT=60
+
+# --- Argument parsing ---
+usage() {
+    cat <<'USAGE'
+Usage: ./scripts/bench-partition-recovery.sh [OPTIONS]
+
+Options:
+  --baseline-keys N      Number of keys to write in baseline phase (default 100)
+  --partition-keys N     Number of keys to write during partition (default 50)
+  --partition-secs N     Seconds the partition is held (default 10)
+  --convergence-timeout  Max seconds to wait for convergence (default 60)
+  --help                 Show this help message
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --baseline-keys)
+            BASELINE_KEYS="${2:?--baseline-keys requires a value}"
+            shift 2
+            ;;
+        --partition-keys)
+            PARTITION_KEYS="${2:?--partition-keys requires a value}"
+            shift 2
+            ;;
+        --partition-secs)
+            PARTITION_SECS="${2:?--partition-secs requires a value}"
+            shift 2
+            ;;
+        --convergence-timeout)
+            CONVERGENCE_TIMEOUT="${2:?--convergence-timeout requires a value}"
+            shift 2
+            ;;
+        --help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1" >&2
+            usage >&2
+            exit 1
+            ;;
+    esac
+done
+
+NODE1_URL="http://localhost:3001"
+NODE2_URL="http://localhost:3002"
+NODE3_URL="http://localhost:3003"
+NODE3_CONTAINER="asteroidb-node-3"
+
+TOTAL_KEYS=$(( BASELINE_KEYS + PARTITION_KEYS ))
+RUN_ID="bench-pr-$$"
+
+# --- Cleanup trap ---
+cleanup() {
+    echo ""
+    echo "[bench] Cleaning up..."
+    # Remove iptables / netem rules from node-3
+    docker exec "$NODE3_CONTAINER" iptables -F OUTPUT 2>/dev/null || true
+    docker exec "$NODE3_CONTAINER" iptables -F INPUT 2>/dev/null || true
+    "${NETEM_DIR}/remove-netem.sh" "$NODE3_CONTAINER" 2>/dev/null || true
+    # Tear down the cluster
+    docker compose -f "$COMPOSE_FILE" down --timeout 5 2>/dev/null || true
+}
+trap cleanup EXIT
+
+# --- Helper: write a register key to a node ---
+write_key() {
+    local url="$1"
+    local key="$2"
+    local value="$3"
+    curl -sf -X POST "${url}/api/eventual/write" \
+        -H "Content-Type: application/json" \
+        -d "{\"type\":\"register_set\",\"key\":\"${key}\",\"value\":\"${value}\"}" > /dev/null
+}
+
+# --- Helper: check if a key exists with expected value ---
+check_key() {
+    local url="$1"
+    local key="$2"
+    local expected_value="$3"
+    local json
+    json=$(curl -sf --max-time 5 "${url}/api/eventual/${key}" 2>/dev/null || echo '{"value":null}')
+    local actual
+    actual=$(echo "$json" | python3 -c "
+import sys, json
+try:
+    d = json.load(sys.stdin)
+    v = d.get('value')
+    if v is None:
+        print('')
+    elif isinstance(v, dict):
+        print(v.get('value', ''))
+    else:
+        print(v)
+except Exception:
+    print('')
+" 2>/dev/null || echo "")
+    [ "$actual" = "$expected_value" ]
+}
+
+# --- Helper: count how many of the expected keys are present ---
+count_present_keys() {
+    local url="$1"
+    local prefix="$2"
+    local total="$3"
+    local count=0
+    for i in $(seq 1 "$total"); do
+        local key="${prefix}-${i}"
+        if check_key "$url" "$key" "v-${i}"; then
+            count=$(( count + 1 ))
+        fi
+    done
+    echo "$count"
+}
+
+# --- Start cluster ---
+separator
+echo -e "${CLR_BOLD}AsteroidDB Partition Recovery Benchmark${CLR_RESET}"
+separator
+echo ""
+echo "  Baseline keys:       ${BASELINE_KEYS}"
+echo "  Partition keys:      ${PARTITION_KEYS}"
+echo "  Partition duration:  ${PARTITION_SECS}s"
+echo "  Convergence timeout: ${CONVERGENCE_TIMEOUT}s"
+echo ""
+
+echo "[bench] Starting cluster..."
+docker compose -f "$COMPOSE_FILE" up -d --build --quiet-pull 2>&1 | tail -5
+
+echo "[bench] Waiting for cluster health..."
+for port in 3001 3002 3003; do
+    for attempt in $(seq 1 30); do
+        if curl -sf --max-time 2 "http://localhost:${port}/api/eventual/__health_check" > /dev/null 2>&1; then
+            echo "  Node on port ${port} is ready"
+            break
+        fi
+        if [ "$attempt" -eq 30 ]; then
+            echo "[bench] ERROR: Node on port ${port} did not become ready" >&2
+            exit 1
+        fi
+        sleep 1
+    done
+done
+echo "[bench] Cluster is ready."
+echo ""
+
+# ====================================================================
+# Phase 1: Baseline -- write keys to node-1, verify replication
+# ====================================================================
+log_step 1 "Baseline: write ${BASELINE_KEYS} keys to node-1"
+for i in $(seq 1 "$BASELINE_KEYS"); do
+    write_key "$NODE1_URL" "${RUN_ID}-${i}" "v-${i}"
+done
+echo "  Wrote ${BASELINE_KEYS} keys to node-1."
+
+echo "  Waiting for replication to node-2 and node-3..."
+REPLICATION_RETRIES=30
+for attempt in $(seq 1 "$REPLICATION_RETRIES"); do
+    sleep 2
+    n2_count=$(count_present_keys "$NODE2_URL" "$RUN_ID" "$BASELINE_KEYS")
+    n3_count=$(count_present_keys "$NODE3_URL" "$RUN_ID" "$BASELINE_KEYS")
+    echo "  Attempt ${attempt}/${REPLICATION_RETRIES}: node-2=${n2_count}/${BASELINE_KEYS}, node-3=${n3_count}/${BASELINE_KEYS}"
+    if [ "$n2_count" -eq "$BASELINE_KEYS" ] && [ "$n3_count" -eq "$BASELINE_KEYS" ]; then
+        echo -e "  ${CLR_GREEN}[OK] Baseline replication complete.${CLR_RESET}"
+        break
+    fi
+    if [ "$attempt" -eq "$REPLICATION_RETRIES" ]; then
+        echo -e "  ${CLR_RED}[ERROR] Baseline replication did not complete in time.${CLR_RESET}" >&2
+        exit 1
+    fi
+done
+echo ""
+
+# ====================================================================
+# Phase 2: Partition -- isolate node-3 from node-1 and node-2
+# ====================================================================
+log_step 2 "Partition: isolate node-3 using iptables"
+
+# Get IPs of node-1 and node-2 as seen inside the Docker network.
+NODE1_IP=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' asteroidb-node-1)
+NODE2_IP=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' asteroidb-node-2)
+
+echo "  node-1 IP: ${NODE1_IP}"
+echo "  node-2 IP: ${NODE2_IP}"
+
+# Block bidirectional traffic between node-3 and (node-1, node-2).
+# On node-3: drop outgoing to node-1 and node-2, and incoming from them.
+docker exec "$NODE3_CONTAINER" iptables -A OUTPUT -d "$NODE1_IP" -j DROP
+docker exec "$NODE3_CONTAINER" iptables -A OUTPUT -d "$NODE2_IP" -j DROP
+docker exec "$NODE3_CONTAINER" iptables -A INPUT -s "$NODE1_IP" -j DROP
+docker exec "$NODE3_CONTAINER" iptables -A INPUT -s "$NODE2_IP" -j DROP
+
+PARTITION_START_MS=$(now_epoch_ms)
+echo "  Partition active at $(date '+%H:%M:%S'). Holding for ${PARTITION_SECS}s..."
+echo ""
+
+# ====================================================================
+# Phase 3: Write during partition -- write keys to node-1
+# ====================================================================
+log_step 3 "Write ${PARTITION_KEYS} keys to node-1 during partition"
+
+PARTITION_WRITE_START=$(( BASELINE_KEYS + 1 ))
+PARTITION_WRITE_END=$(( BASELINE_KEYS + PARTITION_KEYS ))
+
+for i in $(seq "$PARTITION_WRITE_START" "$PARTITION_WRITE_END"); do
+    write_key "$NODE1_URL" "${RUN_ID}-${i}" "v-${i}"
+done
+echo "  Wrote ${PARTITION_KEYS} keys to node-1 during partition."
+
+# Wait for partition duration to elapse (minus time already spent writing).
+ELAPSED_PARTITION=$(( $(now_epoch_ms) - PARTITION_START_MS ))
+REMAINING_MS=$(( PARTITION_SECS * 1000 - ELAPSED_PARTITION ))
+if [ "$REMAINING_MS" -gt 0 ]; then
+    REMAINING_SECS=$(python3 -c "print(${REMAINING_MS}/1000)")
+    echo "  Holding partition for ${REMAINING_SECS}s more..."
+    sleep "$REMAINING_SECS"
+fi
+
+PARTITION_END_MS=$(now_epoch_ms)
+PARTITION_DURATION_MS=$(( PARTITION_END_MS - PARTITION_START_MS ))
+echo ""
+
+# ====================================================================
+# Phase 4: Heal -- remove iptables rules, start convergence timer
+# ====================================================================
+log_step 4 "Heal: remove iptables rules on node-3"
+docker exec "$NODE3_CONTAINER" iptables -F OUTPUT
+docker exec "$NODE3_CONTAINER" iptables -F INPUT
+HEAL_MS=$(now_epoch_ms)
+echo "  Partition healed at $(date '+%H:%M:%S')."
+echo "  Starting convergence timer..."
+echo ""
+
+# ====================================================================
+# Phase 5: Measure convergence -- poll node-3 for all keys
+# ====================================================================
+log_step 5 "Measure convergence: poll node-3 for ${TOTAL_KEYS} keys"
+
+CONVERGED=false
+CONVERGENCE_TIME_MS=0
+for attempt in $(seq 1 "$CONVERGENCE_TIMEOUT"); do
+    sleep 1
+    present=$(count_present_keys "$NODE3_URL" "$RUN_ID" "$TOTAL_KEYS")
+    elapsed=$(elapsed_ms "$HEAL_MS")
+    echo "  [${elapsed}ms] node-3 has ${present}/${TOTAL_KEYS} keys"
+
+    if [ "$present" -eq "$TOTAL_KEYS" ]; then
+        CONVERGENCE_TIME_MS="$elapsed"
+        CONVERGED=true
+        echo -e "  ${CLR_GREEN}[OK] node-3 converged in ${CONVERGENCE_TIME_MS}ms.${CLR_RESET}"
+        break
+    fi
+done
+
+if [ "$CONVERGED" = "false" ]; then
+    CONVERGENCE_TIME_MS=$(elapsed_ms "$HEAL_MS")
+    echo -e "  ${CLR_RED}[TIMEOUT] node-3 did not converge within ${CONVERGENCE_TIMEOUT}s.${CLR_RESET}"
+fi
+
+# Final verification: count verified keys on node-3.
+VERIFIED=$(count_present_keys "$NODE3_URL" "$RUN_ID" "$TOTAL_KEYS")
+DATA_LOSS=$(( TOTAL_KEYS - VERIFIED ))
+
+echo ""
+
+# ====================================================================
+# Output results as JSON
+# ====================================================================
+separator
+echo -e "${CLR_BOLD}Results${CLR_RESET}"
+sub_separator
+
+RESULT_JSON=$(cat <<EOF
+{
+  "partition_duration_ms": ${PARTITION_DURATION_MS},
+  "convergence_time_ms": ${CONVERGENCE_TIME_MS},
+  "keys_written": ${TOTAL_KEYS},
+  "keys_verified": ${VERIFIED},
+  "data_loss": ${DATA_LOSS},
+  "baseline_keys": ${BASELINE_KEYS},
+  "partition_keys": ${PARTITION_KEYS},
+  "converged": ${CONVERGED}
+}
+EOF
+)
+
+echo "$RESULT_JSON"
+echo ""
+
+# Write to file for CI/CD consumption.
+RESULT_FILE="${SCRIPT_DIR}/../target/bench-partition-recovery.json"
+mkdir -p "$(dirname "$RESULT_FILE")"
+echo "$RESULT_JSON" > "$RESULT_FILE"
+echo "  Results written to: ${RESULT_FILE}"
+
+separator
+
+if [ "$DATA_LOSS" -gt 0 ]; then
+    echo -e "${CLR_RED}[FAIL] Data loss detected: ${DATA_LOSS} keys missing.${CLR_RESET}"
+    exit 1
+fi
+
+if [ "$CONVERGED" = "false" ]; then
+    echo -e "${CLR_YELLOW}[WARN] Convergence timed out but no data loss detected.${CLR_RESET}"
+    exit 1
+fi
+
+echo -e "${CLR_GREEN}[PASS] Partition recovery benchmark complete. Zero data loss.${CLR_RESET}"
+exit 0

--- a/tests/partition_recovery_bench.rs
+++ b/tests/partition_recovery_bench.rs
@@ -1,0 +1,510 @@
+//! In-process partition recovery time measurement (Issue #226).
+//!
+//! Simulates a 2-node cluster where a network partition is modelled by
+//! suspending bidirectional merge calls.  Both sides write independently
+//! during the partition window.  After the partition heals (merges resume),
+//! we measure the number of sync ticks required to reach full convergence
+//! and assert zero data loss.
+
+use std::collections::HashSet;
+
+use asteroidb_poc::api::eventual::EventualApi;
+use asteroidb_poc::store::kv::CrdtValue;
+use asteroidb_poc::types::NodeId;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn node(name: &str) -> NodeId {
+    NodeId(name.into())
+}
+
+/// Bidirectional merge between two EventualApi nodes for ALL shared keys.
+/// Returns the number of keys synced.
+fn sync_all(a: &mut EventualApi, b: &mut EventualApi) -> usize {
+    let all_keys: Vec<String> = a
+        .keys()
+        .into_iter()
+        .chain(b.keys())
+        .cloned()
+        .collect::<HashSet<_>>()
+        .into_iter()
+        .collect();
+
+    let count = all_keys.len();
+
+    for key in &all_keys {
+        if let Some(val) = a.get_eventual(key) {
+            let cloned = val.clone();
+            let _ = b.merge_remote(key.clone(), &cloned);
+        }
+        if let Some(val) = b.get_eventual(key) {
+            let cloned = val.clone();
+            let _ = a.merge_remote(key.clone(), &cloned);
+        }
+    }
+
+    count
+}
+
+/// Get counter value from an EventualApi (returns 0 if key absent).
+fn counter_val(api: &EventualApi, key: &str) -> i64 {
+    match api.get_eventual(key) {
+        Some(CrdtValue::Counter(c)) => c.value(),
+        _ => 0,
+    }
+}
+
+/// Get register value from an EventualApi.
+fn register_val(api: &EventualApi, key: &str) -> Option<String> {
+    match api.get_eventual(key) {
+        Some(CrdtValue::Register(r)) => r.get().cloned(),
+        _ => None,
+    }
+}
+
+/// Check if two nodes have identical values for all given keys.
+fn nodes_converged(a: &EventualApi, b: &EventualApi, keys: &[String]) -> bool {
+    for key in keys {
+        let a_val = a.get_eventual(key);
+        let b_val = b.get_eventual(key);
+        match (a_val, b_val) {
+            (None, None) => {}
+            (Some(va), Some(vb)) => {
+                // Compare using Debug representations since CrdtValue may not impl PartialEq.
+                if format!("{va:?}") != format!("{vb:?}") {
+                    return false;
+                }
+            }
+            _ => return false,
+        }
+    }
+    true
+}
+
+// ===========================================================================
+// 1. Basic partition recovery: 2 nodes, counter writes on both sides
+// ===========================================================================
+
+#[test]
+fn partition_recovery_counter_two_nodes() {
+    let mut node_a = EventualApi::new(node("node-a"));
+    let mut node_b = EventualApi::new(node("node-b"));
+
+    let baseline_keys = 100;
+    let partition_keys_per_side = 25;
+
+    // --- Baseline: write keys on A, sync to B ---
+    for i in 0..baseline_keys {
+        node_a.eventual_counter_inc(&format!("key-{i}")).unwrap();
+    }
+    sync_all(&mut node_a, &mut node_b);
+
+    // Verify baseline replication.
+    for i in 0..baseline_keys {
+        assert_eq!(
+            counter_val(&node_a, &format!("key-{i}")),
+            counter_val(&node_b, &format!("key-{i}")),
+            "baseline key-{i} should match"
+        );
+    }
+
+    // --- Partition: no sync calls between A and B ---
+
+    // Node A writes during partition.
+    for i in 0..partition_keys_per_side {
+        node_a
+            .eventual_counter_inc(&format!("partition-a-{i}"))
+            .unwrap();
+    }
+    // Also increment some baseline keys on A.
+    for i in 0..10 {
+        node_a.eventual_counter_inc(&format!("key-{i}")).unwrap();
+    }
+
+    // Node B writes during partition.
+    for i in 0..partition_keys_per_side {
+        node_b
+            .eventual_counter_inc(&format!("partition-b-{i}"))
+            .unwrap();
+    }
+    // Also increment some baseline keys on B (different range).
+    for i in 50..60 {
+        node_b.eventual_counter_inc(&format!("key-{i}")).unwrap();
+    }
+
+    // Collect all keys that should exist after convergence.
+    let mut all_keys: Vec<String> = (0..baseline_keys).map(|i| format!("key-{i}")).collect();
+    for i in 0..partition_keys_per_side {
+        all_keys.push(format!("partition-a-{i}"));
+        all_keys.push(format!("partition-b-{i}"));
+    }
+
+    // --- Heal: measure ticks until convergence ---
+    let max_ticks = 10;
+    let mut converged_at_tick = None;
+
+    for tick in 1..=max_ticks {
+        sync_all(&mut node_a, &mut node_b);
+
+        if nodes_converged(&node_a, &node_b, &all_keys) {
+            converged_at_tick = Some(tick);
+            break;
+        }
+    }
+
+    let ticks = converged_at_tick.expect("nodes should converge within max_ticks");
+    println!("[partition_recovery_counter_two_nodes] converged in {ticks} sync tick(s)");
+
+    // --- Assert zero data loss ---
+    // Baseline keys: all should be reachable and have correct merged value.
+    for i in 0..baseline_keys {
+        let key = format!("key-{i}");
+        let a_val = counter_val(&node_a, &key);
+        let b_val = counter_val(&node_b, &key);
+        assert_eq!(a_val, b_val, "key-{i} should match after convergence");
+
+        // Keys 0..10 were incremented on A, keys 50..60 on B.
+        if i < 10 {
+            assert_eq!(
+                a_val, 2,
+                "key-{i} should be 2 (baseline + A partition write)"
+            );
+        } else if (50..60).contains(&i) {
+            assert_eq!(
+                a_val, 2,
+                "key-{i} should be 2 (baseline + B partition write)"
+            );
+        } else {
+            assert_eq!(a_val, 1, "key-{i} should be 1 (baseline only)");
+        }
+    }
+
+    // Partition-only keys: should exist on both sides.
+    for i in 0..partition_keys_per_side {
+        assert_eq!(
+            counter_val(&node_a, &format!("partition-a-{i}")),
+            1,
+            "partition-a-{i} should be 1 on node_a"
+        );
+        assert_eq!(
+            counter_val(&node_b, &format!("partition-a-{i}")),
+            1,
+            "partition-a-{i} should be 1 on node_b"
+        );
+        assert_eq!(
+            counter_val(&node_a, &format!("partition-b-{i}")),
+            1,
+            "partition-b-{i} should be 1 on node_a"
+        );
+        assert_eq!(
+            counter_val(&node_b, &format!("partition-b-{i}")),
+            1,
+            "partition-b-{i} should be 1 on node_b"
+        );
+    }
+
+    // Final total key count check.
+    let a_keys: HashSet<_> = node_a.keys().into_iter().cloned().collect();
+    let b_keys: HashSet<_> = node_b.keys().into_iter().cloned().collect();
+    assert_eq!(a_keys, b_keys, "both nodes should have identical key sets");
+    assert_eq!(a_keys.len(), all_keys.len(), "total key count should match");
+}
+
+// ===========================================================================
+// 2. Register recovery: LWW-Register writes on both sides
+// ===========================================================================
+
+#[test]
+fn partition_recovery_register_two_nodes() {
+    let mut node_a = EventualApi::new(node("node-a"));
+    let mut node_b = EventualApi::new(node("node-b"));
+
+    let num_keys = 50;
+
+    // --- Baseline: write registers on A, sync to B ---
+    for i in 0..num_keys {
+        node_a
+            .eventual_register_set(&format!("reg-{i}"), format!("init-{i}"))
+            .unwrap();
+    }
+    sync_all(&mut node_a, &mut node_b);
+
+    for i in 0..num_keys {
+        assert_eq!(
+            register_val(&node_a, &format!("reg-{i}")),
+            register_val(&node_b, &format!("reg-{i}")),
+        );
+    }
+
+    // --- Partition: each side updates different registers ---
+    // A updates even-numbered keys.
+    for i in (0..num_keys).step_by(2) {
+        node_a
+            .eventual_register_set(&format!("reg-{i}"), format!("from-a-{i}"))
+            .unwrap();
+    }
+    // B updates odd-numbered keys (with a small delay to ensure distinct HLC).
+    std::thread::sleep(std::time::Duration::from_millis(1));
+    for i in (1..num_keys).step_by(2) {
+        node_b
+            .eventual_register_set(&format!("reg-{i}"), format!("from-b-{i}"))
+            .unwrap();
+    }
+
+    // --- Heal ---
+    let max_ticks = 5;
+    let all_keys: Vec<String> = (0..num_keys).map(|i| format!("reg-{i}")).collect();
+    let mut converged_at_tick = None;
+
+    for tick in 1..=max_ticks {
+        sync_all(&mut node_a, &mut node_b);
+        if nodes_converged(&node_a, &node_b, &all_keys) {
+            converged_at_tick = Some(tick);
+            break;
+        }
+    }
+
+    let ticks = converged_at_tick.expect("register nodes should converge");
+    println!("[partition_recovery_register_two_nodes] converged in {ticks} sync tick(s)");
+
+    // Zero data loss: all keys present on both sides with matching values.
+    for i in 0..num_keys {
+        let a_val = register_val(&node_a, &format!("reg-{i}"));
+        let b_val = register_val(&node_b, &format!("reg-{i}"));
+        assert_eq!(a_val, b_val, "reg-{i} should match after convergence");
+        assert!(a_val.is_some(), "reg-{i} should not be None");
+    }
+}
+
+// ===========================================================================
+// 3. Three-node partition recovery with isolated node
+// ===========================================================================
+
+#[test]
+fn partition_recovery_three_nodes_isolated() {
+    let mut node_a = EventualApi::new(node("node-a"));
+    let mut node_b = EventualApi::new(node("node-b"));
+    let mut node_c = EventualApi::new(node("node-c"));
+
+    let baseline_keys = 100;
+    let partition_keys = 50;
+
+    // --- Baseline: write on A, replicate to all ---
+    for i in 0..baseline_keys {
+        node_a
+            .eventual_register_set(&format!("k-{i}"), format!("v-{i}"))
+            .unwrap();
+    }
+    sync_all(&mut node_a, &mut node_b);
+    sync_all(&mut node_a, &mut node_c);
+
+    for i in 0..baseline_keys {
+        assert_eq!(
+            register_val(&node_c, &format!("k-{i}")),
+            Some(format!("v-{i}")),
+            "baseline k-{i} should be on node_c"
+        );
+    }
+
+    // --- Partition: node_c is isolated; A and B continue ---
+    for i in baseline_keys..(baseline_keys + partition_keys) {
+        node_a
+            .eventual_register_set(&format!("k-{i}"), format!("v-{i}"))
+            .unwrap();
+    }
+    // A and B sync normally during partition.
+    sync_all(&mut node_a, &mut node_b);
+
+    // Verify C does not see partition-time writes.
+    for i in baseline_keys..(baseline_keys + partition_keys) {
+        assert!(
+            register_val(&node_c, &format!("k-{i}")).is_none(),
+            "k-{i} should NOT be on node_c during partition"
+        );
+    }
+
+    // --- Heal: resume sync with C, measure ticks ---
+    let total_keys = baseline_keys + partition_keys;
+    let all_keys: Vec<String> = (0..total_keys).map(|i| format!("k-{i}")).collect();
+    let max_ticks = 10;
+    let mut converged_at_tick = None;
+
+    for tick in 1..=max_ticks {
+        // Simulate anti-entropy: sync C with A and B.
+        sync_all(&mut node_a, &mut node_c);
+        sync_all(&mut node_b, &mut node_c);
+
+        // Check if C has all keys.
+        let c_has_all = all_keys.iter().all(|k| register_val(&node_c, k).is_some());
+        if c_has_all && nodes_converged(&node_a, &node_c, &all_keys) {
+            converged_at_tick = Some(tick);
+            break;
+        }
+    }
+
+    let ticks = converged_at_tick.expect("3-node cluster should converge after partition heal");
+    println!("[partition_recovery_three_nodes_isolated] converged in {ticks} sync tick(s)");
+
+    // --- Assert zero data loss ---
+    let keys_verified = all_keys
+        .iter()
+        .filter(|k| register_val(&node_c, k).is_some())
+        .count();
+    assert_eq!(
+        keys_verified, total_keys,
+        "all {total_keys} keys should be present on node_c"
+    );
+
+    for i in 0..total_keys {
+        let key = format!("k-{i}");
+        let expected = format!("v-{i}");
+        assert_eq!(
+            register_val(&node_a, &key),
+            Some(expected.clone()),
+            "node_a should have k-{i}"
+        );
+        assert_eq!(
+            register_val(&node_b, &key),
+            Some(expected.clone()),
+            "node_b should have k-{i}"
+        );
+        assert_eq!(
+            register_val(&node_c, &key),
+            Some(expected),
+            "node_c should have k-{i}"
+        );
+    }
+}
+
+// ===========================================================================
+// 4. Convergence tick measurement with varying partition sizes
+// ===========================================================================
+
+#[test]
+fn partition_recovery_measures_tick_scaling() {
+    // Measure whether convergence ticks scale with partition size.
+    // With CRDT merges, a single full sync should suffice regardless of
+    // partition size (since merge is idempotent and total).
+    let sizes = [10, 50, 100, 200];
+    let mut results: Vec<(usize, usize)> = Vec::new();
+
+    for &size in &sizes {
+        let mut node_a = EventualApi::new(node("node-a"));
+        let mut node_b = EventualApi::new(node("node-b"));
+
+        // Write `size` keys on each side during "partition".
+        for i in 0..size {
+            node_a
+                .eventual_counter_inc(&format!("scale-a-{i}"))
+                .unwrap();
+            node_b
+                .eventual_counter_inc(&format!("scale-b-{i}"))
+                .unwrap();
+        }
+
+        let all_keys: Vec<String> = (0..size)
+            .flat_map(|i| vec![format!("scale-a-{i}"), format!("scale-b-{i}")])
+            .collect();
+
+        // Heal and measure ticks.
+        let max_ticks = 10;
+        let mut ticks = 0;
+        for tick in 1..=max_ticks {
+            sync_all(&mut node_a, &mut node_b);
+            ticks = tick;
+            if nodes_converged(&node_a, &node_b, &all_keys) {
+                break;
+            }
+        }
+
+        results.push((size, ticks));
+
+        // Assert zero data loss for every size.
+        let a_keys: HashSet<_> = node_a.keys().into_iter().cloned().collect();
+        let b_keys: HashSet<_> = node_b.keys().into_iter().cloned().collect();
+        assert_eq!(a_keys, b_keys, "key sets should match for size={size}");
+        assert_eq!(
+            a_keys.len(),
+            size * 2,
+            "total keys should be {0} for size={size}",
+            size * 2
+        );
+    }
+
+    println!("[partition_recovery_measures_tick_scaling] results:");
+    for (size, ticks) in &results {
+        println!("  partition_size={size:>4}, convergence_ticks={ticks}");
+    }
+
+    // CRDT full-state merge should converge in 1 tick regardless of size.
+    for (size, ticks) in &results {
+        assert!(
+            *ticks <= 2,
+            "convergence for size={size} took {ticks} ticks; expected <= 2"
+        );
+    }
+}
+
+// ===========================================================================
+// 5. Partition with concurrent writes to the same keys (conflict resolution)
+// ===========================================================================
+
+#[test]
+fn partition_recovery_concurrent_same_key_zero_loss() {
+    let mut node_a = EventualApi::new(node("node-a"));
+    let mut node_b = EventualApi::new(node("node-b"));
+
+    let num_keys = 50;
+    let writes_per_side = 10;
+
+    // Both sides increment the same counters during partition.
+    for i in 0..num_keys {
+        for _ in 0..writes_per_side {
+            node_a.eventual_counter_inc(&format!("shared-{i}")).unwrap();
+            node_b.eventual_counter_inc(&format!("shared-{i}")).unwrap();
+        }
+    }
+
+    // Before merge: each node sees only its own writes.
+    for i in 0..num_keys {
+        assert_eq!(
+            counter_val(&node_a, &format!("shared-{i}")),
+            writes_per_side as i64
+        );
+        assert_eq!(
+            counter_val(&node_b, &format!("shared-{i}")),
+            writes_per_side as i64
+        );
+    }
+
+    // Heal.
+    let mut ticks = 0;
+    let all_keys: Vec<String> = (0..num_keys).map(|i| format!("shared-{i}")).collect();
+    for tick in 1..=5 {
+        sync_all(&mut node_a, &mut node_b);
+        ticks = tick;
+        if nodes_converged(&node_a, &node_b, &all_keys) {
+            break;
+        }
+    }
+
+    println!("[partition_recovery_concurrent_same_key_zero_loss] converged in {ticks} tick(s)");
+
+    // Assert zero data loss: each key should equal writes_per_side * 2.
+    let expected = (writes_per_side * 2) as i64;
+    for i in 0..num_keys {
+        let key = format!("shared-{i}");
+        assert_eq!(
+            counter_val(&node_a, &key),
+            expected,
+            "{key} should be {expected} on node_a"
+        );
+        assert_eq!(
+            counter_val(&node_b, &key),
+            expected,
+            "{key} should be {expected} on node_b"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Closes #226 — adds quantitative partition recovery measurement.

**scripts/bench-partition-recovery.sh**: Docker-based 3-node benchmark
- Baseline write → iptables partition → write during partition → heal → measure convergence
- Configurable via CLI flags
- JSON output for CI tracking

**tests/partition_recovery_bench.rs** (5 in-process tests):
- 2-node and 3-node partition recovery with counters and registers
- Tick scaling measurement across partition sizes
- Concurrent same-key writes with zero data loss assertion

## Test plan

- [x] cargo test — 836+ tests pass
- [x] cargo clippy -- -D warnings — clean
- [x] cargo fmt --check — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)