### PR TITLE
refactor: reduce unnecessary clones in CRDT merge and store hot paths

### DIFF
--- a/src/authority/ack_frontier.rs
+++ b/src/authority/ack_frontier.rs
@@ -174,10 +174,9 @@ impl AckFrontierSet {
 
     /// Check whether a (key_range, policy_version) pair has been fenced.
     pub fn is_version_fenced(&self, range: &KeyRange, version: &PolicyVersion) -> bool {
-        self.fenced_versions.contains(&FencedVersion {
-            key_range: range.clone(),
-            policy_version: *version,
-        })
+        self.fenced_versions
+            .iter()
+            .any(|fv| fv.key_range == *range && fv.policy_version == *version)
     }
 
     /// Get the frontier for a specific authority by `NodeId`.

--- a/src/crdt/or_map.rs
+++ b/src/crdt/or_map.rs
@@ -153,11 +153,12 @@ where
             });
 
             // Add dots from other that we haven't tombstoned.
-            for dot in other_dots {
-                if !self.deferred.contains(dot) {
-                    entry.0.insert(dot.clone());
-                }
-            }
+            entry.0.extend(
+                other_dots
+                    .iter()
+                    .filter(|dot| !self.deferred.contains(dot))
+                    .cloned(),
+            );
 
             // Remove our dots that the other has tombstoned.
             entry.0.retain(|dot| !other.deferred.contains(dot));
@@ -183,9 +184,7 @@ where
         }
 
         // Merge deferred sets.
-        for dot in &other.deferred {
-            self.deferred.insert(dot.clone());
-        }
+        self.deferred.extend(other.deferred.iter().cloned());
     }
 
     /// Return the number of present keys.

--- a/src/crdt/or_set.rs
+++ b/src/crdt/or_set.rs
@@ -127,11 +127,12 @@ where
             let dots = self.elements.entry(elem.clone()).or_default();
 
             // Add dots from other that we haven't tombstoned.
-            for dot in other_dots {
-                if !self.deferred.contains(dot) {
-                    dots.insert(dot.clone());
-                }
-            }
+            dots.extend(
+                other_dots
+                    .iter()
+                    .filter(|dot| !self.deferred.contains(dot))
+                    .cloned(),
+            );
 
             // Remove our dots that the other has tombstoned.
             dots.retain(|dot| !other.deferred.contains(dot));
@@ -150,15 +151,11 @@ where
         // Merge counters so future dots stay globally unique.
         for (node_id, &other_counter) in &other.counters {
             let counter = self.counters.entry(node_id.clone()).or_insert(0);
-            if other_counter > *counter {
-                *counter = other_counter;
-            }
+            *counter = (*counter).max(other_counter);
         }
 
         // Merge deferred (tombstone) sets.
-        for dot in &other.deferred {
-            self.deferred.insert(dot.clone());
-        }
+        self.deferred.extend(other.deferred.iter().cloned());
     }
 }
 

--- a/src/runtime/node_runner.rs
+++ b/src/runtime/node_runner.rs
@@ -1245,20 +1245,28 @@ impl NodeRunner {
             // --- Push phase: send only changed local keys to peer ---
             if let Some(frontier) = self.peer_frontiers.get(&peer_key) {
                 let api = eventual_api.lock().await;
-                // entries_since returns entries sorted by HLC; preserve the
-                // per-entry HLC so we can compute the correct frontier to
-                // advance to after a (possibly partial) push.
+                // entries_since returns entries sorted by HLC; split into
+                // (key, value) pairs for push and a parallel HLC vec for
+                // frontier tracking, avoiding a second clone of every entry.
                 let entries_with_hlc: Vec<(
                     String,
                     crate::store::kv::CrdtValue,
                     crate::hlc::HlcTimestamp,
                 )> = api.store().entries_since(frontier);
-                let changed: Vec<(String, crate::store::kv::CrdtValue)> = entries_with_hlc
-                    .iter()
-                    .map(|(key, value, _hlc)| (key.clone(), value.clone()))
-                    .collect();
-                let changed_count = changed.len();
                 drop(api);
+
+                let changed_count = entries_with_hlc.len();
+                // Separate HLCs (cheap Copy-like fields) from owned key-value
+                // pairs so push_changed_keys can take ownership without an
+                // extra clone of every CrdtValue.
+                let hlc_vec: Vec<crate::hlc::HlcTimestamp> = entries_with_hlc
+                    .iter()
+                    .map(|(_, _, hlc)| hlc.clone())
+                    .collect();
+                let changed: Vec<(String, crate::store::kv::CrdtValue)> = entries_with_hlc
+                    .into_iter()
+                    .map(|(key, value, _hlc)| (key, value))
+                    .collect();
 
                 if !changed.is_empty() {
                     let push_result = sync_client
@@ -1277,7 +1285,7 @@ impl NodeRunner {
                             // entry write (HLC physical) to push completion.
                             if let Some(slo) = &self.slo_tracker {
                                 let now_ms = self.clock.now().physical;
-                                for (_key, _val, hlc) in entries_with_hlc.iter().take(pushed) {
+                                for hlc in hlc_vec.iter().take(pushed) {
                                     let convergence_ms = now_ms.saturating_sub(hlc.physical) as f64;
                                     slo.record_observation(
                                         SLO_REPLICATION_CONVERGENCE,
@@ -1288,7 +1296,7 @@ impl NodeRunner {
                             // Advance peer frontier to the max HLC of the
                             // pushed batch — NOT current_frontier(), which may
                             // have advanced past unpushed concurrent writes.
-                            if let Some((_key, _val, max_hlc)) = entries_with_hlc.last() {
+                            if let Some(max_hlc) = hlc_vec.last() {
                                 self.peer_frontiers
                                     .insert(peer_key.clone(), max_hlc.clone());
                             }
@@ -1302,11 +1310,10 @@ impl NodeRunner {
                             );
                             // On partial failure, advance the frontier only to
                             // the HLC of the last successfully pushed entry.
-                            // entries_with_hlc is sorted by HLC, so index
+                            // hlc_vec is sorted by HLC, so index
                             // `pushed - 1` is the last entry that was sent.
                             if e.pushed > 0
-                                && let Some((_key, _val, last_pushed_hlc)) =
-                                    entries_with_hlc.get(e.pushed - 1)
+                                && let Some(last_pushed_hlc) = hlc_vec.get(e.pushed - 1)
                             {
                                 self.peer_frontiers
                                     .insert(peer_key.clone(), last_pushed_hlc.clone());

--- a/src/store/kv.rs
+++ b/src/store/kv.rs
@@ -280,7 +280,7 @@ impl Store {
                     .map(|v| (key.clone(), v.clone(), ts.clone()))
             })
             .collect();
-        result.sort_by(|a, b| a.2.cmp(&b.2));
+        result.sort_unstable_by(|a, b| a.2.cmp(&b.2));
         result
     }
 


### PR DESCRIPTION
## Summary

Closes #224 — reduces unnecessary .clone() calls in hot paths.

**Optimizations:**
- **or_set.rs/or_map.rs**: Bulk `extend()` for dot insertion and deferred merge instead of per-element insert+clone
- **node_runner.rs**: Eliminate full clone of (key, CrdtValue) pairs in delta push — extract HLCs separately and move values via `into_iter()`
- **ack_frontier.rs**: Replace `HashSet::contains()` (allocates String) with `.iter().any()` by-ref comparison
- **kv.rs**: `sort_unstable_by` instead of `sort_by` in entries_since (no stability needed)

## Test plan

- [x] cargo test — 836+ tests + 12 property tests pass
- [x] cargo clippy -- -D warnings — clean
- [x] cargo fmt --check — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)