### PR TITLE
feat: add criterion micro-benchmarks and multi-node bench script (#223)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,21 @@
 version = 4
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "anstream"
 version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -65,6 +80,7 @@ dependencies = [
  "axum",
  "blst",
  "clap",
+ "criterion",
  "ed25519-dalek",
  "http-body-util",
  "proptest",
@@ -210,6 +226,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cc"
 version = "1.2.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -224,6 +246,33 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
 
 [[package]]
 name = "clap"
@@ -311,6 +360,73 @@ checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -404,6 +520,12 @@ dependencies = [
  "subtle",
  "zeroize",
 ]
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "encoding_rs"
@@ -602,6 +724,17 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+]
+
+[[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
 ]
 
 [[package]]
@@ -893,10 +1026,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -1031,6 +1184,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
 name = "openssl"
 version = "0.10.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1130,6 +1289,34 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
 
 [[package]]
 name = "potential_utf"
@@ -1283,12 +1470,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "rayon"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -1431,6 +1661,15 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "schannel"
@@ -1733,6 +1972,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "tokio"
 version = "1.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1953,6 +2202,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2086,6 +2345,15 @@ checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ tempfile = "3"
 tower = { version = "0.5", features = ["util"] }
 http-body-util = "0.1"
 proptest = "1"
+criterion = { version = "0.5", features = ["html_reports"] }
 
 [[bin]]
 name = "asteroidb-cli"
@@ -28,4 +29,16 @@ path = "src/bin/cli.rs"
 
 [[bench]]
 name = "sync_benchmark"
+harness = false
+
+[[bench]]
+name = "crdt_bench"
+harness = false
+
+[[bench]]
+name = "store_bench"
+harness = false
+
+[[bench]]
+name = "certified_bench"
 harness = false

--- a/benches/certified_bench.rs
+++ b/benches/certified_bench.rs
@@ -1,0 +1,185 @@
+//! Criterion benchmarks for the certified write path:
+//! certified_write, process_certifications, and verify_proof.
+
+use std::sync::{Arc, RwLock};
+
+use criterion::{Criterion, criterion_group, criterion_main};
+use ed25519_dalek::SigningKey;
+use rand::rngs::OsRng;
+
+use asteroidb_poc::api::certified::{CertifiedApi, OnTimeout, ProofBundle};
+use asteroidb_poc::authority::ack_frontier::AckFrontier;
+use asteroidb_poc::authority::certificate::{
+    AuthoritySignature, KeysetVersion, MajorityCertificate, create_certificate_message,
+    sign_message,
+};
+use asteroidb_poc::authority::verifier::verify_proof;
+use asteroidb_poc::control_plane::system_namespace::{AuthorityDefinition, SystemNamespace};
+use asteroidb_poc::crdt::pn_counter::PnCounter;
+use asteroidb_poc::hlc::HlcTimestamp;
+use asteroidb_poc::store::kv::CrdtValue;
+use asteroidb_poc::types::{KeyRange, NodeId, PolicyVersion};
+
+fn node(name: &str) -> NodeId {
+    NodeId(name.into())
+}
+
+fn ts(physical: u64, logical: u32, node: &str) -> HlcTimestamp {
+    HlcTimestamp {
+        physical,
+        logical,
+        node_id: node.into(),
+    }
+}
+
+/// Build a CertifiedApi with 3 authorities for "user/" key range.
+fn build_certified_api() -> CertifiedApi {
+    let mut ns = SystemNamespace::new();
+    ns.set_authority_definition(AuthorityDefinition {
+        key_range: KeyRange {
+            prefix: "user/".into(),
+        },
+        authority_nodes: vec![node("auth-0"), node("auth-1"), node("auth-2")],
+        auto_generated: false,
+    });
+    let ns = Arc::new(RwLock::new(ns));
+    CertifiedApi::new(node("node-a"), ns)
+}
+
+/// Build a signed ProofBundle with `n_signers` out of `total` authorities.
+fn make_signed_proof(n_signers: usize, total: usize) -> ProofBundle {
+    let kr = KeyRange {
+        prefix: "user/".into(),
+    };
+    let hlc = ts(1_700_000_000_000, 42, "node-1");
+    let pv = PolicyVersion(1);
+
+    let message = create_certificate_message(&kr, &hlc, &pv);
+    let mut cert = MajorityCertificate::new(kr.clone(), hlc.clone(), pv, KeysetVersion(1));
+
+    let authorities: Vec<NodeId> = (0..n_signers)
+        .map(|i| NodeId(format!("auth-{i}")))
+        .collect();
+
+    for auth in &authorities {
+        let sk = SigningKey::generate(&mut OsRng);
+        let vk = sk.verifying_key();
+        let sig = sign_message(&sk, &message);
+        cert.add_signature(AuthoritySignature {
+            authority_id: auth.clone(),
+            public_key: vk,
+            signature: sig,
+            keyset_version: KeysetVersion(1),
+        });
+    }
+
+    ProofBundle {
+        key_range: kr,
+        frontier_hlc: hlc,
+        policy_version: pv,
+        contributing_authorities: authorities,
+        total_authorities: total,
+        certificate: Some(cert),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// certified_write benchmark
+// ---------------------------------------------------------------------------
+
+fn bench_certified_write(c: &mut Criterion) {
+    c.bench_function("certified/write_pending", |b| {
+        b.iter_batched(
+            build_certified_api,
+            |mut api| {
+                for i in 0..100 {
+                    let key = format!("user/key-{i}");
+                    let mut counter = PnCounter::new();
+                    counter.increment(&node("node-a"));
+                    let _ =
+                        api.certified_write(key, CrdtValue::Counter(counter), OnTimeout::Pending);
+                }
+            },
+            criterion::BatchSize::SmallInput,
+        );
+    });
+}
+
+// ---------------------------------------------------------------------------
+// process_certifications benchmark
+// ---------------------------------------------------------------------------
+
+fn bench_process_certifications(c: &mut Criterion) {
+    c.bench_function("certified/process_certifications", |b| {
+        b.iter_batched(
+            || {
+                let mut api = build_certified_api();
+                // Write 100 pending entries.
+                for i in 0..100 {
+                    let key = format!("user/key-{i}");
+                    let mut counter = PnCounter::new();
+                    counter.increment(&node("node-a"));
+                    let _ =
+                        api.certified_write(key, CrdtValue::Counter(counter), OnTimeout::Pending);
+                }
+                // Advance frontiers so some writes become certifiable.
+                let frontier_hlc = ts(u64::MAX - 1, u32::MAX, "zzz");
+                let kr = KeyRange {
+                    prefix: "user/".into(),
+                };
+                let pv = PolicyVersion(1);
+                for i in 0..2 {
+                    api.update_frontier(AckFrontier {
+                        authority_id: node(&format!("auth-{i}")),
+                        frontier_hlc: frontier_hlc.clone(),
+                        key_range: kr.clone(),
+                        policy_version: pv,
+                        digest_hash: String::new(),
+                    });
+                }
+                api
+            },
+            |mut api| {
+                api.process_certifications();
+            },
+            criterion::BatchSize::SmallInput,
+        );
+    });
+}
+
+// ---------------------------------------------------------------------------
+// verify_proof benchmark
+// ---------------------------------------------------------------------------
+
+fn bench_verify_proof(c: &mut Criterion) {
+    // 3-of-5 signed proof.
+    let proof = make_signed_proof(3, 5);
+
+    c.bench_function("certified/verify_proof_3of5", |b| {
+        b.iter(|| {
+            let result = verify_proof(&proof);
+            std::hint::black_box(result.valid);
+        });
+    });
+}
+
+fn bench_verify_proof_large(c: &mut Criterion) {
+    // 5-of-9 signed proof for heavier workload.
+    let proof = make_signed_proof(5, 9);
+
+    c.bench_function("certified/verify_proof_5of9", |b| {
+        b.iter(|| {
+            let result = verify_proof(&proof);
+            std::hint::black_box(result.valid);
+        });
+    });
+}
+
+criterion_group!(
+    benches,
+    bench_certified_write,
+    bench_process_certifications,
+    bench_verify_proof,
+    bench_verify_proof_large,
+);
+criterion_main!(benches);

--- a/benches/crdt_bench.rs
+++ b/benches/crdt_bench.rs
@@ -1,0 +1,197 @@
+//! Criterion benchmarks for CRDT types: PnCounter, OrSet, OrMap, LwwRegister.
+
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+
+use asteroidb_poc::crdt::lww_register::LwwRegister;
+use asteroidb_poc::crdt::or_map::OrMap;
+use asteroidb_poc::crdt::or_set::OrSet;
+use asteroidb_poc::crdt::pn_counter::PnCounter;
+use asteroidb_poc::hlc::HlcTimestamp;
+use asteroidb_poc::types::NodeId;
+
+fn node(name: &str) -> NodeId {
+    NodeId(name.into())
+}
+
+fn ts(physical: u64, logical: u32, node: &str) -> HlcTimestamp {
+    HlcTimestamp {
+        physical,
+        logical,
+        node_id: node.into(),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// PnCounter benchmarks
+// ---------------------------------------------------------------------------
+
+fn bench_pn_counter_increment(c: &mut Criterion) {
+    let node_a = node("node-a");
+    c.bench_function("pn_counter/increment", |b| {
+        b.iter(|| {
+            let mut counter = PnCounter::new();
+            for _ in 0..100 {
+                counter.increment(&node_a);
+            }
+            counter
+        });
+    });
+}
+
+fn bench_pn_counter_merge(c: &mut Criterion) {
+    let node_a = node("node-a");
+    let node_b = node("node-b");
+
+    let mut counter_a = PnCounter::new();
+    for _ in 0..1000 {
+        counter_a.increment(&node_a);
+    }
+
+    let mut counter_b = PnCounter::new();
+    for _ in 0..1000 {
+        counter_b.increment(&node_b);
+    }
+    for _ in 0..500 {
+        counter_b.decrement(&node_b);
+    }
+
+    c.bench_function("pn_counter/merge_2_replicas", |b| {
+        b.iter(|| {
+            let mut a = counter_a.clone();
+            a.merge(&counter_b);
+            a
+        });
+    });
+}
+
+// ---------------------------------------------------------------------------
+// OrSet benchmarks
+// ---------------------------------------------------------------------------
+
+fn bench_or_set_add_merge(c: &mut Criterion) {
+    let mut group = c.benchmark_group("or_set/add_merge");
+
+    for size in [10, 100, 1000] {
+        group.bench_with_input(BenchmarkId::from_parameter(size), &size, |b, &size| {
+            let node_a = node("node-a");
+            let node_b = node("node-b");
+
+            // Build two sets with `size` elements each (disjoint).
+            let mut set_a = OrSet::new();
+            for i in 0..size {
+                set_a.add(format!("a-{i}"), &node_a);
+            }
+
+            let mut set_b = OrSet::new();
+            for i in 0..size {
+                set_b.add(format!("b-{i}"), &node_b);
+            }
+
+            b.iter(|| {
+                let mut a = set_a.clone();
+                a.merge(&set_b);
+                a
+            });
+        });
+    }
+    group.finish();
+}
+
+fn bench_or_set_add(c: &mut Criterion) {
+    let mut group = c.benchmark_group("or_set/add");
+
+    for size in [10, 100, 1000] {
+        group.bench_with_input(BenchmarkId::from_parameter(size), &size, |b, &size| {
+            let node_a = node("node-a");
+            b.iter(|| {
+                let mut set = OrSet::new();
+                for i in 0..size {
+                    set.add(format!("elem-{i}"), &node_a);
+                }
+                set
+            });
+        });
+    }
+    group.finish();
+}
+
+// ---------------------------------------------------------------------------
+// OrMap benchmarks
+// ---------------------------------------------------------------------------
+
+fn bench_or_map_put_merge(c: &mut Criterion) {
+    let node_a = node("node-a");
+    let node_b = node("node-b");
+
+    let mut map_a: OrMap<String, String> = OrMap::new();
+    for i in 0..100 {
+        map_a.set(
+            format!("key-{i}"),
+            format!("val-a-{i}"),
+            ts(1000 + i, 0, "node-a"),
+            &node_a,
+        );
+    }
+
+    let mut map_b: OrMap<String, String> = OrMap::new();
+    for i in 0..100 {
+        map_b.set(
+            format!("key-{i}"),
+            format!("val-b-{i}"),
+            ts(2000 + i, 0, "node-b"),
+            &node_b,
+        );
+    }
+
+    c.bench_function("or_map/put_100_merge", |b| {
+        b.iter(|| {
+            let mut a = map_a.clone();
+            a.merge(&map_b);
+            a
+        });
+    });
+}
+
+// ---------------------------------------------------------------------------
+// LwwRegister benchmarks
+// ---------------------------------------------------------------------------
+
+fn bench_lww_register_set_merge(c: &mut Criterion) {
+    let mut reg_a = LwwRegister::new();
+    reg_a.set("value-a".to_string(), ts(100, 0, "node-a"));
+
+    let mut reg_b = LwwRegister::new();
+    reg_b.set("value-b".to_string(), ts(200, 0, "node-b"));
+
+    c.bench_function("lww_register/set_and_merge", |b| {
+        b.iter(|| {
+            let mut a = reg_a.clone();
+            a.merge(&reg_b);
+            a
+        });
+    });
+}
+
+fn bench_lww_register_set(c: &mut Criterion) {
+    c.bench_function("lww_register/set_100", |b| {
+        b.iter(|| {
+            let mut reg = LwwRegister::new();
+            for i in 0u64..100 {
+                reg.set(format!("value-{i}"), ts(i, 0, "node-a"));
+            }
+            reg
+        });
+    });
+}
+
+criterion_group!(
+    benches,
+    bench_pn_counter_increment,
+    bench_pn_counter_merge,
+    bench_or_set_add,
+    bench_or_set_add_merge,
+    bench_or_map_put_merge,
+    bench_lww_register_set,
+    bench_lww_register_set_merge,
+);
+criterion_main!(benches);

--- a/benches/store_bench.rs
+++ b/benches/store_bench.rs
@@ -1,0 +1,154 @@
+//! Criterion benchmarks for the Store layer: put, get, entries_since,
+//! save_snapshot, and load_snapshot.
+
+use std::path::Path;
+
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use tempfile::TempDir;
+
+use asteroidb_poc::crdt::pn_counter::PnCounter;
+use asteroidb_poc::hlc::{Hlc, HlcTimestamp};
+use asteroidb_poc::store::kv::{CrdtValue, Store};
+use asteroidb_poc::types::NodeId;
+
+fn node(name: &str) -> NodeId {
+    NodeId(name.into())
+}
+
+/// Build a store pre-populated with `n` counter entries and HLC timestamps.
+fn build_store(n: usize) -> (Store, Option<HlcTimestamp>) {
+    let mut store = Store::new();
+    let mut clock = Hlc::new("bench-node".into());
+    let nid = node("bench-node");
+
+    for i in 0..n {
+        let key = format!("key-{i:06}");
+        let mut counter = PnCounter::new();
+        counter.increment(&nid);
+        let ts = clock.now();
+        store.put(key.clone(), CrdtValue::Counter(counter));
+        store.record_change(&key, ts);
+    }
+
+    let frontier = store.current_frontier();
+    (store, frontier)
+}
+
+// ---------------------------------------------------------------------------
+// put + get benchmarks
+// ---------------------------------------------------------------------------
+
+fn bench_store_put(c: &mut Criterion) {
+    let nid = node("bench-node");
+
+    c.bench_function("store/put_1000", |b| {
+        b.iter(|| {
+            let mut store = Store::new();
+            for i in 0..1000 {
+                let key = format!("key-{i:06}");
+                let mut counter = PnCounter::new();
+                counter.increment(&nid);
+                store.put(key, CrdtValue::Counter(counter));
+            }
+            store
+        });
+    });
+}
+
+fn bench_store_get(c: &mut Criterion) {
+    let (store, _) = build_store(1000);
+
+    c.bench_function("store/get_existing", |b| {
+        b.iter(|| {
+            // Access 100 keys spread across the keyspace.
+            for i in (0..1000).step_by(10) {
+                let key = format!("key-{i:06}");
+                std::hint::black_box(store.get(&key));
+            }
+        });
+    });
+}
+
+fn bench_store_get_missing(c: &mut Criterion) {
+    let (store, _) = build_store(1000);
+
+    c.bench_function("store/get_missing", |b| {
+        b.iter(|| {
+            for i in 0..100 {
+                let key = format!("nonexistent-{i}");
+                std::hint::black_box(store.get(&key));
+            }
+        });
+    });
+}
+
+// ---------------------------------------------------------------------------
+// entries_since benchmarks
+// ---------------------------------------------------------------------------
+
+fn bench_entries_since(c: &mut Criterion) {
+    let mut group = c.benchmark_group("store/entries_since");
+
+    for total in [100, 1000, 5000] {
+        group.bench_with_input(BenchmarkId::from_parameter(total), &total, |b, &total| {
+            let (mut store, frontier) = build_store(total);
+
+            // Record changes for the last 10% of keys (simulate delta).
+            let mut clock = Hlc::new("bench-node".into());
+            let changed = total / 10;
+            for i in 0..changed {
+                let key = format!("key-{i:06}");
+                let ts = clock.now();
+                store.record_change(&key, ts);
+            }
+
+            let frontier = frontier.unwrap();
+            b.iter(|| {
+                let entries = store.entries_since(&frontier);
+                std::hint::black_box(entries.len());
+            });
+        });
+    }
+    group.finish();
+}
+
+// ---------------------------------------------------------------------------
+// Snapshot benchmarks
+// ---------------------------------------------------------------------------
+
+fn bench_save_snapshot(c: &mut Criterion) {
+    let (store, _) = build_store(1000);
+    let tmp_dir = TempDir::new().expect("create temp dir");
+    let path = tmp_dir.path().join("bench-snapshot.json");
+
+    c.bench_function("store/save_snapshot_1000", |b| {
+        b.iter(|| {
+            store.save_snapshot(Path::new(&path)).unwrap();
+        });
+    });
+}
+
+fn bench_load_snapshot(c: &mut Criterion) {
+    let (store, _) = build_store(1000);
+    let tmp_dir = TempDir::new().expect("create temp dir");
+    let path = tmp_dir.path().join("bench-snapshot.json");
+    store.save_snapshot(Path::new(&path)).unwrap();
+
+    c.bench_function("store/load_snapshot_1000", |b| {
+        b.iter(|| {
+            let loaded = Store::load_snapshot(Path::new(&path)).unwrap();
+            std::hint::black_box(loaded.len());
+        });
+    });
+}
+
+criterion_group!(
+    benches,
+    bench_store_put,
+    bench_store_get,
+    bench_store_get_missing,
+    bench_entries_since,
+    bench_save_snapshot,
+    bench_load_snapshot,
+);
+criterion_main!(benches);

--- a/scripts/bench-multinode.sh
+++ b/scripts/bench-multinode.sh
@@ -1,0 +1,204 @@
+#!/usr/bin/env bash
+# bench-multinode.sh — Multi-node throughput and latency benchmark.
+#
+# Spins up a 3-node AsteroidDB cluster via docker compose, fires concurrent
+# writes, measures throughput (ops/sec) and latency percentiles (p50/p95/p99),
+# and outputs results as JSON.
+#
+# Usage:
+#   ./scripts/bench-multinode.sh [--ops N] [--concurrency C]
+#
+# Requirements: docker, docker compose, curl, jq, bc
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# Defaults.
+TOTAL_OPS=500
+CONCURRENCY=10
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --ops) TOTAL_OPS="$2"; shift 2 ;;
+        --concurrency) CONCURRENCY="$2"; shift 2 ;;
+        *) echo "Unknown flag: $1"; exit 1 ;;
+    esac
+done
+
+# Node endpoints (mapped ports from docker-compose.yml).
+NODES=("http://localhost:3001" "http://localhost:3002" "http://localhost:3003")
+
+# Generate a random internal token if not set.
+export ASTEROIDB_INTERNAL_TOKEN="${ASTEROIDB_INTERNAL_TOKEN:-bench-token-$(date +%s)}"
+
+cleanup() {
+    echo "Tearing down cluster..."
+    docker compose -f "$PROJECT_DIR/docker-compose.yml" down --remove-orphans 2>/dev/null || true
+}
+trap cleanup EXIT
+
+# ---------------------------------------------------------------
+# 1. Start cluster
+# ---------------------------------------------------------------
+echo "=== Multi-Node Benchmark ==="
+echo "Ops: $TOTAL_OPS  Concurrency: $CONCURRENCY"
+echo ""
+echo "Building and starting 3-node cluster..."
+docker compose -f "$PROJECT_DIR/docker-compose.yml" up -d --build --wait 2>&1 | tail -1
+
+# Wait for all nodes to be healthy.
+MAX_WAIT=60
+for node_url in "${NODES[@]}"; do
+    echo -n "Waiting for $node_url..."
+    waited=0
+    until curl -sf "$node_url/status" >/dev/null 2>&1; do
+        sleep 1
+        waited=$((waited + 1))
+        if [ $waited -ge $MAX_WAIT ]; then
+            echo " TIMEOUT"
+            echo "ERROR: Node $node_url did not become ready within ${MAX_WAIT}s"
+            exit 1
+        fi
+    done
+    echo " ready"
+done
+
+echo ""
+
+# ---------------------------------------------------------------
+# 2. Run concurrent writes and collect latencies
+# ---------------------------------------------------------------
+LATENCY_FILE=$(mktemp)
+
+run_writes() {
+    local worker_id=$1
+    local ops_per_worker=$2
+    local node_url=${NODES[$((worker_id % ${#NODES[@]}))]}
+
+    for i in $(seq 1 "$ops_per_worker"); do
+        local key="bench/worker-${worker_id}/key-${i}"
+        local start_ns
+        start_ns=$(date +%s%N)
+
+        local http_code
+        http_code=$(curl -sf -o /dev/null -w "%{http_code}" \
+            -X POST "$node_url/api/eventual/write" \
+            -H "Content-Type: application/json" \
+            -d "{\"key\": \"$key\", \"value\": {\"Counter\": {\"p\": {\"bench-node\": 1}, \"n\": {}}}}" \
+            2>/dev/null) || http_code="000"
+
+        local end_ns
+        end_ns=$(date +%s%N)
+        local latency_us=$(( (end_ns - start_ns) / 1000 ))
+
+        echo "$latency_us $http_code"
+    done
+}
+
+OPS_PER_WORKER=$((TOTAL_OPS / CONCURRENCY))
+echo "Launching $CONCURRENCY workers, $OPS_PER_WORKER ops each..."
+echo ""
+
+OVERALL_START=$(date +%s%N)
+
+pids=()
+for w in $(seq 0 $((CONCURRENCY - 1))); do
+    run_writes "$w" "$OPS_PER_WORKER" >> "$LATENCY_FILE" &
+    pids+=($!)
+done
+
+# Wait for all workers.
+for pid in "${pids[@]}"; do
+    wait "$pid" 2>/dev/null || true
+done
+
+OVERALL_END=$(date +%s%N)
+OVERALL_DURATION_MS=$(( (OVERALL_END - OVERALL_START) / 1000000 ))
+
+# ---------------------------------------------------------------
+# 3. Compute statistics
+# ---------------------------------------------------------------
+TOTAL_REQUESTS=$(wc -l < "$LATENCY_FILE")
+SUCCESS_COUNT=$(awk '$2 >= 200 && $2 < 300 {c++} END {print c+0}' "$LATENCY_FILE")
+ERROR_COUNT=$((TOTAL_REQUESTS - SUCCESS_COUNT))
+
+if [ "$OVERALL_DURATION_MS" -gt 0 ]; then
+    THROUGHPUT=$(echo "scale=2; $TOTAL_REQUESTS * 1000 / $OVERALL_DURATION_MS" | bc)
+else
+    THROUGHPUT="0"
+fi
+
+# Sort latencies (microseconds) for percentile calculation.
+SORTED_LATENCIES=$(awk '{print $1}' "$LATENCY_FILE" | sort -n)
+
+percentile() {
+    local pct=$1
+    local count
+    count=$(echo "$SORTED_LATENCIES" | wc -l)
+    if [ "$count" -eq 0 ]; then
+        echo "0"
+        return
+    fi
+    local idx
+    idx=$(echo "scale=0; ($count * $pct + 99) / 100" | bc)
+    if [ "$idx" -lt 1 ]; then idx=1; fi
+    echo "$SORTED_LATENCIES" | sed -n "${idx}p"
+}
+
+P50=$(percentile 50)
+P95=$(percentile 95)
+P99=$(percentile 99)
+
+# Convert microseconds to milliseconds for display.
+p50_ms=$(echo "scale=2; $P50 / 1000" | bc)
+p95_ms=$(echo "scale=2; $P95 / 1000" | bc)
+p99_ms=$(echo "scale=2; $P99 / 1000" | bc)
+
+# ---------------------------------------------------------------
+# 4. Output results
+# ---------------------------------------------------------------
+echo "=== Results ==="
+echo "  Total requests: $TOTAL_REQUESTS"
+echo "  Successful:     $SUCCESS_COUNT"
+echo "  Errors:         $ERROR_COUNT"
+echo "  Duration:       ${OVERALL_DURATION_MS}ms"
+echo "  Throughput:     ${THROUGHPUT} ops/sec"
+echo "  Latency p50:    ${p50_ms}ms"
+echo "  Latency p95:    ${p95_ms}ms"
+echo "  Latency p99:    ${p99_ms}ms"
+echo ""
+
+# JSON output.
+RESULTS_JSON=$(cat <<EOF
+{
+  "benchmark": "multinode-throughput",
+  "timestamp": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
+  "config": {
+    "total_ops": $TOTAL_OPS,
+    "concurrency": $CONCURRENCY,
+    "nodes": ${#NODES[@]}
+  },
+  "results": {
+    "total_requests": $TOTAL_REQUESTS,
+    "success_count": $SUCCESS_COUNT,
+    "error_count": $ERROR_COUNT,
+    "duration_ms": $OVERALL_DURATION_MS,
+    "throughput_ops_sec": $THROUGHPUT,
+    "latency_us": {
+      "p50": $P50,
+      "p95": $P95,
+      "p99": $P99
+    }
+  }
+}
+EOF
+)
+
+RESULTS_FILE="$PROJECT_DIR/target/bench-multinode-results.json"
+mkdir -p "$(dirname "$RESULTS_FILE")"
+echo "$RESULTS_JSON" > "$RESULTS_FILE"
+echo "JSON results written to: $RESULTS_FILE"
+
+rm -f "$LATENCY_FILE"


### PR DESCRIPTION
## Summary

- Add **criterion micro-benchmarks** for CRDT merge operations (PnCounter, OrSet, OrMap, LwwRegister), Store operations (put, get, entries_since, snapshot save/load), and the certified write path (certified_write, process_certifications, verify_proof)
- Add **`scripts/bench-multinode.sh`** — a Docker-based multi-node throughput/latency benchmark that spins up a 3-node cluster and outputs JSON results
- Wire up criterion in `Cargo.toml` with three `[[bench]]` targets: `crdt_bench`, `store_bench`, `certified_bench`

## Test plan

- [ ] `cargo bench` runs all three criterion benchmark suites successfully
- [ ] `scripts/bench-multinode.sh` starts a Docker cluster, runs the benchmark, and produces JSON output
- [ ] CI passes (`cargo fmt --check && cargo clippy -- -D warnings && cargo test`)

Closes #223

🤖 Generated with [Claude Code](https://claude.com/claude-code)