### PR TITLE
fix: address P1 robustness issues (BLS panic, HLC panic, PolicyVersion fallback)

### DIFF
--- a/src/api/certified.rs
+++ b/src/api/certified.rs
@@ -200,7 +200,12 @@ impl CertifiedApi {
         let policy_version = ns
             .get_placement_policy(&key_range.prefix)
             .map(|p| p.version)
-            .unwrap_or(PolicyVersion(1));
+            .ok_or_else(|| {
+                CrdtError::InvalidArgument(format!(
+                    "no placement policy for prefix: {}",
+                    key_range.prefix
+                ))
+            })?;
 
         Ok((key_range, policy_version, total))
     }
@@ -697,6 +702,11 @@ mod tests {
             authority_nodes: authorities.iter().map(|a| node(a)).collect(),
             auto_generated: false,
         });
+        ns.set_placement_policy(PlacementPolicy::new(
+            PolicyVersion(1),
+            kr(prefix),
+            authorities.len(),
+        ));
         wrap_ns(ns)
     }
 
@@ -1232,6 +1242,8 @@ mod tests {
             authority_nodes: vec![node("auth-o1"), node("auth-o2"), node("auth-o3")],
             auto_generated: false,
         });
+        ns.set_placement_policy(PlacementPolicy::new(PolicyVersion(1), kr("user/"), 3));
+        ns.set_placement_policy(PlacementPolicy::new(PolicyVersion(1), kr("order/"), 3));
 
         let mut api = CertifiedApi::new(node("node-1"), wrap_ns(ns));
 
@@ -1292,6 +1304,8 @@ mod tests {
             authority_nodes: vec![node("auth-o1"), node("auth-o2"), node("auth-o3")],
             auto_generated: false,
         });
+        ns.set_placement_policy(PlacementPolicy::new(PolicyVersion(1), kr("user/"), 3));
+        ns.set_placement_policy(PlacementPolicy::new(PolicyVersion(1), kr("order/"), 3));
 
         let mut api = CertifiedApi::new(node("node-1"), wrap_ns(ns));
 
@@ -1379,6 +1393,8 @@ mod tests {
             authority_nodes: vec![node("auth-v1"), node("auth-v2")],
             auto_generated: false,
         });
+        ns.set_placement_policy(PlacementPolicy::new(PolicyVersion(1), kr("user/"), 3));
+        ns.set_placement_policy(PlacementPolicy::new(PolicyVersion(1), kr("user/vip/"), 2));
 
         let mut api = CertifiedApi::new(node("node-1"), wrap_ns(ns));
 
@@ -1454,6 +1470,8 @@ mod tests {
             authority_nodes: vec![node("auth-s1"), node("auth-s2"), node("auth-s3")],
             auto_generated: false,
         });
+        ns.set_placement_policy(PlacementPolicy::new(PolicyVersion(1), kr("cert/"), 3));
+        ns.set_placement_policy(PlacementPolicy::new(PolicyVersion(1), kr("stale/"), 3));
 
         let policy = RetentionPolicy {
             max_age_ms: 5_000,
@@ -1680,6 +1698,7 @@ mod tests {
             authority_nodes: vec![node("auth-a"), node("auth-b"), node("auth-c")],
             auto_generated: false,
         });
+        ns.set_placement_policy(PlacementPolicy::new(PolicyVersion(1), kr("data/"), 3));
 
         let mut api = CertifiedApi::new(node("node-1"), wrap_ns(ns));
         api.certified_write("data/x".into(), counter_value(1), OnTimeout::Pending)

--- a/src/authority/bls.rs
+++ b/src/authority/bls.rs
@@ -6,6 +6,8 @@
 
 use serde::{Deserialize, Serialize};
 
+use crate::error::CrdtError;
+
 /// Domain separation tag for BLS signatures (required by blst).
 const DST: &[u8] = b"BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_NUL_";
 
@@ -136,16 +138,18 @@ pub fn verify_signature(
 
 /// Aggregate multiple BLS signatures into a single signature.
 ///
-/// # Panics
-///
-/// Panics if `signatures` is empty.
-pub fn aggregate_signatures(signatures: &[BlsSignature]) -> BlsSignature {
-    assert!(!signatures.is_empty(), "cannot aggregate zero signatures");
+/// Returns an error if `signatures` is empty.
+pub fn aggregate_signatures(signatures: &[BlsSignature]) -> Result<BlsSignature, CrdtError> {
+    if signatures.is_empty() {
+        return Err(CrdtError::InvalidArgument(
+            "cannot aggregate zero signatures".into(),
+        ));
+    }
 
     let refs: Vec<&blst::min_pk::Signature> = signatures.iter().map(|s| &s.0).collect();
     let agg = blst::min_pk::AggregateSignature::aggregate(&refs, true)
         .expect("signature aggregation should not fail for valid inputs");
-    BlsSignature(agg.to_signature())
+    Ok(BlsSignature(agg.to_signature()))
 }
 
 /// Verify an aggregated BLS signature against the corresponding set of
@@ -214,7 +218,7 @@ mod tests {
             .map(|kp| sign_message(kp.secret_key(), msg))
             .collect();
 
-        let agg = aggregate_signatures(&sigs);
+        let agg = aggregate_signatures(&sigs).unwrap();
 
         let pks: Vec<BlsPublicKey> = keypairs.iter().map(|kp| kp.public_key.clone()).collect();
         assert!(aggregate_verify(&pks, msg, &agg));
@@ -230,7 +234,7 @@ mod tests {
             .map(|kp| sign_message(kp.secret_key(), msg))
             .collect();
 
-        let agg = aggregate_signatures(&sigs);
+        let agg = aggregate_signatures(&sigs).unwrap();
         let pks: Vec<BlsPublicKey> = keypairs.iter().map(|kp| kp.public_key.clone()).collect();
 
         assert!(!aggregate_verify(&pks, b"tampered", &agg));
@@ -246,7 +250,7 @@ mod tests {
             .map(|kp| sign_message(kp.secret_key(), msg))
             .collect();
 
-        let agg = aggregate_signatures(&sigs);
+        let agg = aggregate_signatures(&sigs).unwrap();
 
         // Only use first 3 public keys (missing the 4th signer).
         let pks: Vec<BlsPublicKey> = keypairs[..3]
@@ -260,14 +264,20 @@ mod tests {
     fn aggregate_verify_empty_keys_returns_false() {
         let kp = make_keypair(40);
         let sig = sign_message(kp.secret_key(), b"x");
-        let agg = aggregate_signatures(&[sig]);
+        let agg = aggregate_signatures(&[sig]).unwrap();
         assert!(!aggregate_verify(&[], b"x", &agg));
     }
 
     #[test]
-    #[should_panic(expected = "cannot aggregate zero signatures")]
-    fn aggregate_empty_panics() {
-        aggregate_signatures(&[]);
+    fn aggregate_empty_returns_error() {
+        let result = aggregate_signatures(&[]);
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("cannot aggregate zero signatures")
+        );
     }
 
     #[test]
@@ -292,7 +302,7 @@ mod tests {
         let kp = make_keypair(60);
         let msg = b"single aggregate";
         let sig = sign_message(kp.secret_key(), msg);
-        let agg = aggregate_signatures(std::slice::from_ref(&sig));
+        let agg = aggregate_signatures(std::slice::from_ref(&sig)).unwrap();
 
         // Aggregating a single signature should produce a valid aggregate.
         assert!(aggregate_verify(&[kp.public_key], msg, &agg));

--- a/src/authority/certificate.rs
+++ b/src/authority/certificate.rs
@@ -1792,7 +1792,7 @@ mod tests {
             bls_sigs.push(sig);
         }
 
-        let agg = crate::authority::bls::aggregate_signatures(&bls_sigs);
+        let agg = crate::authority::bls::aggregate_signatures(&bls_sigs).unwrap();
         cert.set_bls_aggregate(signers, agg);
 
         assert_eq!(cert.signer_count(), 5);
@@ -1815,7 +1815,7 @@ mod tests {
         ikm[0] = 99;
         let kp = crate::authority::bls::BlsKeypair::generate(&ikm);
         let sig = crate::authority::bls::sign_message(kp.secret_key(), &message);
-        let agg = crate::authority::bls::aggregate_signatures(&[sig]);
+        let agg = crate::authority::bls::aggregate_signatures(&[sig]).unwrap();
         cert.set_bls_aggregate(vec![(NodeId("a".into()), kp.public_key.clone())], agg);
 
         let result = cert.verify(b"wrong message");
@@ -1887,7 +1887,7 @@ mod tests {
         ikm[0] = 77;
         let kp = crate::authority::bls::BlsKeypair::generate(&ikm);
         let sig = crate::authority::bls::sign_message(kp.secret_key(), &message);
-        let agg = crate::authority::bls::aggregate_signatures(&[sig]);
+        let agg = crate::authority::bls::aggregate_signatures(&[sig]).unwrap();
         cert.set_bls_aggregate(vec![(NodeId("b".into()), kp.public_key.clone())], agg);
 
         let json = serde_json::to_string(&cert).unwrap();
@@ -2064,7 +2064,7 @@ mod tests {
 
         let kp = make_bls_keypair(80);
         let sig = crate::authority::bls::sign_message(kp.secret_key(), &message);
-        let agg = crate::authority::bls::aggregate_signatures(&[sig]);
+        let agg = crate::authority::bls::aggregate_signatures(&[sig]).unwrap();
 
         // Set 1 signer ID but 0 public keys (mismatch).
         cert.bls_signer_ids = vec![NodeId("a".into())];
@@ -2097,7 +2097,7 @@ mod tests {
         let kp2 = make_bls_keypair(82);
         let sig1 = crate::authority::bls::sign_message(kp1.secret_key(), &message);
         let sig2 = crate::authority::bls::sign_message(kp2.secret_key(), &message);
-        let agg = crate::authority::bls::aggregate_signatures(&[sig1, sig2]);
+        let agg = crate::authority::bls::aggregate_signatures(&[sig1, sig2]).unwrap();
 
         // Same signer ID listed twice with different keys.
         cert.bls_signer_ids = vec![NodeId("dup".into()), NodeId("dup".into())];
@@ -2144,7 +2144,7 @@ mod tests {
         let kp_unknown = make_bls_keypair(84);
         let sig_known = crate::authority::bls::sign_message(kp_known.secret_key(), &message);
         let sig_unknown = crate::authority::bls::sign_message(kp_unknown.secret_key(), &message);
-        let agg = crate::authority::bls::aggregate_signatures(&[sig_known, sig_unknown]);
+        let agg = crate::authority::bls::aggregate_signatures(&[sig_known, sig_unknown]).unwrap();
 
         cert.set_bls_aggregate(
             vec![
@@ -2201,7 +2201,7 @@ mod tests {
         let mut cert = DualModeCertificate::new_bls(kr, hlc, pv, KeysetVersion(1));
         let sig_a = crate::authority::bls::sign_message(kp_a.secret_key(), &message);
         let sig_b = crate::authority::bls::sign_message(kp_b.secret_key(), &message);
-        let agg = crate::authority::bls::aggregate_signatures(&[sig_a, sig_b]);
+        let agg = crate::authority::bls::aggregate_signatures(&[sig_a, sig_b]).unwrap();
 
         cert.set_bls_aggregate(
             vec![

--- a/src/hlc.rs
+++ b/src/hlc.rs
@@ -101,7 +101,7 @@ impl Hlc {
 fn physical_ms() -> u64 {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
-        .expect("system clock before UNIX epoch")
+        .unwrap_or_default()
         .as_millis() as u64
 }
 

--- a/src/http/routes.rs
+++ b/src/http/routes.rs
@@ -99,7 +99,8 @@ mod tests {
         WriteResponse,
     };
     use crate::ops::metrics::RuntimeMetrics;
-    use crate::types::{CertificationStatus, KeyRange, NodeId};
+    use crate::placement::PlacementPolicy;
+    use crate::types::{CertificationStatus, KeyRange, NodeId, PolicyVersion};
     use axum::body::Body;
     use axum::http::{Request, StatusCode};
     use http_body_util::BodyExt;
@@ -126,6 +127,13 @@ mod tests {
             ],
             auto_generated: false,
         });
+        ns.set_placement_policy(PlacementPolicy::new(
+            PolicyVersion(1),
+            KeyRange {
+                prefix: String::new(),
+            },
+            3,
+        ));
 
         let namespace = Arc::new(RwLock::new(ns));
 
@@ -744,7 +752,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn control_plane_list_policies_empty() {
+    async fn control_plane_list_policies_has_default() {
         let state = test_state();
         let app = router(state);
 
@@ -758,7 +766,7 @@ mod tests {
 
         let body = body_string(resp.into_body()).await;
         let policies: Vec<PlacementPolicyResponse> = serde_json::from_str(&body).unwrap();
-        assert!(policies.is_empty());
+        assert_eq!(policies.len(), 1, "expected default placement policy");
     }
 
     #[tokio::test]
@@ -827,7 +835,7 @@ mod tests {
         let state = test_state();
         let app = router(state);
 
-        // Initial version history (namespace had 1 authority set -> version 2)
+        // Initial version history (namespace had 1 authority set + 1 placement policy -> version 3)
         let req = Request::builder()
             .uri("/api/control-plane/versions")
             .body(Body::empty())
@@ -838,8 +846,8 @@ mod tests {
 
         let body = body_string(resp.into_body()).await;
         let versions: VersionHistoryResponse = serde_json::from_str(&body).unwrap();
-        assert_eq!(versions.current_version, 2);
-        assert_eq!(versions.history, vec![1, 2]);
+        assert_eq!(versions.current_version, 3);
+        assert_eq!(versions.history, vec![1, 2, 3]);
 
         // Set a policy -> version should increment
         let req = Request::builder()
@@ -861,8 +869,8 @@ mod tests {
         let resp = app.oneshot(req).await.unwrap();
         let body = body_string(resp.into_body()).await;
         let versions: VersionHistoryResponse = serde_json::from_str(&body).unwrap();
-        assert_eq!(versions.current_version, 3);
-        assert_eq!(versions.history, vec![1, 2, 3]);
+        assert_eq!(versions.current_version, 4);
+        assert_eq!(versions.history, vec![1, 2, 3, 4]);
     }
 
     #[tokio::test]
@@ -892,9 +900,9 @@ mod tests {
         let resp = app.oneshot(req).await.unwrap();
         let body = body_string(resp.into_body()).await;
         let versions: VersionHistoryResponse = serde_json::from_str(&body).unwrap();
-        // initial(1) + auth_def(2) + policy_set(3) + policy_set(4)
-        assert_eq!(versions.current_version, 4);
-        assert_eq!(versions.history.len(), 4);
+        // initial(1) + auth_def(2) + default_policy(3) + policy_set(4) + policy_set(5)
+        assert_eq!(versions.current_version, 5);
+        assert_eq!(versions.history.len(), 5);
     }
 
     // ---------------------------------------------------------------

--- a/src/ops/diagnostics.rs
+++ b/src/ops/diagnostics.rs
@@ -211,6 +211,7 @@ mod tests {
     use crate::compaction::{CompactionEngine, RevalidationTrigger};
     use crate::control_plane::system_namespace::{AuthorityDefinition, SystemNamespace};
     use crate::crdt::pn_counter::PnCounter;
+    use crate::placement::PlacementPolicy;
     use crate::store::kv::CrdtValue;
     use crate::types::{KeyRange, NodeId, PolicyVersion};
 
@@ -261,6 +262,7 @@ mod tests {
             authority_nodes: vec![node("auth-1"), node("auth-2"), node("auth-3")],
             auto_generated: false,
         });
+        ns.set_placement_policy(PlacementPolicy::new(PolicyVersion(1), kr(""), 3));
         wrap_ns(ns)
     }
 

--- a/src/runtime/node_runner.rs
+++ b/src/runtime/node_runner.rs
@@ -1611,6 +1611,7 @@ mod tests {
             authority_nodes: vec![node_id("auth-1"), node_id("auth-2"), node_id("auth-3")],
             auto_generated: false,
         });
+        ns.set_placement_policy(PlacementPolicy::new(PolicyVersion(1), kr(""), 3));
         wrap_ns(ns)
     }
 
@@ -2080,6 +2081,7 @@ mod tests {
             authority_nodes: vec![node_id("auth-1")],
             auto_generated: false,
         });
+        ns.set_placement_policy(PlacementPolicy::new(PolicyVersion(1), kr(""), 1));
 
         let mut api = CertifiedApi::new(node_id("auth-1"), wrap_ns(ns));
         api.certified_write("key1".into(), counter_value(1), OnTimeout::Pending)

--- a/tests/bls_runtime_integration.rs
+++ b/tests/bls_runtime_integration.rs
@@ -21,6 +21,7 @@ use asteroidb_poc::control_plane::system_namespace::{AuthorityDefinition, System
 use asteroidb_poc::crdt::pn_counter::PnCounter;
 use asteroidb_poc::hlc::HlcTimestamp;
 use asteroidb_poc::ops::metrics::RuntimeMetrics;
+use asteroidb_poc::placement::PlacementPolicy;
 use asteroidb_poc::runtime::{BlsConfig, NodeRunner, NodeRunnerConfig};
 use asteroidb_poc::store::kv::CrdtValue;
 use asteroidb_poc::types::{CertificationStatus, KeyRange, NodeId, PolicyVersion};
@@ -71,6 +72,7 @@ fn three_authority_namespace() -> SystemNamespace {
         authority_nodes: vec![node_id("auth-1"), node_id("auth-2"), node_id("auth-3")],
         auto_generated: false,
     });
+    ns.set_placement_policy(PlacementPolicy::new(PolicyVersion(1), kr(""), 3));
     ns
 }
 
@@ -234,7 +236,7 @@ fn bls_certificate_mode_when_keys_registered() {
     let sig2 = asteroidb_poc::authority::bls::sign_message(kp2.secret_key(), msg);
     let sig3 = asteroidb_poc::authority::bls::sign_message(kp3.secret_key(), msg);
 
-    let agg = asteroidb_poc::authority::bls::aggregate_signatures(&[sig1, sig2, sig3]);
+    let agg = asteroidb_poc::authority::bls::aggregate_signatures(&[sig1, sig2, sig3]).unwrap();
 
     cert.set_bls_aggregate(
         vec![
@@ -304,7 +306,7 @@ fn bls_certificate_with_registry_verification() {
     let mut cert = DualModeCertificate::new_bls(kr.clone(), hlc.clone(), pv, version.clone());
     let sig1 = asteroidb_poc::authority::bls::sign_message(kp1.secret_key(), msg);
     let sig2 = asteroidb_poc::authority::bls::sign_message(kp2.secret_key(), msg);
-    let agg = asteroidb_poc::authority::bls::aggregate_signatures(&[sig1, sig2]);
+    let agg = asteroidb_poc::authority::bls::aggregate_signatures(&[sig1, sig2]).unwrap();
     cert.set_bls_aggregate(
         vec![
             (node_id("auth-1"), kp1.public_key.clone()),
@@ -574,7 +576,7 @@ fn bls_majority_threshold_with_5_authorities() {
         .iter()
         .map(|kp| asteroidb_poc::authority::bls::sign_message(kp.secret_key(), msg))
         .collect();
-    let agg = asteroidb_poc::authority::bls::aggregate_signatures(&sigs);
+    let agg = asteroidb_poc::authority::bls::aggregate_signatures(&sigs).unwrap();
 
     let mut cert = DualModeCertificate::new_bls(kr, hlc, pv, KeysetVersion(1));
     let signers: Vec<_> = (0..3)

--- a/tests/certification_worker.rs
+++ b/tests/certification_worker.rs
@@ -24,6 +24,7 @@ use asteroidb_poc::control_plane::system_namespace::{AuthorityDefinition, System
 use asteroidb_poc::crdt::pn_counter::PnCounter;
 use asteroidb_poc::hlc::HlcTimestamp;
 use asteroidb_poc::ops::metrics::RuntimeMetrics;
+use asteroidb_poc::placement::PlacementPolicy;
 use asteroidb_poc::runtime::{NodeRunner, NodeRunnerConfig};
 use asteroidb_poc::store::kv::CrdtValue;
 use asteroidb_poc::types::{CertificationStatus, KeyRange, NodeId, PolicyVersion};
@@ -75,6 +76,7 @@ fn three_authority_namespace() -> SystemNamespace {
         authority_nodes: vec![node_id("auth-1"), node_id("auth-2"), node_id("auth-3")],
         auto_generated: false,
     });
+    ns.set_placement_policy(PlacementPolicy::new(PolicyVersion(1), kr(""), 3));
     ns
 }
 
@@ -232,6 +234,7 @@ async fn single_authority_self_certification() {
         authority_nodes: vec![node_id("auth-1")],
         auto_generated: false,
     });
+    ns.set_placement_policy(PlacementPolicy::new(PolicyVersion(1), kr(""), 1));
 
     let mut api = CertifiedApi::new(node_id("auth-1"), wrap_ns(ns));
     api.certified_write("key1".into(), counter_value(10), OnTimeout::Pending)
@@ -548,6 +551,9 @@ async fn mixed_outcomes_all_observable() {
         authority_nodes: vec![node_id("auth-r1"), node_id("auth-r2"), node_id("auth-r3")],
         auto_generated: false,
     });
+    ns.set_placement_policy(PlacementPolicy::new(PolicyVersion(1), kr("cert/"), 3));
+    ns.set_placement_policy(PlacementPolicy::new(PolicyVersion(1), kr("stale/"), 3));
+    ns.set_placement_policy(PlacementPolicy::new(PolicyVersion(1), kr("rej/"), 3));
 
     let retention = RetentionPolicy {
         max_age_ms: 5_000,
@@ -611,6 +617,8 @@ async fn cleanup_after_auto_certification() {
         authority_nodes: vec![node_id("auth-b1"), node_id("auth-b2"), node_id("auth-b3")],
         auto_generated: false,
     });
+    ns.set_placement_policy(PlacementPolicy::new(PolicyVersion(1), kr("a/"), 3));
+    ns.set_placement_policy(PlacementPolicy::new(PolicyVersion(1), kr("b/"), 3));
 
     let mut api = CertifiedApi::new(node_id("node-1"), wrap_ns(ns));
 

--- a/tests/e2e_multiprocess.rs
+++ b/tests/e2e_multiprocess.rs
@@ -22,6 +22,7 @@ use asteroidb_poc::hlc::HlcTimestamp;
 use asteroidb_poc::http::handlers::AppState;
 use asteroidb_poc::http::routes::router;
 use asteroidb_poc::ops::metrics::RuntimeMetrics;
+use asteroidb_poc::placement::PlacementPolicy;
 use asteroidb_poc::store::kv::CrdtValue;
 use asteroidb_poc::types::{KeyRange, NodeId, PolicyVersion};
 
@@ -45,6 +46,13 @@ fn default_namespace() -> SystemNamespace {
         authority_nodes: vec![node_id("auth-1"), node_id("auth-2"), node_id("auth-3")],
         auto_generated: false,
     });
+    ns.set_placement_policy(PlacementPolicy::new(
+        PolicyVersion(1),
+        KeyRange {
+            prefix: String::new(),
+        },
+        3,
+    ));
     ns
 }
 

--- a/tests/http_server.rs
+++ b/tests/http_server.rs
@@ -11,7 +11,8 @@ use asteroidb_poc::http::handlers::AppState;
 use asteroidb_poc::http::routes::router;
 use asteroidb_poc::ops::metrics::RuntimeMetrics;
 use asteroidb_poc::ops::slo::{SLO_CERTIFIED_READ_P99, SLO_EVENTUAL_READ_P99, SloTracker};
-use asteroidb_poc::types::{KeyRange, NodeId};
+use asteroidb_poc::placement::PlacementPolicy;
+use asteroidb_poc::types::{KeyRange, NodeId, PolicyVersion};
 use tokio::sync::Mutex;
 
 fn test_state() -> Arc<AppState> {
@@ -29,6 +30,13 @@ fn test_state() -> Arc<AppState> {
         ],
         auto_generated: false,
     });
+    ns.set_placement_policy(PlacementPolicy::new(
+        PolicyVersion(1),
+        KeyRange {
+            prefix: String::new(),
+        },
+        3,
+    ));
 
     let namespace = Arc::new(RwLock::new(ns));
 
@@ -286,6 +294,13 @@ fn test_state_with_slo() -> (Arc<AppState>, Arc<SloTracker>) {
         ],
         auto_generated: false,
     });
+    ns.set_placement_policy(PlacementPolicy::new(
+        PolicyVersion(1),
+        KeyRange {
+            prefix: String::new(),
+        },
+        3,
+    ));
 
     let namespace = Arc::new(RwLock::new(ns));
 

--- a/tests/integration/authority_certified_flow.rs
+++ b/tests/integration/authority_certified_flow.rs
@@ -96,6 +96,11 @@ fn make_namespace(prefix: &str, authorities: &[&str]) -> Arc<RwLock<SystemNamesp
         authority_nodes: authorities.iter().map(|a| node(a)).collect(),
         auto_generated: false,
     });
+    ns.set_placement_policy(PlacementPolicy::new(
+        PolicyVersion(1),
+        key_range(prefix),
+        authorities.len(),
+    ));
     wrap_ns(ns)
 }
 
@@ -903,6 +908,16 @@ fn cross_range_certification_contamination_prevented() {
         authority_nodes: vec![node("auth-o1"), node("auth-o2"), node("auth-o3")],
         auto_generated: false,
     });
+    ns.set_placement_policy(PlacementPolicy::new(
+        PolicyVersion(1),
+        key_range("user/"),
+        3,
+    ));
+    ns.set_placement_policy(PlacementPolicy::new(
+        PolicyVersion(1),
+        key_range("order/"),
+        3,
+    ));
 
     let mut api = CertifiedApi::new(node("node-1"), wrap_ns(ns));
 
@@ -1024,6 +1039,16 @@ fn longest_prefix_authority_resolution_in_integration() {
         authority_nodes: vec![node("auth-v1"), node("auth-v2")],
         auto_generated: false,
     });
+    ns.set_placement_policy(PlacementPolicy::new(
+        PolicyVersion(1),
+        key_range("user/"),
+        3,
+    ));
+    ns.set_placement_policy(PlacementPolicy::new(
+        PolicyVersion(1),
+        key_range("user/vip/"),
+        2,
+    ));
 
     let mut api = CertifiedApi::new(node("node-1"), wrap_ns(ns));
 

--- a/tests/integration/quorum_safety_regression.rs
+++ b/tests/integration/quorum_safety_regression.rs
@@ -101,6 +101,7 @@ fn default_namespace() -> Arc<RwLock<SystemNamespace>> {
         authority_nodes: vec![node("auth-1"), node("auth-2"), node("auth-3")],
         auto_generated: false,
     });
+    ns.set_placement_policy(PlacementPolicy::new(PolicyVersion(1), key_range(""), 3));
     wrap_ns(ns)
 }
 

--- a/tests/partition_tolerance.rs
+++ b/tests/partition_tolerance.rs
@@ -18,6 +18,7 @@ use asteroidb_poc::control_plane::system_namespace::{AuthorityDefinition, System
 use asteroidb_poc::crdt::pn_counter::PnCounter;
 use asteroidb_poc::error::CrdtError;
 use asteroidb_poc::hlc::HlcTimestamp;
+use asteroidb_poc::placement::PlacementPolicy;
 use asteroidb_poc::store::kv::CrdtValue;
 use asteroidb_poc::types::{CertificationStatus, KeyRange, NodeId, PolicyVersion};
 
@@ -65,6 +66,11 @@ fn default_namespace() -> Arc<RwLock<SystemNamespace>> {
         authority_nodes: vec![node("auth-1"), node("auth-2"), node("auth-3")],
         auto_generated: false,
     });
+    ns.set_placement_policy(PlacementPolicy::new(
+        PolicyVersion(1),
+        KeyRange { prefix: "".into() },
+        3,
+    ));
     wrap_ns(ns)
 }
 


### PR DESCRIPTION
## Summary
- Change BLS aggregate_signatures to return Result instead of panicking on empty input
- Replace HLC physical_ms expect() with unwrap_or_default() for clock resilience
- Remove silent PolicyVersion(1) fallback in resolve_scope, require explicit placement policy
- Update 13 test fixtures to register PlacementPolicy alongside authority definitions

## Test plan
- [x] cargo fmt --check
- [x] cargo clippy -- -D warnings
- [x] cargo test (836 tests pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)