### PR TITLE
fix: address P1 performance issues (version_history cap, SLO VecDeque)

### DIFF
--- a/src/control_plane/system_namespace.rs
+++ b/src/control_plane/system_namespace.rs
@@ -227,9 +227,16 @@ impl SystemNamespace {
         Ok(Some(ns))
     }
 
+    /// Maximum number of version history entries to retain.
+    const MAX_VERSION_HISTORY: usize = 1000;
+
     fn bump_version(&mut self) {
         self.version = PolicyVersion(self.version.0 + 1);
         self.version_history.push(self.version);
+        if self.version_history.len() > Self::MAX_VERSION_HISTORY {
+            self.version_history
+                .drain(..self.version_history.len() - Self::MAX_VERSION_HISTORY);
+        }
     }
 }
 

--- a/src/ops/slo.rs
+++ b/src/ops/slo.rs
@@ -4,7 +4,7 @@
 //! for dashboards and alerting integration.
 
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 use std::sync::Mutex;
 use std::time::{Duration, Instant};
 
@@ -114,7 +114,7 @@ struct Observation {
 struct SloState {
     target: SloTarget,
     window: Duration,
-    observations: Vec<Observation>,
+    observations: VecDeque<Observation>,
 }
 
 impl SloState {
@@ -123,14 +123,14 @@ impl SloState {
         Self {
             target,
             window,
-            observations: Vec::new(),
+            observations: VecDeque::new(),
         }
     }
 
     /// Record an observation, evicting expired entries.
     fn record(&mut self, value: f64, now: Instant) {
         self.evict_expired(now);
-        self.observations.push(Observation {
+        self.observations.push_back(Observation {
             timestamp: now,
             value,
         });
@@ -139,7 +139,13 @@ impl SloState {
     /// Remove observations outside the evaluation window.
     fn evict_expired(&mut self, now: Instant) {
         let cutoff = now.checked_sub(self.window).unwrap_or(now);
-        self.observations.retain(|o| o.timestamp >= cutoff);
+        while let Some(front) = self.observations.front() {
+            if front.timestamp < cutoff {
+                self.observations.pop_front();
+            } else {
+                break;
+            }
+        }
     }
 
     /// Compute the budget snapshot.


### PR DESCRIPTION
## Summary
- Cap version_history to 1000 entries to prevent unbounded memory growth
- Replace SLO observations Vec with VecDeque for O(1) eviction instead of O(n) retain

## Test plan
- [x] cargo fmt --check
- [x] cargo clippy -- -D warnings
- [x] cargo test (all tests pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)