### PR TITLE
fix: address P2 config issues (hex seed validation, configurable authority nodes)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -82,6 +82,7 @@ dependencies = [
  "clap",
  "criterion",
  "ed25519-dalek",
+ "hex",
  "http-body-util",
  "proptest",
  "rand 0.8.5",
@@ -764,6 +765,12 @@ name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "http"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ reqwest = { version = "0.12", features = ["json", "blocking"] }
 clap = { version = "4", features = ["derive", "env"] }
 tracing = "0.1"
 subtle = "2"
+hex = "0.4"
 
 [dev-dependencies]
 tempfile = "3"

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,6 +16,22 @@ use asteroidb_poc::ops::metrics::RuntimeMetrics;
 use asteroidb_poc::runtime::{BlsConfig, NodeRunner, NodeRunnerConfig};
 use asteroidb_poc::types::{KeyRange, NodeId};
 
+/// Parse authority node IDs from `ASTEROIDB_AUTHORITY_NODES` env var (comma-separated),
+/// falling back to the default `["auth-1", "auth-2", "auth-3"]`.
+fn authority_nodes() -> Vec<NodeId> {
+    match std::env::var("ASTEROIDB_AUTHORITY_NODES") {
+        Ok(val) if !val.trim().is_empty() => val
+            .split(',')
+            .map(|s| NodeId(s.trim().to_string()))
+            .collect(),
+        _ => vec![
+            NodeId("auth-1".into()),
+            NodeId("auth-2".into()),
+            NodeId("auth-3".into()),
+        ],
+    }
+}
+
 #[tokio::main]
 async fn main() {
     // Load configuration: either from a config file or from individual env vars.
@@ -53,16 +69,14 @@ async fn main() {
 
     println!("AsteroidDB starting... (node_id={})", node_id.0);
 
+    let auth_nodes = authority_nodes();
+
     let mut ns = SystemNamespace::new();
     ns.set_authority_definition(AuthorityDefinition {
         key_range: KeyRange {
             prefix: String::new(),
         },
-        authority_nodes: vec![
-            NodeId("auth-1".into()),
-            NodeId("auth-2".into()),
-            NodeId("auth-3".into()),
-        ],
+        authority_nodes: auth_nodes.clone(),
         auto_generated: false,
     });
 
@@ -132,11 +146,7 @@ async fn main() {
     };
 
     // Build control-plane consensus with the same authority nodes (FR-009).
-    let consensus = Arc::new(Mutex::new(ControlPlaneConsensus::new(vec![
-        NodeId("auth-1".into()),
-        NodeId("auth-2".into()),
-        NodeId("auth-3".into()),
-    ])));
+    let consensus = Arc::new(Mutex::new(ControlPlaneConsensus::new(auth_nodes)));
 
     // Optional shared token for authenticating internal API requests.
     let internal_token = std::env::var("ASTEROIDB_INTERNAL_TOKEN").ok();
@@ -184,10 +194,10 @@ async fn main() {
     // Parse optional BLS key seed from environment variable.
     // When set, the node generates a BLS keypair and enables BLS certificate mode.
     let bls_config = std::env::var("ASTEROIDB_BLS_SEED").ok().map(|hex_seed| {
-        let bytes: Vec<u8> = (0..hex_seed.len())
-            .step_by(2)
-            .filter_map(|i| u8::from_str_radix(hex_seed.get(i..i + 2).unwrap_or(""), 16).ok())
-            .collect();
+        let bytes = hex::decode(&hex_seed).unwrap_or_else(|e| {
+            eprintln!("error: ASTEROIDB_BLS_SEED contains invalid hex: {e}");
+            std::process::exit(1);
+        });
         let mut seed = [0u8; 32];
         let len = bytes.len().min(32);
         seed[..len].copy_from_slice(&bytes[..len]);


### PR DESCRIPTION
## Summary
- Replace silent filter_map hex parsing with hex::decode() that fails loudly on invalid BLS seed
- Make authority node IDs configurable via ASTEROIDB_AUTHORITY_NODES env var (comma-separated)

## Test plan
- [x] cargo fmt --check
- [x] cargo clippy -- -D warnings
- [x] cargo test (all tests pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)