### PR TITLE
fix: certified cache eviction, OR-Set tombstone compaction, merge timestamp guard

### DIFF
--- a/src/api/certified.rs
+++ b/src/api/certified.rs
@@ -123,6 +123,9 @@ pub struct CertifiedCacheEntry {
     pub write_timestamp: HlcTimestamp,
 }
 
+/// Maximum number of entries in the certified proof cache before eviction.
+const MAX_CERTIFIED_CACHE: usize = 10_000;
+
 /// Certified consistency API (FR-002, FR-004).
 ///
 /// Provides `get_certified` and `certified_write` operations that integrate
@@ -241,6 +244,20 @@ impl CertifiedApi {
                 write_timestamp: pw.timestamp.clone(),
             },
         );
+
+        // Evict oldest entries when the cache exceeds the size limit.
+        if self.certified_cache.len() > MAX_CERTIFIED_CACHE {
+            let evict_count = self.certified_cache.len() - MAX_CERTIFIED_CACHE;
+            let mut entries: Vec<(String, HlcTimestamp)> = self
+                .certified_cache
+                .iter()
+                .map(|(k, v)| (k.clone(), v.write_timestamp.clone()))
+                .collect();
+            entries.sort_by(|a, b| a.1.cmp(&b.1));
+            for (key, _) in entries.into_iter().take(evict_count) {
+                self.certified_cache.remove(&key);
+            }
+        }
     }
 
     /// Read a key with certification status (FR-002).

--- a/src/api/eventual.rs
+++ b/src/api/eventual.rs
@@ -251,6 +251,9 @@ impl EventualApi {
     /// Merge a CRDT value received from a remote node with a pre-assigned HLC.
     ///
     /// Used by delta sync to preserve the original modification timestamp.
+    /// Only updates the change timestamp if the incoming HLC is newer than
+    /// the existing one for that key, preventing an older remote timestamp
+    /// from overwriting a newer local one.
     pub fn merge_remote_with_hlc(
         &mut self,
         key: String,
@@ -259,7 +262,13 @@ impl EventualApi {
     ) -> Result<(), CrdtError> {
         self.clock.update(&hlc);
         self.store.merge_value(key.clone(), remote_value)?;
-        self.store.record_change(&key, hlc);
+        let should_record = match self.store.timestamp_for(&key) {
+            Some(existing) => hlc > *existing,
+            None => true,
+        };
+        if should_record {
+            self.store.record_change(&key, hlc);
+        }
         Ok(())
     }
 

--- a/src/crdt/or_map.rs
+++ b/src/crdt/or_map.rs
@@ -187,6 +187,37 @@ where
         self.deferred.extend(other.deferred.iter().cloned());
     }
 
+    /// Remove tombstone dots from `deferred` that are already absent from
+    /// all entry dot sets AND whose counter is dominated by the known
+    /// counter for that node.
+    ///
+    /// Call this periodically (e.g., after a full sync round completes) to
+    /// bound the growth of the deferred set. A dot `(node_id, counter)` is
+    /// safe to remove when no entry references it AND `counter` is below
+    /// the maximum counter we track for that node — meaning any future dot
+    /// for that node will have a strictly higher counter and cannot collide.
+    ///
+    /// **Do not** call this in the middle of a partial sync round; wait
+    /// until all replicas have exchanged state to avoid prematurely
+    /// discarding tombstones that a not-yet-merged replica still needs.
+    pub fn compact_deferred(&mut self) {
+        let live_dots: HashSet<&Dot> = self
+            .entries
+            .values()
+            .flat_map(|(dots, _)| dots.iter())
+            .collect();
+        self.deferred.retain(|d| {
+            if live_dots.contains(d) {
+                return true;
+            }
+            // Only remove if counter is dominated by the known max for this node.
+            match self.counters.get(&d.node_id) {
+                Some(&max_counter) => d.counter >= max_counter,
+                None => true, // unknown node — keep to be safe
+            }
+        });
+    }
+
     /// Return the number of present keys.
     pub fn len(&self) -> usize {
         self.entries

--- a/src/crdt/or_set.rs
+++ b/src/crdt/or_set.rs
@@ -157,6 +157,37 @@ where
         // Merge deferred (tombstone) sets.
         self.deferred.extend(other.deferred.iter().cloned());
     }
+
+    /// Remove tombstone dots from `deferred` that are already absent from
+    /// all element dot sets AND whose counter is dominated by the known
+    /// counter for that node.
+    ///
+    /// Call this periodically (e.g., after a full sync round completes) to
+    /// bound the growth of the deferred set. A dot `(node_id, counter)` is
+    /// safe to remove when no element references it AND `counter` is below
+    /// the maximum counter we track for that node — meaning any future dot
+    /// for that node will have a strictly higher counter and cannot collide.
+    ///
+    /// **Do not** call this in the middle of a partial sync round; wait
+    /// until all replicas have exchanged state to avoid prematurely
+    /// discarding tombstones that a not-yet-merged replica still needs.
+    pub fn compact_deferred(&mut self) {
+        let live_dots: HashSet<&Dot> = self
+            .elements
+            .values()
+            .flat_map(|dots| dots.iter())
+            .collect();
+        self.deferred.retain(|d| {
+            if live_dots.contains(d) {
+                return true;
+            }
+            // Only remove if counter is dominated by the known max for this node.
+            match self.counters.get(&d.node_id) {
+                Some(&max_counter) => d.counter >= max_counter,
+                None => true, // unknown node — keep to be safe
+            }
+        });
+    }
 }
 
 impl<T: Eq + Hash + Clone + Serialize + DeserializeOwned> Default for OrSet<T> {


### PR DESCRIPTION
## Summary
- Add MAX_CERTIFIED_CACHE (10k) with oldest-entry eviction to prevent unbounded memory growth
- Add compact_deferred() to OrSet/OrMap for periodic tombstone cleanup
- Guard merge_remote_with_hlc to only update change timestamp if incoming HLC is newer

## Test plan
- [x] cargo fmt --check
- [x] cargo clippy -- -D warnings
- [x] cargo test (836 tests pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)