### PR TITLE
fix: atomic persistence for CertificationTracker/AckFrontierSet, TOCTOU-safe consensus

### DIFF
--- a/src/api/status.rs
+++ b/src/api/status.rs
@@ -1,5 +1,6 @@
 use std::collections::{HashMap, HashSet};
-use std::io;
+use std::fs::File;
+use std::io::{self, Write};
 use std::path::Path;
 
 use serde::{Deserialize, Serialize};
@@ -246,9 +247,34 @@ impl CertificationTracker {
     }
 
     /// Save the tracker to a file as JSON.
+    ///
+    /// Uses atomic write (temp file + fsync + rename + dir fsync) to ensure
+    /// crash safety. Matches the pattern in `SystemNamespace::save`.
     pub fn save(&self, path: &Path) -> Result<(), io::Error> {
+        let parent = path.parent();
+        if let Some(p) = parent {
+            std::fs::create_dir_all(p)?;
+        }
+
+        let tmp = path.with_file_name(format!(
+            "{}.tmp.{}",
+            path.file_name().unwrap_or_default().to_string_lossy(),
+            std::process::id(),
+        ));
         let json = self.to_json()?;
-        std::fs::write(path, json)
+
+        let mut file = File::create(&tmp)?;
+        file.write_all(json.as_bytes())?;
+        file.sync_all()?;
+        drop(file);
+        std::fs::rename(&tmp, path)?;
+
+        if let Some(p) = parent
+            && let Ok(dir) = File::open(p)
+        {
+            let _ = dir.sync_all();
+        }
+        Ok(())
     }
 
     /// Load a tracker from a JSON file.

--- a/src/authority/ack_frontier.rs
+++ b/src/authority/ack_frontier.rs
@@ -1,5 +1,6 @@
 use std::collections::{HashMap, HashSet};
-use std::io;
+use std::fs::File;
+use std::io::{self, Write};
 use std::path::Path;
 
 use serde::{Deserialize, Serialize};
@@ -330,9 +331,34 @@ impl AckFrontierSet {
     }
 
     /// Save the frontier set to a file as JSON.
+    ///
+    /// Uses atomic write (temp file + fsync + rename + dir fsync) to ensure
+    /// crash safety. Matches the pattern in `SystemNamespace::save`.
     pub fn save(&self, path: &Path) -> Result<(), io::Error> {
+        let parent = path.parent();
+        if let Some(p) = parent {
+            std::fs::create_dir_all(p)?;
+        }
+
+        let tmp = path.with_file_name(format!(
+            "{}.tmp.{}",
+            path.file_name().unwrap_or_default().to_string_lossy(),
+            std::process::id(),
+        ));
         let json = self.to_json()?;
-        std::fs::write(path, json)
+
+        let mut file = File::create(&tmp)?;
+        file.write_all(json.as_bytes())?;
+        file.sync_all()?;
+        drop(file);
+        std::fs::rename(&tmp, path)?;
+
+        if let Some(p) = parent
+            && let Ok(dir) = File::open(p)
+        {
+            let _ = dir.sync_all();
+        }
+        Ok(())
     }
 
     /// Load a frontier set from a JSON file.

--- a/src/http/handlers.rs
+++ b/src/http/handlers.rs
@@ -358,14 +358,12 @@ pub async fn set_authority_definition(
     };
     let approvals: Vec<NodeId> = req.approvals.iter().map(|a| NodeId(a.clone())).collect();
 
-    // Validate majority consensus (FR-009).
+    // Hold consensus lock across both validation and mutation to prevent
+    // TOCTOU races where a concurrent request could invalidate the approval
+    // between the check and the namespace write.
     {
         let consensus = state.consensus.lock().await;
         consensus.propose_authority_update(def.clone(), &approvals)?;
-    }
-
-    // Apply to shared namespace for read handlers and CertifiedApi.
-    {
         let mut ns = state.namespace.write().unwrap();
         ns.set_authority_definition(def);
     }
@@ -473,18 +471,16 @@ pub async fn set_placement_policy(
         policy
     };
 
-    // Validate majority consensus (FR-009) with a provisional version.
-    // The consensus check only validates authority approval, not the version
-    // number, so using a placeholder is safe here.
-    {
+    // Hold consensus lock across both validation and mutation to prevent
+    // TOCTOU races where a concurrent request could invalidate the approval
+    // between the check and the namespace write.
+    let policy = {
         let provisional = build_policy(PolicyVersion(0));
         let consensus = state.consensus.lock().await;
         consensus.propose_policy_update(provisional, &approvals)?;
-    }
 
-    // Atomically read the current version, create the policy, and apply it
-    // inside a single write-lock scope to prevent version collisions.
-    let policy = {
+        // Atomically read the current version, create the policy, and apply it
+        // inside a single write-lock scope to prevent version collisions.
         let mut ns = state.namespace.write().unwrap();
         let current_version = ns.version().0;
         let policy = build_policy(PolicyVersion(current_version + 1));
@@ -516,14 +512,12 @@ pub async fn remove_policy(
 ) -> Result<Json<PlacementPolicyResponse>, ApiError> {
     let approvals: Vec<NodeId> = req.approvals.iter().map(|a| NodeId(a.clone())).collect();
 
-    // Validate majority consensus (FR-009).
-    {
+    // Hold consensus lock across both validation and mutation to prevent
+    // TOCTOU races where a concurrent request could invalidate the approval
+    // between the check and the namespace write.
+    let removed = {
         let consensus = state.consensus.lock().await;
         consensus.propose_policy_removal(&prefix, &approvals)?;
-    }
-
-    // Apply to shared namespace for read handlers and CertifiedApi.
-    let removed = {
         let mut ns = state.namespace.write().unwrap();
         ns.remove_placement_policy(&prefix)
     };


### PR DESCRIPTION
## Summary
- CertificationTracker::save and AckFrontierSet::save now use atomic write (tmp+fsync+rename)
- Consensus handlers hold lock across validation and namespace mutation to close TOCTOU gap

🤖 Generated with [Claude Code](https://claude.com/claude-code)