### PR TITLE
fix: scoped frontier get, WriteRateBucket min span, majority_frontier safety, empty guard

### DIFF
--- a/src/authority/ack_frontier.rs
+++ b/src/authority/ack_frontier.rs
@@ -1,5 +1,6 @@
 use std::collections::{HashMap, HashSet};
-use std::io;
+use std::fs::File;
+use std::io::{self, Write};
 use std::path::Path;
 
 use serde::{Deserialize, Serialize};
@@ -181,12 +182,42 @@ impl AckFrontierSet {
 
     /// Get the frontier for a specific authority by `NodeId`.
     ///
-    /// Searches all scopes and returns the first match. Suitable for
-    /// single-scope sets or when the authority appears in only one scope.
+    /// Searches all scopes and returns the first match. **Only correct when
+    /// the authority appears in at most one scope.** In multi-scope sets the
+    /// result is non-deterministic because `HashMap::values()` iteration
+    /// order is arbitrary. Prefer [`get_for_scope`] when the scope is known,
+    /// or [`get_scoped`] for a fully-qualified lookup.
+    ///
+    /// A `debug_assert` fires when more than one scope matches in debug
+    /// builds so that callers notice the ambiguity during development.
     pub fn get(&self, authority_id: &NodeId) -> Option<&AckFrontier> {
-        self.frontiers
+        let matches: Vec<&AckFrontier> = self
+            .frontiers
             .values()
-            .find(|f| &f.authority_id == authority_id)
+            .filter(|f| &f.authority_id == authority_id)
+            .collect();
+        debug_assert!(
+            matches.len() <= 1,
+            "get() is ambiguous: authority {:?} appears in {} scopes — use get_for_scope() instead",
+            authority_id,
+            matches.len(),
+        );
+        matches.into_iter().next()
+    }
+
+    /// Get the frontier for an authority within a specific scope defined by
+    /// `key_range` and `policy_version`.
+    ///
+    /// This is the recommended accessor when the set may contain entries for
+    /// multiple scopes.
+    pub fn get_for_scope(
+        &self,
+        key_range: &KeyRange,
+        policy_version: &PolicyVersion,
+        authority_id: &NodeId,
+    ) -> Option<&AckFrontier> {
+        let scope = FrontierScope::new(key_range.clone(), *policy_version, authority_id.clone());
+        self.frontiers.get(&scope)
     }
 
     /// Get the frontier for a fully-scoped key.
@@ -235,7 +266,26 @@ impl AckFrontierSet {
     /// authorities have a frontier `>= t`.
     ///
     /// Returns `None` if fewer than a majority of authorities have reported.
+    ///
+    /// **Warning:** When entries span multiple scopes (key ranges / policy
+    /// versions) the result mixes authority sets and may not be meaningful.
+    /// A `debug_assert` fires in debug builds when more than one distinct
+    /// scope is present. Prefer [`majority_frontier_for_scope`] in
+    /// multi-scope scenarios.
     pub fn majority_frontier(&self, total_authorities: usize) -> Option<&HlcTimestamp> {
+        // Guard: mixing scopes silently produces incorrect majorities.
+        let distinct_scopes: HashSet<(&KeyRange, &PolicyVersion)> = self
+            .frontiers
+            .keys()
+            .map(|s| (&s.key_range, &s.policy_version))
+            .collect();
+        debug_assert!(
+            distinct_scopes.len() <= 1,
+            "majority_frontier() called on multi-scope set ({} scopes) — \
+             use majority_frontier_for_scope() instead",
+            distinct_scopes.len(),
+        );
+
         let majority = total_authorities / 2 + 1;
         if self.frontiers.len() < majority {
             return None;
@@ -330,9 +380,34 @@ impl AckFrontierSet {
     }
 
     /// Save the frontier set to a file as JSON.
+    ///
+    /// Uses atomic write (temp file + fsync + rename + dir fsync) to ensure
+    /// crash safety. Matches the pattern in `SystemNamespace::save`.
     pub fn save(&self, path: &Path) -> Result<(), io::Error> {
+        let parent = path.parent();
+        if let Some(p) = parent {
+            std::fs::create_dir_all(p)?;
+        }
+
+        let tmp = path.with_file_name(format!(
+            "{}.tmp.{}",
+            path.file_name().unwrap_or_default().to_string_lossy(),
+            std::process::id(),
+        ));
         let json = self.to_json()?;
-        std::fs::write(path, json)
+
+        let mut file = File::create(&tmp)?;
+        file.write_all(json.as_bytes())?;
+        file.sync_all()?;
+        drop(file);
+        std::fs::rename(&tmp, path)?;
+
+        if let Some(p) = parent
+            && let Ok(dir) = File::open(p)
+        {
+            let _ = dir.sync_all();
+        }
+        Ok(())
     }
 
     /// Load a frontier set from a JSON file.
@@ -834,30 +909,49 @@ mod tests {
     }
 
     #[test]
-    fn get_by_authority_returns_first_match_across_scopes() {
+    fn get_for_scope_returns_correct_entry() {
         let mut set = AckFrontierSet::new();
 
         set.update(make_frontier("auth-1", 100, 0, "user/"));
         set.update(make_frontier("auth-1", 500, 0, "order/"));
 
-        // get() returns some entry for auth-1 (implementation-defined which one)
-        let got = set.get(&NodeId("auth-1".into()));
-        assert!(got.is_some());
-        let got = got.unwrap();
-        assert_eq!(got.authority_id, NodeId("auth-1".into()));
+        // get_for_scope() returns the exact scope's entry
+        let user_f = set
+            .get_for_scope(&kr("user/"), &pv(1), &NodeId("auth-1".into()))
+            .unwrap();
+        assert_eq!(user_f.frontier_hlc.physical, 100);
+
+        let order_f = set
+            .get_for_scope(&kr("order/"), &pv(1), &NodeId("auth-1".into()))
+            .unwrap();
+        assert_eq!(order_f.frontier_hlc.physical, 500);
+
+        // Missing scope returns None
+        assert!(
+            set.get_for_scope(&kr("data/"), &pv(1), &NodeId("auth-1".into()))
+                .is_none()
+        );
     }
 
     #[test]
-    fn mixed_scopes_global_majority_counts_all_entries() {
+    fn mixed_scopes_use_scoped_majority() {
         let mut set = AckFrontierSet::new();
 
-        // 2 entries: auth-1 in user/, auth-1 in order/
+        // 2 entries in separate scopes — use scoped majority instead of
+        // the unscoped variant which now asserts single-scope.
         set.update(make_frontier("auth-1", 100, 0, "user/"));
         set.update(make_frontier("auth-1", 200, 0, "order/"));
 
-        // Global: 2 entries, majority=2 for total=2 → 100
-        let mf = set.majority_frontier(2).unwrap();
-        assert_eq!(mf.physical, 100);
+        // Each scope has 1 entry; majority for total=1 is 1
+        let mf_user = set
+            .majority_frontier_for_scope(&kr("user/"), &pv(1), 1)
+            .unwrap();
+        assert_eq!(mf_user.physical, 100);
+
+        let mf_order = set
+            .majority_frontier_for_scope(&kr("order/"), &pv(1), 1)
+            .unwrap();
+        assert_eq!(mf_order.physical, 200);
     }
 
     #[test]

--- a/src/compaction/tuner.rs
+++ b/src/compaction/tuner.rs
@@ -13,6 +13,13 @@ const DEFAULT_TUNING_INTERVAL_MS: u64 = 30_000;
 /// Default maximum checkpoint history per key range.
 const DEFAULT_MAX_CHECKPOINT_HISTORY: usize = 10;
 
+/// Minimum span (in milliseconds) required for a meaningful rate calculation.
+///
+/// If the actual time span between the oldest in-window entry and `now` is
+/// less than this value, `ops_per_sec` returns 0.0 to avoid wildly inflated
+/// rates from sub-second bursts.
+const MIN_RATE_SPAN_MS: u64 = 1_000;
+
 /// Tracks write operations in a sliding window for a single key range prefix.
 #[derive(Debug, Clone)]
 struct WriteRateBucket {
@@ -76,7 +83,13 @@ impl WriteRateBucket {
 
         match oldest {
             Some(oldest_ts) => {
-                let span_ms = now_ms.saturating_sub(oldest_ts).max(1);
+                let span_ms = now_ms.saturating_sub(oldest_ts);
+                // Avoid inflated rates from very short spans (e.g. single
+                // burst within 1 ms).  Return 0.0 until enough time has
+                // elapsed for a meaningful measurement.
+                if span_ms < MIN_RATE_SPAN_MS {
+                    return 0.0;
+                }
                 let span_secs = span_ms as f64 / 1000.0;
                 total_ops as f64 / span_secs
             }
@@ -703,11 +716,12 @@ mod tests {
         let mut adaptive = AdaptiveCompactionConfig::with_write_rate_window(base, 60_000);
         adaptive.set_tuning_interval_ms(0);
 
-        // Record moderate write rate (inside ops dead zone) to avoid ops adjustment
-        adaptive.record_ops("user/", 500, 100);
+        // Record moderate write rate (inside ops dead zone) with >= 1s span
+        // so the rate is not suppressed by MIN_RATE_SPAN_MS.
+        adaptive.record_ops("user/", 1_000, 100);
 
         // Lag at 5s — inside the dead zone [1000, 15000]
-        let changed = adaptive.tune(1_000, Some(5_000));
+        let changed = adaptive.tune(2_000, Some(5_000));
         assert!(!changed);
         assert_eq!(adaptive.effective().time_threshold_ms, 30_000);
     }
@@ -722,17 +736,18 @@ mod tests {
         let mut adaptive = AdaptiveCompactionConfig::with_write_rate_window(base, 60_000);
         adaptive.set_tuning_interval_ms(0);
 
-        // Record moderate write rate (inside ops dead zone) to avoid ops adjustment
-        adaptive.record_ops("user/", 500, 100);
+        // Record moderate write rate (inside ops dead zone) with >= 1s span
+        // so the rate is not suppressed by MIN_RATE_SPAN_MS.
+        adaptive.record_ops("user/", 1_000, 100);
 
-        let changed = adaptive.tune(1_000, Some(2_000));
+        let changed = adaptive.tune(2_000, Some(2_000));
         assert!(!changed);
         assert_eq!(adaptive.effective().time_threshold_ms, 30_000);
 
         // Also at lag=10000 (old high boundary)
         // Record enough ops to keep rate in the dead zone (between 30 and 750).
-        // Window is 60s, entries at (500,100) and (31500,2000).
-        // At t=32000: total=2100, span=31.5s, rate=66.7 ops/sec — in dead zone.
+        // Window is 60s, entries at (1000,100) and (31500,2000).
+        // At t=32000: total=2100, span=31.0s, rate=67.7 ops/sec — in dead zone.
         adaptive.record_ops("user/", 31_500, 2_000);
         let changed = adaptive.tune(32_000, Some(10_000));
         assert!(!changed);

--- a/src/ops/metrics.rs
+++ b/src/ops/metrics.rs
@@ -37,11 +37,21 @@ pub struct BenchmarkResult {
 /// Returns a [`BenchmarkResult`] with the given name, populated with
 /// mean, p50, p95, p99, min, and max latencies in microseconds.
 ///
-/// # Panics
-///
-/// Panics if `durations` is empty.
+/// If `durations` is empty, returns a zero-valued [`BenchmarkResult`]
+/// instead of panicking, so the metrics collection path never crashes.
 pub fn collect_latencies(name: &str, durations: &[Duration]) -> BenchmarkResult {
-    assert!(!durations.is_empty(), "durations must not be empty");
+    if durations.is_empty() {
+        return BenchmarkResult {
+            name: name.to_string(),
+            iterations: 0,
+            mean_us: 0.0,
+            p50_us: 0.0,
+            p95_us: 0.0,
+            p99_us: 0.0,
+            min_us: 0.0,
+            max_us: 0.0,
+        };
+    }
 
     let mut us_values: Vec<f64> = durations
         .iter()
@@ -622,9 +632,15 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "durations must not be empty")]
-    fn collect_empty_panics() {
-        collect_latencies("empty", &[]);
+    fn collect_empty_returns_zero() {
+        let result = collect_latencies("empty", &[]);
+        assert_eq!(result.iterations, 0);
+        assert_eq!(result.mean_us, 0.0);
+        assert_eq!(result.p50_us, 0.0);
+        assert_eq!(result.p95_us, 0.0);
+        assert_eq!(result.p99_us, 0.0);
+        assert_eq!(result.min_us, 0.0);
+        assert_eq!(result.max_us, 0.0);
     }
 
     // ---------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Add get_for_scope() to AckFrontierSet
- WriteRateBucket returns 0 for spans < 1s
- majority_frontier debug_assert single scope
- collect_latencies returns zero instead of panic

🤖 Generated with [Claude Code](https://claude.com/claude-code)