### PR TITLE
fix: clippy collapsible_if, doc drift, partial_cmp safety

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -156,6 +156,8 @@ ASTEROIDB_INTERNAL_TOKEN=my-secret-token cargo run
 | `GET` | `/api/certified/{key}` | Certified read (ステータス付き) |
 | `GET` | `/api/status/{key}` | 認証ステータス確認 |
 | `GET` | `/api/metrics` | ランタイムメトリクス取得 |
+| `GET` | `/api/slo` | SLO ステータス取得 |
+| `GET` | `/api/topology` | クラスタトポロジービュー取得 |
 | `PUT` | `/api/control-plane/authorities` | Authority 定義の設定 (要過半数承認) |
 | `GET` | `/api/control-plane/authorities` | Authority 定義の一覧 |
 | `GET` | `/api/control-plane/authorities/{prefix}` | Authority 定義の取得 |
@@ -177,6 +179,8 @@ ASTEROIDB_INTERNAL_TOKEN=my-secret-token cargo run
 | `GET` | `/api/internal/keys` | キー一覧取得 |
 | `POST` | `/api/internal/join` | ノード参加 |
 | `POST` | `/api/internal/leave` | ノード離脱 |
+| `POST` | `/api/internal/announce` | ノードアナウンス |
+| `POST` | `/api/internal/ping` | ヘルスチェック + ピアディスカバリ |
 
 #### Control Plane API
 
@@ -196,6 +200,8 @@ ASTEROIDB_INTERNAL_TOKEN=my-secret-token cargo run
 | メソッド | パス | 説明 |
 |---------|------|------|
 | `GET` | `/api/metrics` | メトリクス取得 |
+| `GET` | `/api/slo` | SLO ステータス取得 |
+| `GET` | `/api/topology` | クラスタトポロジービュー取得 |
 
 ### 3.1 Eventual Read/Write
 

--- a/src/ops/metrics.rs
+++ b/src/ops/metrics.rs
@@ -57,7 +57,7 @@ pub fn collect_latencies(name: &str, durations: &[Duration]) -> BenchmarkResult 
         .iter()
         .map(|d| d.as_secs_f64() * 1_000_000.0)
         .collect();
-    us_values.sort_by(|a, b| a.partial_cmp(b).unwrap());
+    us_values.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
 
     let n = us_values.len();
     let sum: f64 = us_values.iter().sum();
@@ -167,7 +167,7 @@ impl PeerSyncStats {
             let sum: f64 = active.iter().sum();
             let mean = sum / active.len() as f64;
             let mut sorted = active;
-            sorted.sort_by(|a, b| a.partial_cmp(b).unwrap());
+            sorted.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
             let p99 = percentile(&sorted, 99.0);
             (mean, p99)
         };
@@ -228,7 +228,7 @@ impl CertificationLatencyWindow {
         let sum: f64 = active.iter().sum();
         let mean = sum / active.len() as f64;
         let mut sorted = active.clone();
-        sorted.sort_by(|a, b| a.partial_cmp(b).unwrap());
+        sorted.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
         let p99 = percentile(&sorted, 99.0);
 
         CertificationLatencySnapshot {

--- a/tests/cli_e2e.rs
+++ b/tests/cli_e2e.rs
@@ -98,10 +98,9 @@ async fn spawn_server() -> (std::net::SocketAddr, tokio::task::JoinHandle<()>) {
             .timeout(Duration::from_millis(200))
             .send()
             .await
+            && resp.status().is_success()
         {
-            if resp.status().is_success() {
-                break;
-            }
+            break;
         }
         if tokio::time::Instant::now() > deadline {
             panic!("server at {addr} did not become ready within 5 s");


### PR DESCRIPTION
## Summary
- Fix clippy collapsible_if in cli_e2e.rs
- Add 4 missing routes to getting-started.md
- Replace partial_cmp().unwrap() with unwrap_or(Equal) in metrics.rs

🤖 Generated with [Claude Code](https://claude.com/claude-code)