### PR TITLE
fix: sync frontier respects merge errors, ping handler validates sender

### DIFF
--- a/src/http/handlers.rs
+++ b/src/http/handlers.rs
@@ -1038,19 +1038,32 @@ pub async fn internal_ping(
         let sender_is_known = registry.get_peer(&sender_nid).is_some()
             || state.self_node_id.as_ref() == Some(&sender_nid);
 
-        // Always update the sender's address if it changed.
+        // Update or add the sender. Only add an unknown sender if the
+        // request passed bearer-token authentication (i.e. internal_token
+        // is configured and was validated by the middleware). Without auth,
+        // unknown nodes must not be able to inject themselves into the
+        // registry via a bare ping.
         if registry.get_peer(&sender_nid).is_some() {
             if registry.update_address(&sender_nid, &req.sender_addr) {
                 changed = true;
             }
-        } else if registry
-            .add_peer(PeerConfig {
-                node_id: sender_nid.clone(),
-                addr: req.sender_addr.clone(),
-            })
-            .is_ok()
-        {
-            changed = true;
+        } else if state.internal_token.is_some() {
+            // The request reached us through the auth middleware, so the
+            // sender has a valid token — safe to add as a new peer.
+            if registry
+                .add_peer(PeerConfig {
+                    node_id: sender_nid.clone(),
+                    addr: req.sender_addr.clone(),
+                })
+                .is_ok()
+            {
+                changed = true;
+            }
+        } else {
+            tracing::warn!(
+                sender = %req.sender_id,
+                "ping from unknown sender rejected: no auth configured"
+            );
         }
 
         // Only accept peer list from known senders.

--- a/src/network/sync.rs
+++ b/src/network/sync.rs
@@ -379,10 +379,34 @@ impl SyncClient {
             match self.authorized_post(&url).json(&request).send().await {
                 Ok(resp) => {
                     if resp.status().is_success() {
-                        total_pushed += chunk.len();
+                        // Parse the response body to check for per-key merge
+                        // errors. Only count entries that were actually merged.
+                        let sync_resp: Option<SyncResponse> =
+                            resp.json::<SyncResponse>().await.ok();
+                        let error_count = sync_resp.as_ref().map(|r| r.errors.len()).unwrap_or(0);
+                        let actually_pushed = chunk.len().saturating_sub(error_count);
+                        if error_count > 0 {
+                            let error_keys: Vec<&str> = sync_resp
+                                .as_ref()
+                                .map(|r| r.errors.iter().map(|e| e.key.as_str()).collect())
+                                .unwrap_or_default();
+                            tracing::warn!(
+                                peer_addr = %peer_addr,
+                                error_count = error_count,
+                                error_keys = ?error_keys,
+                                "delta push batch had merge errors on remote"
+                            );
+                            // Partial success: return error so the caller can
+                            // advance the frontier only up to what succeeded.
+                            return Err(SyncPushError {
+                                pushed: total_pushed + actually_pushed,
+                                reason: format!("{error_count} keys failed to merge on remote"),
+                            });
+                        }
+                        total_pushed += actually_pushed;
                         tracing::debug!(
                             peer_addr = %peer_addr,
-                            batch_keys = chunk.len(),
+                            batch_keys = actually_pushed,
                             "delta push batch succeeded"
                         );
                     } else {

--- a/src/runtime/node_runner.rs
+++ b/src/runtime/node_runner.rs
@@ -1370,20 +1370,44 @@ impl NodeRunner {
                     .await;
 
                 if let Some(delta_resp) = delta_result {
-                    // Apply delta entries.
+                    // Apply delta entries, tracking merge errors.
+                    // Only advance the frontier to the HLC of the last
+                    // successfully merged entry so failed entries are retried.
                     let mut api = eventual_api.lock().await;
+                    let mut last_success_hlc: Option<crate::hlc::HlcTimestamp> = None;
+                    let mut merge_failed = false;
                     for entry in &delta_resp.entries {
-                        let _ = api.merge_remote_with_hlc(
+                        match api.merge_remote_with_hlc(
                             entry.key.clone(),
                             &entry.value,
                             entry.hlc.clone(),
-                        );
+                        ) {
+                            Ok(()) => last_success_hlc = Some(entry.hlc.clone()),
+                            Err(e) => {
+                                tracing::warn!(
+                                    peer = %peer.node_id.0,
+                                    key = %entry.key,
+                                    error = %e,
+                                    "delta pull merge failed, stopping frontier advance"
+                                );
+                                merge_failed = true;
+                                break;
+                            }
+                        }
                     }
                     drop(api);
 
-                    // Update peer frontier.
-                    if let Some(new_frontier) = delta_resp.sender_frontier {
+                    // Update peer frontier only to the last successfully
+                    // merged entry's HLC. If all entries succeeded and the
+                    // sender provided a frontier, use that instead.
+                    if merge_failed {
+                        if let Some(hlc) = last_success_hlc {
+                            self.peer_frontiers.insert(peer_key.clone(), hlc);
+                        }
+                    } else if let Some(new_frontier) = delta_resp.sender_frontier {
                         self.peer_frontiers.insert(peer_key.clone(), new_frontier);
+                    } else if let Some(hlc) = last_success_hlc {
+                        self.peer_frontiers.insert(peer_key.clone(), hlc);
                     }
 
                     any_success = true;
@@ -1410,17 +1434,37 @@ impl NodeRunner {
 
                 if let Some(delta_resp) = retry_result {
                     let mut api = eventual_api.lock().await;
+                    let mut last_success_hlc: Option<crate::hlc::HlcTimestamp> = None;
+                    let mut merge_failed = false;
                     for entry in &delta_resp.entries {
-                        let _ = api.merge_remote_with_hlc(
+                        match api.merge_remote_with_hlc(
                             entry.key.clone(),
                             &entry.value,
                             entry.hlc.clone(),
-                        );
+                        ) {
+                            Ok(()) => last_success_hlc = Some(entry.hlc.clone()),
+                            Err(e) => {
+                                tracing::warn!(
+                                    peer = %peer.node_id.0,
+                                    key = %entry.key,
+                                    error = %e,
+                                    "delta pull retry merge failed, stopping frontier advance"
+                                );
+                                merge_failed = true;
+                                break;
+                            }
+                        }
                     }
                     drop(api);
 
-                    if let Some(new_frontier) = delta_resp.sender_frontier {
+                    if merge_failed {
+                        if let Some(hlc) = last_success_hlc {
+                            self.peer_frontiers.insert(peer_key.clone(), hlc);
+                        }
+                    } else if let Some(new_frontier) = delta_resp.sender_frontier {
                         self.peer_frontiers.insert(peer_key.clone(), new_frontier);
+                    } else if let Some(hlc) = last_success_hlc {
+                        self.peer_frontiers.insert(peer_key.clone(), hlc);
                     }
 
                     any_success = true;


### PR DESCRIPTION
## Summary
- Delta pull/push paths only advance frontier for successfully merged entries
- Ping handler only adds unknown senders when auth is configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)