### PR TITLE
fix: update join/ping tests, wire compaction record_op, HLC overflow protection

### DIFF
--- a/src/compaction/engine.rs
+++ b/src/compaction/engine.rs
@@ -78,9 +78,19 @@ pub struct CompactionEngine {
     revalidation_log: Vec<(HlcTimestamp, RevalidationTrigger)>,
     /// Optional adaptive tuning configuration.
     adaptive_config: Option<AdaptiveCompactionConfig>,
+    /// Timestamp (ms since epoch) when this engine was created, used as the
+    /// base for the time threshold when no prior checkpoint exists.
+    created_at_ms: u64,
 }
 
 impl CompactionEngine {
+    fn now_ms() -> u64 {
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis() as u64
+    }
+
     /// Create a new compaction engine with the given configuration.
     pub fn new(config: CompactionConfig) -> Self {
         Self {
@@ -90,6 +100,7 @@ impl CompactionEngine {
             ops_count: HashMap::new(),
             revalidation_log: Vec::new(),
             adaptive_config: None,
+            created_at_ms: Self::now_ms(),
         }
     }
 
@@ -108,6 +119,7 @@ impl CompactionEngine {
             ops_count: HashMap::new(),
             revalidation_log: Vec::new(),
             adaptive_config: Some(adaptive),
+            created_at_ms: Self::now_ms(),
         }
     }
 
@@ -174,6 +186,10 @@ impl CompactionEngine {
     ///
     /// Returns `true` if either the operations count threshold or the time
     /// threshold has been reached since the last checkpoint.
+    ///
+    /// When no prior checkpoint exists and at least one operation has been
+    /// recorded, the time threshold is evaluated against the engine's
+    /// creation time to ensure the first checkpoint is eventually created.
     pub fn should_checkpoint(&self, key_range: &KeyRange, now: &HlcTimestamp) -> bool {
         let prefix = &key_range.prefix;
 
@@ -186,6 +202,14 @@ impl CompactionEngine {
         // Check time threshold
         if let Some(cp) = self.checkpoints.get(prefix) {
             let elapsed = now.physical.saturating_sub(cp.timestamp.physical);
+            if elapsed >= self.config.time_threshold_ms {
+                return true;
+            }
+        } else if ops > 0 {
+            // No prior checkpoint exists but there are pending ops.
+            // Use the engine creation time as the base so the first
+            // checkpoint is created once the time threshold elapses.
+            let elapsed = now.physical.saturating_sub(self.created_at_ms);
             if elapsed >= self.config.time_threshold_ms {
                 return true;
             }

--- a/src/hlc.rs
+++ b/src/hlc.rs
@@ -61,7 +61,13 @@ impl Hlc {
             self.physical = wall;
             self.logical = 0;
         } else {
-            self.logical += 1;
+            self.logical = self.logical.saturating_add(1);
+            // If the logical counter saturated, advance the physical
+            // timestamp by 1 ms and reset logical to preserve monotonicity.
+            if self.logical == u32::MAX {
+                self.physical = self.physical.saturating_add(1);
+                self.logical = 0;
+            }
         }
 
         HlcTimestamp {
@@ -75,25 +81,37 @@ impl Hlc {
     ///
     /// Takes the maximum of the local physical time, the received physical time,
     /// and the current wall clock, then adjusts the logical counter accordingly.
+    ///
+    /// Uses saturating arithmetic to prevent overflow when a peer sends
+    /// `logical: u32::MAX`. When saturation is detected the physical
+    /// timestamp is advanced by 1 ms and the logical counter is reset to 0,
+    /// preserving strict monotonicity.
     pub fn update(&mut self, received: &HlcTimestamp) {
         let wall = physical_ms();
         let max_physical = wall.max(self.physical).max(received.physical);
 
         if max_physical == self.physical && max_physical == received.physical {
             // All three equal (or wall <= both): advance logical beyond both.
-            self.logical = self.logical.max(received.logical) + 1;
+            self.logical = self.logical.max(received.logical).saturating_add(1);
         } else if max_physical == self.physical {
             // Local physical is ahead: just bump logical.
-            self.logical += 1;
+            self.logical = self.logical.saturating_add(1);
         } else if max_physical == received.physical {
             // Received physical is ahead: adopt its logical + 1.
-            self.logical = received.logical + 1;
+            self.logical = received.logical.saturating_add(1);
         } else {
             // Wall clock is ahead of both: reset logical.
             self.logical = 0;
         }
 
         self.physical = max_physical;
+
+        // If the logical counter saturated, advance the physical timestamp
+        // by 1 ms and reset logical to preserve strict monotonicity.
+        if self.logical == u32::MAX {
+            self.physical = self.physical.saturating_add(1);
+            self.logical = 0;
+        }
     }
 }
 

--- a/src/http/handlers.rs
+++ b/src/http/handlers.rs
@@ -120,6 +120,11 @@ pub async fn eventual_write(
         }
     }
 
+    state
+        .metrics
+        .write_ops_total
+        .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+
     Ok(Json(WriteResponse { ok: true }))
 }
 
@@ -169,6 +174,11 @@ pub async fn certified_write(
 
     let mut api = state.certified.lock().await;
     let status = api.certified_write(req.key, crdt_value, on_timeout)?;
+
+    state
+        .metrics
+        .write_ops_total
+        .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
 
     Ok(Json(CertifiedWriteResponse { status }))
 }

--- a/src/ops/metrics.rs
+++ b/src/ops/metrics.rs
@@ -295,6 +295,12 @@ pub struct RuntimeMetrics {
     /// Timestamp (ms) of the last key rotation (0 if none).
     pub key_rotation_last_time_ms: AtomicU64,
 
+    /// Cumulative write operations (eventual + certified) for compaction tracking.
+    ///
+    /// Incremented in HTTP write handlers and drained by the compaction engine
+    /// during periodic checkpoint checks.
+    pub write_ops_total: AtomicU64,
+
     /// Per-peer sync statistics (peer_id -> stats).
     peer_sync_stats: Mutex<HashMap<String, PeerSyncStats>>,
 
@@ -324,6 +330,7 @@ impl Default for RuntimeMetrics {
             key_rotation_total: AtomicU64::default(),
             key_rotation_last_version: AtomicU64::default(),
             key_rotation_last_time_ms: AtomicU64::default(),
+            write_ops_total: AtomicU64::default(),
             peer_sync_stats: Mutex::new(HashMap::new()),
             certification_latency_window: Mutex::new(CertificationLatencyWindow::default()),
             window_duration: Duration::from_secs(WINDOW_SECS),
@@ -491,6 +498,7 @@ impl RuntimeMetrics {
             key_rotation_total: self.key_rotation_total.load(Ordering::Relaxed),
             key_rotation_last_version: self.key_rotation_last_version.load(Ordering::Relaxed),
             key_rotation_last_time_ms: self.key_rotation_last_time_ms.load(Ordering::Relaxed),
+            write_ops_total: self.write_ops_total.load(Ordering::Relaxed),
         }
     }
 }
@@ -556,6 +564,8 @@ pub struct MetricsSnapshot {
     pub key_rotation_last_version: u64,
     /// Timestamp (ms) of the last key rotation (0 if none).
     pub key_rotation_last_time_ms: u64,
+    /// Cumulative write operations (eventual + certified) for compaction tracking.
+    pub write_ops_total: u64,
 }
 
 #[cfg(test)]

--- a/src/runtime/node_runner.rs
+++ b/src/runtime/node_runner.rs
@@ -1627,6 +1627,11 @@ impl NodeRunner {
     async fn check_compaction(&mut self) {
         let now = self.clock.now();
 
+        // Drain write ops recorded by HTTP handlers and feed them into the
+        // compaction engine so that the ops-based checkpoint threshold works
+        // in production.
+        let pending_ops = self.metrics.write_ops_total.swap(0, Ordering::Relaxed);
+
         let api = self.certified_api.lock().await;
         let ns = api.namespace().read().unwrap();
 
@@ -1636,6 +1641,20 @@ impl NodeRunner {
             .into_iter()
             .map(|def| (def.key_range.clone(), def.authority_nodes.len()))
             .collect();
+
+        // Distribute drained write ops across key ranges. With a single
+        // key range (common case) all ops go to it; with multiple ranges
+        // each gets an equal share (approximation).
+        if pending_ops > 0 && !defs.is_empty() {
+            let ops_per_range = pending_ops / defs.len() as u64;
+            let remainder = pending_ops % defs.len() as u64;
+            for (i, (key_range, _)) in defs.iter().enumerate() {
+                let ops = ops_per_range + if (i as u64) < remainder { 1 } else { 0 };
+                for _ in 0..ops {
+                    self.compaction_engine.record_op(key_range);
+                }
+            }
+        }
 
         for (key_range, _total_authorities) in &defs {
             if self.compaction_engine.should_checkpoint(key_range, &now) {

--- a/tests/membership_protocol.rs
+++ b/tests/membership_protocol.rs
@@ -414,12 +414,28 @@ async fn announce_join_is_idempotent() {
 }
 
 /// Test ping endpoint directly: sender provides peers, receiver returns its list.
+///
+/// The ping handler only reconciles peers from known senders, so node-2
+/// must be pre-registered as a peer of node-1 before the ping request.
 #[tokio::test]
 async fn ping_endpoint_exchanges_peer_lists() {
     let (state1, addr1, _h1) = spawn_node("node-1", vec![]).await;
 
     // node-1 has no peers initially.
     assert_eq!(peer_count(&state1).await, 0);
+
+    // Pre-register node-2 as a known peer of node-1 so the ping handler
+    // treats it as a trusted sender and reconciles the peer list.
+    {
+        let mut registry = state1.peers.as_ref().unwrap().lock().await;
+        registry
+            .add_peer(PeerConfig {
+                node_id: node_id("node-2"),
+                addr: "127.0.0.1:4001".into(),
+            })
+            .unwrap();
+    }
+    assert_eq!(peer_count(&state1).await, 1);
 
     let client = reqwest::Client::new();
 
@@ -449,7 +465,7 @@ async fn ping_endpoint_exchanges_peer_lists() {
     // node-1's response should include the sender and any newly learned peers.
     assert!(!ping_resp.known_peers.is_empty());
 
-    // Verify node-1 learned about node-2 and node-3.
+    // Verify node-1 learned about node-3 from node-2's peer list.
     let ids = peer_ids(&state1).await;
     assert!(ids.contains(&"node-2".to_string()), "should know node-2");
     assert!(ids.contains(&"node-3".to_string()), "should know node-3");

--- a/tests/node_join_leave.rs
+++ b/tests/node_join_leave.rs
@@ -380,12 +380,12 @@ async fn node_leave_removes_from_registry() {
 }
 
 // ===========================================================================
-// Test 3: Duplicate join is rejected
+// Test 3: Duplicate join updates address (idempotent)
 // ===========================================================================
 
-/// Attempting to join with the same node_id twice should fail.
+/// Joining with the same node_id twice should succeed and update the address.
 #[tokio::test]
-async fn duplicate_join_is_rejected() {
+async fn duplicate_join_updates_address() {
     let (_state1, addr1, server1) = spawn_node_with_peers("dup-node-1", vec![]).await;
     let (_state2, addr2, server2) = spawn_node_with_peers("dup-node-2", vec![]).await;
 
@@ -409,18 +409,38 @@ async fn duplicate_join_is_rejected() {
         .unwrap();
     assert!(resp.status().is_success(), "first join should succeed");
 
-    // Second join with same node_id: should fail.
+    // Second join with same node_id but a different address: should succeed
+    // (idempotent) and update the address.
+    let new_address = "127.0.0.1:19999".to_string();
+    let join_req2 = JoinRequest {
+        node_id: "dup-node-2".to_string(),
+        address: new_address.clone(),
+        tags: vec![],
+    };
+
     let resp = client
         .post(format!("http://{}/api/internal/join", addr1))
         .header("content-type", "application/json")
-        .json(&join_req)
+        .json(&join_req2)
         .send()
         .await
         .unwrap();
     assert!(
-        resp.status().is_client_error(),
-        "duplicate join should fail: {}",
+        resp.status().is_success(),
+        "duplicate join should succeed (idempotent): {}",
         resp.status()
+    );
+
+    let join_resp: JoinResponse = resp.json().await.unwrap();
+    // Verify the peer list contains dup-node-2 with the updated address.
+    let dup_peer = join_resp
+        .peers
+        .iter()
+        .find(|p| p.node_id == "dup-node-2")
+        .expect("dup-node-2 should be in peer list");
+    assert_eq!(
+        dup_peer.address, new_address,
+        "address should be updated to the new value"
     );
 
     // Clean up.


### PR DESCRIPTION
## Summary
- Update duplicate_join test to expect 200 (idempotent behavior)
- Pre-register sender in ping test for peer exchange to work
- Wire compaction record_op via write_ops_total metric in HTTP handlers
- Add first-checkpoint fallback in should_checkpoint using engine created_at
- HLC logical counter uses saturating_add with physical advancement on saturation

## Test plan
- [x] cargo fmt --check
- [x] cargo clippy -- -D warnings
- [x] cargo test (1138 tests pass, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)