### PR TITLE
fix: treat empty ASTEROIDB_INTERNAL_TOKEN as no auth (Docker sync fix)

### DIFF
--- a/src/http/handlers.rs
+++ b/src/http/handlers.rs
@@ -1084,7 +1084,7 @@ pub async fn internal_ping(
             if registry.update_address(&sender_nid, &req.sender_addr) {
                 changed = true;
             }
-        } else if state.internal_token.is_some() {
+        } else if state.internal_token.as_ref().is_some_and(|t| !t.is_empty()) {
             // The request reached us through the auth middleware, so the
             // sender has a valid token — safe to add as a new peer.
             if registry
@@ -1556,5 +1556,45 @@ mod tests {
             CrdtValue::Counter(c) => assert_eq!(c.value(), 1_000_000_000),
             other => panic!("expected Counter, got {other:?}"),
         }
+    }
+
+    // ---------------------------------------------------------------
+    // validate_peer_address tests
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn validate_peer_address_accepts_docker_hostnames_with_hyphens() {
+        // Docker container names use hyphens (e.g. asteroidb-node-2:3000).
+        assert!(validate_peer_address("asteroidb-node-1:3000").is_ok());
+        assert!(validate_peer_address("asteroidb-node-2:3000").is_ok());
+        assert!(validate_peer_address("asteroidb-node-3:3000").is_ok());
+    }
+
+    #[test]
+    fn validate_peer_address_accepts_ip_port() {
+        assert!(validate_peer_address("127.0.0.1:3000").is_ok());
+        assert!(validate_peer_address("0.0.0.0:3000").is_ok());
+        assert!(validate_peer_address("192.168.1.1:8080").is_ok());
+    }
+
+    #[test]
+    fn validate_peer_address_accepts_ipv6() {
+        assert!(validate_peer_address("[::1]:3000").is_ok());
+    }
+
+    #[test]
+    fn validate_peer_address_rejects_scheme() {
+        assert!(validate_peer_address("http://localhost:3000").is_err());
+        assert!(validate_peer_address("ftp://host:22").is_err());
+    }
+
+    #[test]
+    fn validate_peer_address_rejects_path() {
+        assert!(validate_peer_address("localhost:3000/secret").is_err());
+    }
+
+    #[test]
+    fn validate_peer_address_rejects_missing_port() {
+        assert!(validate_peer_address("localhost").is_err());
     }
 }

--- a/src/http/routes.rs
+++ b/src/http/routes.rs
@@ -46,7 +46,9 @@ pub fn router(state: Arc<AppState>) -> Router {
             delete(remove_policy),
         );
 
-    let (internal_routes, cp_mutation_routes) = if let Some(ref token) = state.internal_token {
+    let (internal_routes, cp_mutation_routes) = if let Some(ref token) = state.internal_token
+        && !token.is_empty()
+    {
         let token1 = token.clone();
         let token2 = token.clone();
         let internal_routes = internal_routes.layer(axum::middleware::from_fn(move |req, next| {
@@ -1840,6 +1842,47 @@ mod tests {
 
         let resp = app.oneshot(req).await.unwrap();
         assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn empty_string_token_treated_as_no_auth() {
+        // When ASTEROIDB_INTERNAL_TOKEN is set to "" (e.g. Docker Compose
+        // substituting an unset host variable), the router must NOT activate
+        // the auth middleware so that inter-node sync works without a Bearer
+        // header.
+        let state = test_state_with_token(Some(String::new()));
+        let app = router(state);
+
+        // Internal route without any Authorization header should succeed,
+        // just like when internal_token is None.
+        let req = Request::builder()
+            .uri("/api/internal/keys")
+            .body(Body::empty())
+            .unwrap();
+
+        let resp = app.clone().oneshot(req).await.unwrap();
+        assert_eq!(
+            resp.status(),
+            StatusCode::OK,
+            "empty-string token must not activate auth middleware"
+        );
+
+        // Control-plane mutation should also work without auth.
+        let req = Request::builder()
+            .method("PUT")
+            .uri("/api/control-plane/policies")
+            .header("content-type", "application/json")
+            .body(Body::from(
+                r#"{"key_range_prefix":"x/","replica_count":3,"approvals":["auth-1","auth-2"]}"#,
+            ))
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(
+            resp.status(),
+            StatusCode::OK,
+            "empty-string token must not activate auth middleware on CP routes"
+        );
     }
 
     // ---------------------------------------------------------------

--- a/src/main.rs
+++ b/src/main.rs
@@ -164,7 +164,13 @@ async fn main() {
     let consensus = Arc::new(Mutex::new(ControlPlaneConsensus::new(auth_nodes)));
 
     // Optional shared token for authenticating internal API requests.
-    let internal_token = std::env::var("ASTEROIDB_INTERNAL_TOKEN").ok();
+    // Treat an empty string the same as unset — Docker Compose substitutes
+    // `${ASTEROIDB_INTERNAL_TOKEN}` as "" when the host variable is not
+    // defined, which would otherwise activate the auth middleware with a
+    // degenerate empty token, breaking inter-node communication in CI.
+    let internal_token = std::env::var("ASTEROIDB_INTERNAL_TOKEN")
+        .ok()
+        .filter(|t| !t.is_empty());
 
     // SLO tracker shared between HTTP handlers and NodeRunner.
     let slo_tracker = Arc::new(asteroidb_poc::ops::slo::SloTracker::new());


### PR DESCRIPTION
## Summary
- Filter empty string to None for internal token
- Guard auth middleware against empty token
- Guard ping handler peer admission against empty token
- Add tests for empty token behavior and peer address validation

Fixes Docker E2E sync failure where empty token activated auth middleware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)