### PR TITLE
feat: wire keyset_registry, add tracing-subscriber, healthz endpoint, P3 fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,6 +95,7 @@ dependencies = [
  "tokio",
  "tower",
  "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -1076,6 +1077,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1113,6 +1120,15 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
 
 [[package]]
 name = "matchit"
@@ -1158,6 +1174,15 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "tempfile",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1801,6 +1826,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1958,6 +1992,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -2126,6 +2169,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -2187,6 +2260,12 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vcpkg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ axum = "0.8"
 reqwest = { version = "0.12", features = ["json", "blocking"] }
 clap = { version = "4", features = ["derive", "env"] }
 tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 subtle = "2"
 hex = "0.4"
 

--- a/src/authority/certificate.rs
+++ b/src/authority/certificate.rs
@@ -358,7 +358,12 @@ impl EpochManager {
     /// Create a new epoch manager.
     ///
     /// `epoch_base_secs` is the reference timestamp (in seconds) for epoch 0.
-    pub fn new(config: EpochConfig, epoch_base_secs: u64) -> Self {
+    /// If `config.duration_secs` is 0, it is replaced with the default (86400)
+    /// to prevent division-by-zero in epoch calculations.
+    pub fn new(mut config: EpochConfig, epoch_base_secs: u64) -> Self {
+        if config.duration_secs == 0 {
+            config.duration_secs = 86400;
+        }
         Self {
             config,
             registry: KeysetRegistry::new(),
@@ -371,8 +376,11 @@ impl EpochManager {
     }
 
     /// Compute the epoch number for a given timestamp in seconds.
+    ///
+    /// If `duration_secs` is 0 (misconfiguration), returns 0 to avoid
+    /// a division-by-zero panic.
     pub fn current_epoch(&self, now_secs: u64) -> u64 {
-        if now_secs < self.epoch_base_secs {
+        if self.config.duration_secs == 0 || now_secs < self.epoch_base_secs {
             return 0;
         }
         (now_secs - self.epoch_base_secs) / self.config.duration_secs

--- a/src/http/handlers.rs
+++ b/src/http/handlers.rs
@@ -741,9 +741,12 @@ pub async fn internal_keys(State(state): State<Arc<AppState>>) -> Json<KeyDumpRe
         timestamps.insert(k.clone(), hlc.clone());
     }
     // Include entries without tracked timestamps (rare, but possible for
-    // stores migrated from older versions).
+    // stores migrated from older versions). Only iterate entries not already
+    // covered by `all_entries_with_hlc()` to avoid redundant cloning.
     for (k, v) in store.all_entries() {
-        entries.entry(k.clone()).or_insert_with(|| v.clone());
+        if !entries.contains_key(k) {
+            entries.insert(k.clone(), v.clone());
+        }
     }
     let frontier = store.current_frontier();
 
@@ -1223,6 +1226,15 @@ pub async fn get_metrics(State(state): State<Arc<AppState>>) -> Json<MetricsSnap
 /// Returns a snapshot of all SLO budgets for operational monitoring.
 pub async fn get_slo(State(state): State<Arc<AppState>>) -> Json<SloSnapshot> {
     Json(state.slo_tracker.snapshot())
+}
+
+/// `GET /healthz`
+///
+/// Simple health check endpoint for load balancers and orchestrators.
+/// Returns 200 OK with a static JSON body. Placed outside auth middleware
+/// so that unauthenticated probes succeed.
+pub async fn healthz() -> Json<serde_json::Value> {
+    Json(serde_json::json!({"status": "ok"}))
 }
 
 // ---------------------------------------------------------------

--- a/src/http/routes.rs
+++ b/src/http/routes.rs
@@ -6,10 +6,10 @@ use axum::routing::{delete, get, post, put};
 use super::handlers::{
     AppState, certified_write, eventual_write, get_authority_definition, get_certification_status,
     get_certified, get_eventual, get_internal_frontiers, get_metrics, get_policy, get_slo,
-    get_topology, get_version_history, internal_announce, internal_delta_sync, internal_join,
-    internal_keys, internal_leave, internal_ping, internal_sync, list_authorities, list_policies,
-    post_internal_frontiers, remove_policy, set_authority_definition, set_placement_policy,
-    verify_proof,
+    get_topology, get_version_history, healthz, internal_announce, internal_delta_sync,
+    internal_join, internal_keys, internal_leave, internal_ping, internal_sync, list_authorities,
+    list_policies, post_internal_frontiers, remove_policy, set_authority_definition,
+    set_placement_policy, verify_proof,
 };
 
 /// Build the HTTP API router with all endpoints.
@@ -86,6 +86,8 @@ pub fn router(state: Arc<AppState>) -> Router {
         .route("/api/topology", get(get_topology))
         .route("/api/metrics", get(get_metrics))
         .route("/api/slo", get(get_slo))
+        // Health check endpoint — outside auth middleware for load balancer probes.
+        .route("/healthz", get(healthz))
         .with_state(state)
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,8 @@ use tokio::sync::Mutex;
 
 use asteroidb_poc::api::certified::CertifiedApi;
 use asteroidb_poc::api::eventual::EventualApi;
+use asteroidb_poc::authority::bls::BlsKeypair;
+use asteroidb_poc::authority::certificate::{EpochManager, KeysetRegistry, KeysetVersion};
 use asteroidb_poc::compaction::CompactionEngine;
 use asteroidb_poc::control_plane::consensus::ControlPlaneConsensus;
 use asteroidb_poc::control_plane::system_namespace::{AuthorityDefinition, SystemNamespace};
@@ -34,6 +36,12 @@ fn authority_nodes() -> Vec<NodeId> {
 
 #[tokio::main]
 async fn main() {
+    // Initialize structured logging. Users control verbosity via RUST_LOG env var
+    // (e.g. RUST_LOG=info or RUST_LOG=asteroidb_poc=debug).
+    tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .init();
+
     // Load configuration: either from a config file or from individual env vars.
     let (node_id, bind_addr, advertise_addr, config_peer_registry) =
         match std::env::var("ASTEROIDB_CONFIG") {
@@ -190,6 +198,52 @@ async fn main() {
         ),
     ));
 
+    // Parse optional BLS key seed from environment variable.
+    // When set, the node generates a BLS keypair and enables BLS certificate mode.
+    let bls_config = std::env::var("ASTEROIDB_BLS_SEED").ok().map(|hex_seed| {
+        let bytes = hex::decode(&hex_seed).unwrap_or_else(|e| {
+            eprintln!("error: ASTEROIDB_BLS_SEED contains invalid hex: {e}");
+            std::process::exit(1);
+        });
+        let mut seed = [0u8; 32];
+        let len = bytes.len().min(32);
+        seed[..len].copy_from_slice(&bytes[..len]);
+        BlsConfig { seed }
+    });
+
+    // Wire keyset_registry and current_epoch from EpochManager when BLS is configured.
+    let epoch_config = asteroidb_poc::authority::certificate::EpochConfig::default();
+    let now_secs = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+    let epoch_manager = EpochManager::new(epoch_config.clone(), now_secs);
+    let current_epoch_val = epoch_manager.current_epoch(now_secs);
+
+    let keyset_registry = bls_config.as_ref().map(|bls_cfg| {
+        let keypair = BlsKeypair::generate(&bls_cfg.seed);
+        let mut registry = KeysetRegistry::new();
+        // Register an initial keyset (version 1) with an Ed25519 key derived from
+        // the same seed. The BLS public key is what matters for production verification.
+        let ed_signing_key = ed25519_dalek::SigningKey::from_bytes(&bls_cfg.seed);
+        let ed_verifying_key = ed_signing_key.verifying_key();
+        registry
+            .register_keyset(
+                KeysetVersion(1),
+                current_epoch_val,
+                vec![(node_id.clone(), ed_verifying_key)],
+            )
+            .expect("initial keyset registration should succeed");
+        // Register the BLS public key for this node.
+        registry
+            .register_bls_keys(
+                &KeysetVersion(1),
+                vec![(node_id.0.clone(), keypair.public_key)],
+            )
+            .expect("BLS key registration should succeed");
+        Arc::new(std::sync::RwLock::new(registry))
+    });
+
     // Build shared HTTP state.
     let state = Arc::new(AppState {
         eventual: Arc::clone(&eventual_api),
@@ -206,25 +260,12 @@ async fn main() {
         latency_model: Some(Arc::clone(&shared_latency_model)),
         cluster_nodes: Some(Arc::clone(&shared_cluster_nodes)),
         slo_tracker: Arc::clone(&slo_tracker),
-        keyset_registry: None,
-        epoch_config: asteroidb_poc::authority::certificate::EpochConfig::default(),
-        current_epoch: Arc::new(std::sync::atomic::AtomicU64::new(0)),
+        keyset_registry,
+        epoch_config,
+        current_epoch: Arc::new(std::sync::atomic::AtomicU64::new(current_epoch_val)),
     });
 
     let app = router(state);
-
-    // Parse optional BLS key seed from environment variable.
-    // When set, the node generates a BLS keypair and enables BLS certificate mode.
-    let bls_config = std::env::var("ASTEROIDB_BLS_SEED").ok().map(|hex_seed| {
-        let bytes = hex::decode(&hex_seed).unwrap_or_else(|e| {
-            eprintln!("error: ASTEROIDB_BLS_SEED contains invalid hex: {e}");
-            std::process::exit(1);
-        });
-        let mut seed = [0u8; 32];
-        let len = bytes.len().min(32);
-        seed[..len].copy_from_slice(&bytes[..len]);
-        BlsConfig { seed }
-    });
 
     let runner_config = NodeRunnerConfig {
         bls_config,


### PR DESCRIPTION
## Summary
- Wire KeysetRegistry with BLS public key when ASTEROIDB_BLS_SEED is set
- Add tracing-subscriber with env-filter (RUST_LOG)
- Add GET /healthz endpoint for load balancer probes
- Guard EpochConfig against duration_secs=0
- Eliminate double iteration in internal_keys handler

🤖 Generated with [Claude Code](https://claude.com/claude-code)