### PR TITLE
feat: StorageBackend trait with File/Memory backends, BTreeMap prefix search (#251, #255)

### DIFF
--- a/src/store/backend.rs
+++ b/src/store/backend.rs
@@ -1,0 +1,243 @@
+use std::fs::File;
+use std::io;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+
+/// Abstraction over the persistence layer for snapshot storage.
+///
+/// Implementations are responsible for durably storing and retrieving
+/// opaque byte blobs (serialized store snapshots). The trait is
+/// object-safe so that `Store` can hold a `Box<dyn StorageBackend>`.
+pub trait StorageBackend: Send + Sync {
+    /// Persist `data` to the backend, replacing any previous content.
+    fn save(&self, data: &[u8]) -> io::Result<()>;
+
+    /// Load the most recently saved data, or `NotFound` if nothing has
+    /// been persisted yet.
+    fn load(&self) -> io::Result<Vec<u8>>;
+
+    /// Return `true` if a previous save exists.
+    fn exists(&self) -> bool;
+}
+
+// ---------------------------------------------------------------------------
+// FileBackend
+// ---------------------------------------------------------------------------
+
+/// File-based persistence backend using atomic write + fsync.
+///
+/// Writes go to a `.tmp` sibling file first, which is fsynced and then
+/// renamed over the target path. This prevents half-written snapshots on
+/// crash.
+#[derive(Debug, Clone)]
+pub struct FileBackend {
+    path: PathBuf,
+}
+
+impl FileBackend {
+    /// Create a new `FileBackend` that persists to `path`.
+    pub fn new(path: impl Into<PathBuf>) -> Self {
+        Self { path: path.into() }
+    }
+
+    /// Return the path this backend writes to.
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+impl StorageBackend for FileBackend {
+    fn save(&self, data: &[u8]) -> io::Result<()> {
+        if let Some(parent) = self.path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+
+        // Atomic write: temp file -> fsync -> rename.
+        let tmp_path = self.path.with_extension("tmp");
+        let mut file = File::create(&tmp_path)?;
+        file.write_all(data)?;
+        file.sync_all()?;
+        std::fs::rename(&tmp_path, &self.path)?;
+        Ok(())
+    }
+
+    fn load(&self) -> io::Result<Vec<u8>> {
+        std::fs::read(&self.path)
+    }
+
+    fn exists(&self) -> bool {
+        self.path.exists()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// MemoryBackend
+// ---------------------------------------------------------------------------
+
+/// In-memory persistence backend, useful for testing.
+///
+/// Data is stored in a `Mutex<Option<Vec<u8>>>`. The `Arc`-wrapped inner
+/// state allows cloning the backend to inspect saved data from test code.
+#[derive(Debug, Clone, Default)]
+pub struct MemoryBackend {
+    inner: Arc<Mutex<Option<Vec<u8>>>>,
+}
+
+impl MemoryBackend {
+    /// Create a new, empty `MemoryBackend`.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Return a clone of the stored data, if any.
+    pub fn data(&self) -> Option<Vec<u8>> {
+        self.inner.lock().unwrap().clone()
+    }
+}
+
+impl StorageBackend for MemoryBackend {
+    fn save(&self, data: &[u8]) -> io::Result<()> {
+        *self.inner.lock().unwrap() = Some(data.to_vec());
+        Ok(())
+    }
+
+    fn load(&self) -> io::Result<Vec<u8>> {
+        self.inner
+            .lock()
+            .unwrap()
+            .clone()
+            .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "no data saved"))
+    }
+
+    fn exists(&self) -> bool {
+        self.inner.lock().unwrap().is_some()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ---------------------------------------------------------------
+    // FileBackend
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn file_backend_save_and_load() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test.dat");
+        let backend = FileBackend::new(&path);
+
+        assert!(!backend.exists());
+
+        backend.save(b"hello world").unwrap();
+        assert!(backend.exists());
+
+        let data = backend.load().unwrap();
+        assert_eq!(data, b"hello world");
+    }
+
+    #[test]
+    fn file_backend_overwrite() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test.dat");
+        let backend = FileBackend::new(&path);
+
+        backend.save(b"first").unwrap();
+        backend.save(b"second").unwrap();
+
+        let data = backend.load().unwrap();
+        assert_eq!(data, b"second");
+    }
+
+    #[test]
+    fn file_backend_load_missing_returns_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("missing.dat");
+        let backend = FileBackend::new(&path);
+
+        let err = backend.load().unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::NotFound);
+    }
+
+    #[test]
+    fn file_backend_creates_parent_dirs() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("a").join("b").join("test.dat");
+        let backend = FileBackend::new(&path);
+
+        backend.save(b"nested").unwrap();
+        assert!(path.exists());
+    }
+
+    #[test]
+    fn file_backend_no_tmp_after_success() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test.dat");
+        let tmp_path = dir.path().join("test.tmp");
+        let backend = FileBackend::new(&path);
+
+        backend.save(b"data").unwrap();
+        assert!(path.exists());
+        assert!(!tmp_path.exists());
+    }
+
+    // ---------------------------------------------------------------
+    // MemoryBackend
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn memory_backend_save_and_load() {
+        let backend = MemoryBackend::new();
+
+        assert!(!backend.exists());
+
+        backend.save(b"hello").unwrap();
+        assert!(backend.exists());
+
+        let data = backend.load().unwrap();
+        assert_eq!(data, b"hello");
+    }
+
+    #[test]
+    fn memory_backend_overwrite() {
+        let backend = MemoryBackend::new();
+
+        backend.save(b"first").unwrap();
+        backend.save(b"second").unwrap();
+
+        let data = backend.load().unwrap();
+        assert_eq!(data, b"second");
+    }
+
+    #[test]
+    fn memory_backend_load_empty_returns_error() {
+        let backend = MemoryBackend::new();
+
+        let err = backend.load().unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::NotFound);
+    }
+
+    #[test]
+    fn memory_backend_data_accessor() {
+        let backend = MemoryBackend::new();
+        assert!(backend.data().is_none());
+
+        backend.save(b"peek").unwrap();
+        assert_eq!(backend.data(), Some(b"peek".to_vec()));
+    }
+
+    #[test]
+    fn memory_backend_clone_shares_state() {
+        let backend = MemoryBackend::new();
+        let clone = backend.clone();
+
+        backend.save(b"shared").unwrap();
+        assert_eq!(clone.load().unwrap(), b"shared");
+    }
+}

--- a/src/store/kv.rs
+++ b/src/store/kv.rs
@@ -1,7 +1,5 @@
-use std::collections::HashMap;
-use std::fs::File;
+use std::collections::{BTreeMap, HashMap};
 use std::io;
-use std::io::Write;
 use std::path::Path;
 
 use serde::{Deserialize, Serialize};
@@ -12,6 +10,7 @@ use crate::crdt::or_set::OrSet;
 use crate::crdt::pn_counter::PnCounter;
 use crate::error::CrdtError;
 use crate::hlc::HlcTimestamp;
+use crate::store::backend::{FileBackend, StorageBackend};
 use crate::store::migration;
 
 /// Current persistence format version written by this code.
@@ -56,19 +55,39 @@ impl CrdtValue {
 /// Provides basic CRUD operations, prefix-based key space partitioning,
 /// and CRDT-aware value merging with type checking. Supports HLC-based
 /// change tracking for delta sync.
+///
+/// The data map uses a `BTreeMap` for efficient O(log n + m) prefix range
+/// scans (see [`keys_with_prefix`](Self::keys_with_prefix)).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Store {
-    data: HashMap<String, CrdtValue>,
+    data: BTreeMap<String, CrdtValue>,
     /// Per-key HLC timestamp of the last modification, used for delta sync.
     #[serde(default)]
     timestamps: HashMap<String, HlcTimestamp>,
+}
+
+/// Compute the exclusive upper bound for a BTreeMap range scan.
+///
+/// Increments the last byte of `prefix` to produce a string that is
+/// lexicographically just past all strings that start with `prefix`.
+/// Returns `None` if the prefix consists entirely of `0xFF` bytes.
+fn prefix_upper_bound(prefix: &str) -> Option<String> {
+    let mut bytes = prefix.as_bytes().to_vec();
+    while let Some(last) = bytes.last_mut() {
+        if *last < 0xFF {
+            *last += 1;
+            return Some(String::from_utf8_lossy(&bytes).into_owned());
+        }
+        bytes.pop();
+    }
+    None
 }
 
 impl Store {
     /// Create a new, empty store.
     pub fn new() -> Self {
         Self {
-            data: HashMap::new(),
+            data: BTreeMap::new(),
             timestamps: HashMap::new(),
         }
     }
@@ -99,8 +118,26 @@ impl Store {
     }
 
     /// Return keys that start with the given prefix (FR-001 key space partitioning).
+    ///
+    /// Uses O(log n + m) BTreeMap range scan where m is the number of
+    /// matching keys, instead of O(n) full iteration.
     pub fn keys_with_prefix(&self, prefix: &str) -> Vec<&String> {
-        self.data.keys().filter(|k| k.starts_with(prefix)).collect()
+        if prefix.is_empty() {
+            return self.data.keys().collect();
+        }
+        if let Some(end) = prefix_upper_bound(prefix) {
+            self.data
+                .range::<String, _>(prefix.to_string()..end)
+                .map(|(k, _)| k)
+                .collect()
+        } else {
+            // Fallback: prefix is all 0xFF bytes -- scan from prefix to end.
+            self.data
+                .range::<String, _>(prefix.to_string()..)
+                .take_while(|(k, _)| k.starts_with(prefix))
+                .map(|(k, _)| k)
+                .collect()
+        }
     }
 
     /// Check whether the store contains a value for `key`.
@@ -134,10 +171,16 @@ impl Store {
 
     /// Save the store as a versioned JSON snapshot to the given path.
     ///
-    /// Uses atomic write (write to `.tmp` then rename) to prevent corruption
-    /// on crash. The snapshot includes a `format_version` field for forward
-    /// compatibility.
+    /// Uses a [`FileBackend`] internally for atomic write (write to `.tmp`
+    /// then rename) to prevent corruption on crash. The snapshot includes
+    /// a `format_version` field for forward compatibility.
     pub fn save_snapshot(&self, path: &Path) -> io::Result<()> {
+        let backend = FileBackend::new(path);
+        self.save_to_backend(&backend)
+    }
+
+    /// Save the store to an arbitrary [`StorageBackend`].
+    pub fn save_to_backend(&self, backend: &dyn StorageBackend) -> io::Result<()> {
         let store_value = serde_json::to_value(self)
             .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
         let envelope = PersistedStore {
@@ -146,27 +189,25 @@ impl Store {
         };
         let json = serde_json::to_string(&envelope)
             .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
-
-        if let Some(parent) = path.parent() {
-            std::fs::create_dir_all(parent)?;
-        }
-
-        // Atomic write: write to temp file, fsync, then rename.
-        let tmp_path = path.with_extension("tmp");
-        let mut file = File::create(&tmp_path)?;
-        file.write_all(json.as_bytes())?;
-        file.sync_all()?;
-        std::fs::rename(&tmp_path, path)?;
-        Ok(())
+        backend.save(json.as_bytes())
     }
 
     /// Load a store from a versioned JSON snapshot at the given path.
     ///
-    /// Detects the format version and applies migrations if the data was
-    /// written by an older version. Returns an error if the data version
-    /// is newer than what this code supports (forward incompatibility).
+    /// Uses a [`FileBackend`] internally. Detects the format version and
+    /// applies migrations if the data was written by an older version.
+    /// Returns an error if the data version is newer than what this code
+    /// supports (forward incompatibility).
     pub fn load_snapshot(path: &Path) -> io::Result<Self> {
-        let raw = std::fs::read_to_string(path)?;
+        let backend = FileBackend::new(path);
+        Self::load_from_backend(&backend)
+    }
+
+    /// Load a store from an arbitrary [`StorageBackend`].
+    pub fn load_from_backend(backend: &dyn StorageBackend) -> io::Result<Self> {
+        let bytes = backend.load()?;
+        let raw =
+            String::from_utf8(bytes).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
         Self::deserialize_snapshot(&raw)
     }
 
@@ -226,6 +267,16 @@ impl Store {
     /// prevent silent data loss.
     pub fn load_snapshot_or_default(path: &Path) -> io::Result<Self> {
         match Self::load_snapshot(path) {
+            Ok(store) => Ok(store),
+            Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(Self::default()),
+            Err(e) => Err(e),
+        }
+    }
+
+    /// Load a store from a backend, falling back to an empty store when
+    /// no data has been saved yet.
+    pub fn load_from_backend_or_default(backend: &dyn StorageBackend) -> io::Result<Self> {
+        match Self::load_from_backend(backend) {
             Ok(store) => Ok(store),
             Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(Self::default()),
             Err(e) => Err(e),
@@ -1298,5 +1349,109 @@ mod tests {
             Some(CrdtValue::Counter(c)) => assert_eq!(c.value(), 1),
             other => panic!("expected Counter, got {:?}", other),
         }
+    }
+
+    // ---------------------------------------------------------------
+    // StorageBackend integration (#251)
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn save_and_load_via_memory_backend() {
+        use crate::store::backend::MemoryBackend;
+
+        let backend = MemoryBackend::new();
+
+        let mut store = Store::new();
+        let mut counter = PnCounter::new();
+        counter.increment(&node("A"));
+        store.put("hits".into(), CrdtValue::Counter(counter));
+        store.record_change("hits", ts(100, 0, "N1"));
+
+        store.save_to_backend(&backend).unwrap();
+        assert!(backend.exists());
+
+        let loaded = Store::load_from_backend(&backend).unwrap();
+        assert_eq!(loaded.len(), 1);
+        match loaded.get("hits") {
+            Some(CrdtValue::Counter(c)) => assert_eq!(c.value(), 1),
+            other => panic!("expected Counter, got {:?}", other),
+        }
+        assert_eq!(loaded.timestamp_for("hits"), Some(&ts(100, 0, "N1")));
+    }
+
+    #[test]
+    fn load_from_backend_or_default_empty() {
+        use crate::store::backend::MemoryBackend;
+
+        let backend = MemoryBackend::new();
+        let store = Store::load_from_backend_or_default(&backend).unwrap();
+        assert!(store.is_empty());
+    }
+
+    #[test]
+    fn save_to_file_backend_matches_save_snapshot() {
+        use crate::store::backend::FileBackend;
+
+        let dir = tempfile::tempdir().unwrap();
+
+        // Save via save_snapshot (legacy API).
+        let path_a = dir.path().join("a.json");
+        let mut store = Store::new();
+        store.put("k".into(), CrdtValue::Counter(PnCounter::new()));
+        store.save_snapshot(&path_a).unwrap();
+
+        // Save via save_to_backend with FileBackend.
+        let path_b = dir.path().join("b.json");
+        let backend = FileBackend::new(&path_b);
+        store.save_to_backend(&backend).unwrap();
+
+        // Both should produce loadable stores.
+        let loaded_a = Store::load_snapshot(&path_a).unwrap();
+        let loaded_b = Store::load_from_backend(&backend).unwrap();
+        assert_eq!(loaded_a.len(), loaded_b.len());
+    }
+
+    // ---------------------------------------------------------------
+    // BTreeMap prefix scan optimization (#255)
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn btree_keys_with_prefix_returns_sorted() {
+        let mut store = Store::new();
+        store.put("user/zara".into(), CrdtValue::Counter(PnCounter::new()));
+        store.put("user/alice".into(), CrdtValue::Counter(PnCounter::new()));
+        store.put("user/bob".into(), CrdtValue::Counter(PnCounter::new()));
+        store.put("config/db".into(), CrdtValue::Counter(PnCounter::new()));
+
+        // BTreeMap range scan returns keys in sorted order.
+        let user_keys: Vec<&String> = store.keys_with_prefix("user/");
+        assert_eq!(user_keys, vec!["user/alice", "user/bob", "user/zara"]);
+    }
+
+    #[test]
+    fn prefix_upper_bound_helper() {
+        assert_eq!(super::prefix_upper_bound("abc"), Some("abd".to_string()));
+        assert_eq!(super::prefix_upper_bound("a"), Some("b".to_string()));
+        assert_eq!(
+            super::prefix_upper_bound("user/"),
+            Some("user0".to_string())
+        );
+        // Trailing 0x7E ('~') increments to 0x7F
+        assert_eq!(super::prefix_upper_bound("~"), Some("\x7F".to_string()));
+        // Empty prefix => None (no bytes to increment)
+        assert_eq!(super::prefix_upper_bound(""), None);
+    }
+
+    #[test]
+    fn keys_with_prefix_boundary_keys() {
+        let mut store = Store::new();
+        // Keys that are exactly at prefix boundaries.
+        store.put("abc".into(), CrdtValue::Counter(PnCounter::new()));
+        store.put("abd".into(), CrdtValue::Counter(PnCounter::new()));
+        store.put("ab".into(), CrdtValue::Counter(PnCounter::new()));
+        store.put("abcdef".into(), CrdtValue::Counter(PnCounter::new()));
+
+        let keys = store.keys_with_prefix("abc");
+        assert_eq!(keys, vec!["abc", "abcdef"]);
     }
 }

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -1,5 +1,7 @@
+pub mod backend;
 pub mod kv;
 pub mod migration;
 
+pub use backend::{FileBackend, MemoryBackend, StorageBackend};
 pub use kv::{CrdtValue, Store};
 pub use migration::{Migration, MigrationRegistry};


### PR DESCRIPTION
## Summary
- Define StorageBackend trait with FileBackend (atomic write) and MemoryBackend
- Refactor Store to support generic backends while keeping backward compat
- Change Store.data from HashMap to BTreeMap for O(log n + m) prefix range queries

Closes #251, closes #255

🤖 Generated with [Claude Code](https://claude.com/claude-code)