### PR TITLE
fix: add KvBackend trait with InMemory and Redb implementations (#251)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,6 +86,7 @@ dependencies = [
  "http-body-util",
  "proptest",
  "rand 0.8.5",
+ "redb",
  "reqwest",
  "serde",
  "serde_json",
@@ -1520,6 +1521,15 @@ checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
+]
+
+[[package]]
+name = "redb"
+version = "2.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eca1e9d98d5a7e9002d0013e18d5a9b000aee942eb134883a82f06ebffb6c01"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 subtle = "2"
 hex = "0.4"
+redb = "2"
 
 [dev-dependencies]
 tempfile = "3"

--- a/src/store/backend.rs
+++ b/src/store/backend.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::fs::File;
 use std::io;
 use std::io::Write;
@@ -112,6 +113,198 @@ impl StorageBackend for MemoryBackend {
 
     fn exists(&self) -> bool {
         self.inner.lock().unwrap().is_some()
+    }
+}
+
+// ===========================================================================
+// KvBackend — per-key operations for embedded storage
+// ===========================================================================
+
+/// Per-key storage abstraction for embedded persistent backends.
+///
+/// Unlike [`StorageBackend`] (which saves/loads opaque blobs for snapshot
+/// persistence), `KvBackend` exposes fine-grained key-value operations
+/// suitable for write-ahead or direct-persistence approaches.
+pub trait KvBackend: Send + Sync {
+    /// Return the value associated with `key`, or `None` if absent.
+    fn get(&self, key: &str) -> io::Result<Option<Vec<u8>>>;
+
+    /// Insert or overwrite the value for `key`.
+    fn put(&self, key: &str, value: &[u8]) -> io::Result<()>;
+
+    /// Remove `key` from the store. No-op if absent.
+    fn delete(&self, key: &str) -> io::Result<()>;
+
+    /// Return all entries whose key starts with `prefix`, sorted by key.
+    fn scan_prefix(&self, prefix: &str) -> io::Result<Vec<(String, Vec<u8>)>>;
+
+    /// Return all entries whose key is lexicographically >= `frontier`,
+    /// sorted by key. Useful for delta-sync catchup.
+    fn entries_since(&self, frontier: &[u8]) -> io::Result<Vec<(String, Vec<u8>)>>;
+}
+
+// ---------------------------------------------------------------------------
+// InMemoryKvBackend
+// ---------------------------------------------------------------------------
+
+/// In-memory `KvBackend` backed by a `BTreeMap`.
+///
+/// Useful for testing and as a drop-in when persistence is not required.
+#[derive(Debug, Clone, Default)]
+pub struct InMemoryKvBackend {
+    inner: Arc<Mutex<BTreeMap<String, Vec<u8>>>>,
+}
+
+impl InMemoryKvBackend {
+    /// Create a new, empty backend.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Return the number of stored entries (for test assertions).
+    pub fn len(&self) -> usize {
+        self.inner.lock().unwrap().len()
+    }
+
+    /// Return `true` if the store contains no entries.
+    pub fn is_empty(&self) -> bool {
+        self.inner.lock().unwrap().is_empty()
+    }
+}
+
+impl KvBackend for InMemoryKvBackend {
+    fn get(&self, key: &str) -> io::Result<Option<Vec<u8>>> {
+        Ok(self.inner.lock().unwrap().get(key).cloned())
+    }
+
+    fn put(&self, key: &str, value: &[u8]) -> io::Result<()> {
+        self.inner
+            .lock()
+            .unwrap()
+            .insert(key.to_owned(), value.to_vec());
+        Ok(())
+    }
+
+    fn delete(&self, key: &str) -> io::Result<()> {
+        self.inner.lock().unwrap().remove(key);
+        Ok(())
+    }
+
+    fn scan_prefix(&self, prefix: &str) -> io::Result<Vec<(String, Vec<u8>)>> {
+        let guard = self.inner.lock().unwrap();
+        let results: Vec<(String, Vec<u8>)> = guard
+            .range(prefix.to_owned()..)
+            .take_while(|(k, _)| k.starts_with(prefix))
+            .map(|(k, v)| (k.clone(), v.clone()))
+            .collect();
+        Ok(results)
+    }
+
+    fn entries_since(&self, frontier: &[u8]) -> io::Result<Vec<(String, Vec<u8>)>> {
+        let frontier_str = String::from_utf8_lossy(frontier);
+        let guard = self.inner.lock().unwrap();
+        let results: Vec<(String, Vec<u8>)> = guard
+            .range(frontier_str.as_ref().to_owned()..)
+            .map(|(k, v)| (k.clone(), v.clone()))
+            .collect();
+        Ok(results)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// RedbBackend
+// ---------------------------------------------------------------------------
+
+/// Persistent `KvBackend` backed by [redb](https://docs.rs/redb).
+///
+/// Uses a single B+tree table for all key-value pairs. Provides ACID
+/// transactions and is pure-Rust, making it suitable for WASM targets.
+pub struct RedbBackend {
+    db: redb::Database,
+}
+
+const TABLE: redb::TableDefinition<&str, &[u8]> = redb::TableDefinition::new("kv");
+
+impl RedbBackend {
+    /// Open (or create) a redb database at `path`.
+    pub fn open(path: impl AsRef<Path>) -> io::Result<Self> {
+        let db = redb::Database::create(path.as_ref()).map_err(io::Error::other)?;
+        Ok(Self { db })
+    }
+}
+
+impl KvBackend for RedbBackend {
+    fn get(&self, key: &str) -> io::Result<Option<Vec<u8>>> {
+        let tx = self.db.begin_read().map_err(io::Error::other)?;
+        let table = match tx.open_table(TABLE) {
+            Ok(t) => t,
+            Err(redb::TableError::TableDoesNotExist(_)) => return Ok(None),
+            Err(e) => return Err(io::Error::other(e)),
+        };
+        match table.get(key) {
+            Ok(Some(val)) => Ok(Some(val.value().to_vec())),
+            Ok(None) => Ok(None),
+            Err(e) => Err(io::Error::other(e)),
+        }
+    }
+
+    fn put(&self, key: &str, value: &[u8]) -> io::Result<()> {
+        let tx = self.db.begin_write().map_err(io::Error::other)?;
+        {
+            let mut table = tx.open_table(TABLE).map_err(io::Error::other)?;
+            table.insert(key, value).map_err(io::Error::other)?;
+        }
+        tx.commit().map_err(io::Error::other)?;
+        Ok(())
+    }
+
+    fn delete(&self, key: &str) -> io::Result<()> {
+        let tx = self.db.begin_write().map_err(io::Error::other)?;
+        {
+            let mut table = tx.open_table(TABLE).map_err(io::Error::other)?;
+            table.remove(key).map_err(io::Error::other)?;
+        }
+        tx.commit().map_err(io::Error::other)?;
+        Ok(())
+    }
+
+    fn scan_prefix(&self, prefix: &str) -> io::Result<Vec<(String, Vec<u8>)>> {
+        let tx = self.db.begin_read().map_err(io::Error::other)?;
+        let table = match tx.open_table(TABLE) {
+            Ok(t) => t,
+            Err(redb::TableError::TableDoesNotExist(_)) => return Ok(Vec::new()),
+            Err(e) => return Err(io::Error::other(e)),
+        };
+        let iter = table.range(prefix..).map_err(io::Error::other)?;
+        let mut results = Vec::new();
+        for entry in iter {
+            let entry = entry.map_err(io::Error::other)?;
+            let k = entry.0.value().to_owned();
+            if !k.starts_with(prefix) {
+                break;
+            }
+            results.push((k, entry.1.value().to_vec()));
+        }
+        Ok(results)
+    }
+
+    fn entries_since(&self, frontier: &[u8]) -> io::Result<Vec<(String, Vec<u8>)>> {
+        let frontier_str = String::from_utf8_lossy(frontier);
+        let tx = self.db.begin_read().map_err(io::Error::other)?;
+        let table = match tx.open_table(TABLE) {
+            Ok(t) => t,
+            Err(redb::TableError::TableDoesNotExist(_)) => return Ok(Vec::new()),
+            Err(e) => return Err(io::Error::other(e)),
+        };
+        let iter = table
+            .range(frontier_str.as_ref()..)
+            .map_err(io::Error::other)?;
+        let mut results = Vec::new();
+        for entry in iter {
+            let entry = entry.map_err(io::Error::other)?;
+            results.push((entry.0.value().to_owned(), entry.1.value().to_vec()));
+        }
+        Ok(results)
     }
 }
 
@@ -239,5 +432,121 @@ mod tests {
 
         backend.save(b"shared").unwrap();
         assert_eq!(clone.load().unwrap(), b"shared");
+    }
+
+    // ---------------------------------------------------------------
+    // KvBackend — shared conformance suite
+    // ---------------------------------------------------------------
+
+    /// Run the standard KvBackend conformance suite against any impl.
+    fn kv_backend_conformance(b: &dyn KvBackend) {
+        // get on missing key
+        assert!(b.get("missing").unwrap().is_none());
+
+        // put + get
+        b.put("key1", b"val1").unwrap();
+        assert_eq!(b.get("key1").unwrap(), Some(b"val1".to_vec()));
+
+        // overwrite
+        b.put("key1", b"val1-updated").unwrap();
+        assert_eq!(b.get("key1").unwrap(), Some(b"val1-updated".to_vec()));
+
+        // delete
+        b.delete("key1").unwrap();
+        assert!(b.get("key1").unwrap().is_none());
+
+        // delete non-existent is no-op
+        b.delete("no-such-key").unwrap();
+
+        // scan_prefix
+        b.put("user:1", b"alice").unwrap();
+        b.put("user:2", b"bob").unwrap();
+        b.put("user:3", b"carol").unwrap();
+        b.put("order:1", b"o1").unwrap();
+
+        let users = b.scan_prefix("user:").unwrap();
+        assert_eq!(users.len(), 3);
+        assert_eq!(users[0].0, "user:1");
+        assert_eq!(users[1].0, "user:2");
+        assert_eq!(users[2].0, "user:3");
+
+        let orders = b.scan_prefix("order:").unwrap();
+        assert_eq!(orders.len(), 1);
+        assert_eq!(orders[0].0, "order:1");
+
+        // empty prefix scan
+        let none = b.scan_prefix("zzz:").unwrap();
+        assert!(none.is_empty());
+
+        // entries_since
+        let since = b.entries_since(b"user:2").unwrap();
+        assert!(since.len() >= 2); // user:2, user:3
+        assert_eq!(since[0].0, "user:2");
+        assert_eq!(since[1].0, "user:3");
+    }
+
+    // ---------------------------------------------------------------
+    // InMemoryKvBackend
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn in_memory_kv_conformance() {
+        let b = InMemoryKvBackend::new();
+        kv_backend_conformance(&b);
+    }
+
+    #[test]
+    fn in_memory_kv_len_and_is_empty() {
+        let b = InMemoryKvBackend::new();
+        assert!(b.is_empty());
+        assert_eq!(b.len(), 0);
+
+        b.put("a", b"1").unwrap();
+        assert!(!b.is_empty());
+        assert_eq!(b.len(), 1);
+
+        b.delete("a").unwrap();
+        assert!(b.is_empty());
+    }
+
+    // ---------------------------------------------------------------
+    // RedbBackend
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn redb_kv_conformance() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test.redb");
+        let b = RedbBackend::open(&path).unwrap();
+        kv_backend_conformance(&b);
+    }
+
+    #[test]
+    fn redb_persistence_across_reopen() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("reopen.redb");
+
+        {
+            let b = RedbBackend::open(&path).unwrap();
+            b.put("persist", b"data").unwrap();
+        }
+
+        // Re-open the same database file and verify data survives.
+        let b = RedbBackend::open(&path).unwrap();
+        assert_eq!(b.get("persist").unwrap(), Some(b"data".to_vec()));
+    }
+
+    #[test]
+    fn redb_delete_and_scan_empty() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("del.redb");
+        let b = RedbBackend::open(&path).unwrap();
+
+        b.put("x", b"1").unwrap();
+        b.delete("x").unwrap();
+        assert!(b.get("x").unwrap().is_none());
+
+        let all = b.scan_prefix("").unwrap();
+        assert!(all.is_empty());
     }
 }

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -2,6 +2,8 @@ pub mod backend;
 pub mod kv;
 pub mod migration;
 
-pub use backend::{FileBackend, MemoryBackend, StorageBackend};
+pub use backend::{
+    FileBackend, InMemoryKvBackend, KvBackend, MemoryBackend, RedbBackend, StorageBackend,
+};
 pub use kv::{CrdtValue, Store};
 pub use migration::{Migration, MigrationRegistry};


### PR DESCRIPTION
## Summary
- Add `KvBackend` trait with `get`, `put`, `delete`, `scan_prefix`, `entries_since` methods
- Implement `InMemoryKvBackend` using `Arc<Mutex<BTreeMap>>`
- Implement `RedbBackend` with ACID transactions via redb crate
- Add comprehensive test suite (conformance, persistence, edge cases)

Closes #251

## Test plan
- [x] `cargo fmt --check` clean
- [x] `cargo clippy -- -D warnings` clean  
- [x] All 883 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)