### PR TITLE
fix: wire TombstoneGc and compaction into runtime (#252, #253)

### DIFF
--- a/src/api/certified.rs
+++ b/src/api/certified.rs
@@ -625,6 +625,14 @@ impl CertifiedApi {
         self.frontiers.all()
     }
 
+    /// Return a reference to the underlying `AckFrontierSet`.
+    ///
+    /// Useful for runtime components that need to query frontier state
+    /// (e.g., compaction eligibility, GC version floor derivation).
+    pub fn frontier_set(&self) -> &AckFrontierSet {
+        &self.frontiers
+    }
+
     /// Fence a (key_range, policy_version) pair in the frontier set.
     ///
     /// After fencing, all subsequent frontier updates for this combination

--- a/src/crdt/gc.rs
+++ b/src/crdt/gc.rs
@@ -30,6 +30,13 @@ pub struct TombstoneGc {
     /// A dot `(node_id, counter)` with `counter < version_floor[node_id]`
     /// is safe to garbage-collect (assuming it is not in any live element).
     version_floor: HashMap<NodeId, u64>,
+    /// Global version floor applied to ALL writer nodes.
+    ///
+    /// Derived from the minimum acknowledged frontier HLC physical timestamp
+    /// across all authorities. When set, a dot `(node_id, counter)` with
+    /// `counter < global_floor` is considered safe to GC regardless of the
+    /// per-node floor entries.
+    global_floor: Option<u64>,
     /// Configurable interval between GC runs.
     pub gc_interval: Duration,
     /// Minimum time tombstones must be retained after creation.
@@ -48,6 +55,7 @@ impl Default for TombstoneGc {
     fn default() -> Self {
         Self {
             version_floor: HashMap::new(),
+            global_floor: None,
             gc_interval: Duration::from_secs(60),
             retention_period: Duration::from_secs(300),
             last_gc_ms: 0,
@@ -61,6 +69,7 @@ impl TombstoneGc {
     pub fn new(gc_interval: Duration, retention_period: Duration) -> Self {
         Self {
             version_floor: HashMap::new(),
+            global_floor: None,
             gc_interval,
             retention_period,
             last_gc_ms: 0,
@@ -89,6 +98,19 @@ impl TombstoneGc {
     /// Return the current version floor for a node, if known.
     pub fn floor_for(&self, node_id: &NodeId) -> Option<u64> {
         self.version_floor.get(node_id).copied()
+    }
+
+    /// Set the global version floor that applies to ALL writer nodes.
+    ///
+    /// Typically set to the minimum acknowledged frontier HLC physical
+    /// timestamp across all authorities.
+    pub fn set_global_floor(&mut self, floor: u64) {
+        self.global_floor = Some(floor);
+    }
+
+    /// Return the current global version floor, if set.
+    pub fn global_floor(&self) -> Option<u64> {
+        self.global_floor
     }
 
     /// Return the wall-clock timestamp (ms) of the last GC run.
@@ -126,19 +148,34 @@ impl TombstoneGc {
         }
 
         let mut collected = 0u64;
+        let has_floor = !self.version_floor.is_empty() || self.global_floor.is_some();
 
         for key in store.keys().into_iter().cloned().collect::<Vec<_>>() {
             if let Some(value) = store.get_mut(&key) {
                 match value {
                     CrdtValue::Set(set) => {
                         let before = set.deferred_len();
-                        set.compact_deferred();
+                        if has_floor {
+                            set.compact_deferred_with_floor(
+                                &self.version_floor,
+                                self.global_floor,
+                            );
+                        } else {
+                            set.compact_deferred();
+                        }
                         let after = set.deferred_len();
                         collected += before.saturating_sub(after) as u64;
                     }
                     CrdtValue::Map(map) => {
                         let before = map.deferred_len();
-                        map.compact_deferred();
+                        if has_floor {
+                            map.compact_deferred_with_floor(
+                                &self.version_floor,
+                                self.global_floor,
+                            );
+                        } else {
+                            map.compact_deferred();
+                        }
                         let after = map.deferred_len();
                         collected += before.saturating_sub(after) as u64;
                     }

--- a/src/crdt/or_map.rs
+++ b/src/crdt/or_map.rs
@@ -225,6 +225,39 @@ where
         });
     }
 
+    /// Remove tombstone dots from `deferred` that satisfy **both** the local
+    /// counter check and a cross-replica version floor check.
+    ///
+    /// See [`OrSet::compact_deferred_with_floor`] for detailed semantics.
+    pub fn compact_deferred_with_floor(
+        &mut self,
+        version_floor: &std::collections::HashMap<crate::types::NodeId, u64>,
+        global_floor: Option<u64>,
+    ) {
+        let live_dots: HashSet<&Dot> = self
+            .entries
+            .values()
+            .flat_map(|(dots, _)| dots.iter())
+            .collect();
+        self.deferred.retain(|d| {
+            if live_dots.contains(d) {
+                return true;
+            }
+            let locally_dominated = match self.counters.get(&d.node_id) {
+                Some(&max_counter) => d.counter < max_counter,
+                None => false,
+            };
+            if !locally_dominated {
+                return true;
+            }
+            let effective_floor = version_floor.get(&d.node_id).copied().or(global_floor);
+            match effective_floor {
+                Some(floor) => d.counter >= floor,
+                None => true,
+            }
+        });
+    }
+
     /// Return the number of present keys.
     pub fn len(&self) -> usize {
         self.entries

--- a/src/crdt/or_set.rs
+++ b/src/crdt/or_set.rs
@@ -195,6 +195,44 @@ where
             }
         });
     }
+
+    /// Remove tombstone dots from `deferred` that satisfy **both** the local
+    /// counter check and a cross-replica version floor check.
+    ///
+    /// A dot `(node_id, counter)` is removed when:
+    /// 1. It is not referenced by any live element, AND
+    /// 2. `counter < max_counter` for that node (local dominance), AND
+    /// 3. `counter < floor` where `floor` is the per-node floor from
+    ///    `version_floor`, falling back to `global_floor` if no per-node
+    ///    entry exists.
+    pub fn compact_deferred_with_floor(
+        &mut self,
+        version_floor: &std::collections::HashMap<NodeId, u64>,
+        global_floor: Option<u64>,
+    ) {
+        let live_dots: HashSet<&Dot> = self
+            .elements
+            .values()
+            .flat_map(|dots| dots.iter())
+            .collect();
+        self.deferred.retain(|d| {
+            if live_dots.contains(d) {
+                return true;
+            }
+            let locally_dominated = match self.counters.get(&d.node_id) {
+                Some(&max_counter) => d.counter < max_counter,
+                None => false,
+            };
+            if !locally_dominated {
+                return true;
+            }
+            let effective_floor = version_floor.get(&d.node_id).copied().or(global_floor);
+            match effective_floor {
+                Some(floor) => d.counter >= floor,
+                None => true,
+            }
+        });
+    }
 }
 
 impl<T: Eq + Hash + Clone + Serialize + DeserializeOwned> Default for OrSet<T> {

--- a/src/runtime/node_runner.rs
+++ b/src/runtime/node_runner.rs
@@ -1654,55 +1654,93 @@ impl NodeRunner {
         // in production.
         let pending_ops = self.metrics.write_ops_total.swap(0, Ordering::Relaxed);
 
-        let api = self.certified_api.lock().await;
-        let ns = api.namespace().read().unwrap();
+        let (defs, frontier_set) = {
+            let api = self.certified_api.lock().await;
+            let ns = api.namespace().read().unwrap();
 
-        // Iterate over all authority definitions to check each key range.
-        let defs: Vec<_> = ns
-            .all_authority_definitions()
-            .into_iter()
-            .map(|def| (def.key_range.clone(), def.authority_nodes.len()))
-            .collect();
+            // Iterate over all authority definitions to check each key range.
+            let defs: Vec<_> = ns
+                .all_authority_definitions()
+                .into_iter()
+                .map(|def| (def.key_range.clone(), def.authority_nodes.len()))
+                .collect();
 
-        // Distribute drained write ops across key ranges. With a single
-        // key range (common case) all ops go to it; with multiple ranges
-        // each gets an equal share (approximation).
-        if pending_ops > 0 && !defs.is_empty() {
-            let ops_per_range = pending_ops / defs.len() as u64;
-            let remainder = pending_ops % defs.len() as u64;
-            for (i, (key_range, _)) in defs.iter().enumerate() {
-                let ops = ops_per_range + if (i as u64) < remainder { 1 } else { 0 };
-                for _ in 0..ops {
-                    self.compaction_engine.record_op(key_range);
+            // Distribute drained write ops across key ranges.
+            if pending_ops > 0 && !defs.is_empty() {
+                let ops_per_range = pending_ops / defs.len() as u64;
+                let remainder = pending_ops % defs.len() as u64;
+                for (i, (key_range, _)) in defs.iter().enumerate() {
+                    let ops = ops_per_range + if (i as u64) < remainder { 1 } else { 0 };
+                    for _ in 0..ops {
+                        self.compaction_engine.record_op(key_range);
+                    }
                 }
             }
-        }
 
-        for (key_range, _total_authorities) in &defs {
-            if self.compaction_engine.should_checkpoint(key_range, &now) {
-                // Create a checkpoint with a placeholder digest.
-                // In a full implementation this would compute an actual digest
-                // over the store data for this key range.
-                let policy_version = ns
-                    .get_placement_policy(&key_range.prefix)
-                    .map(|p| p.version)
-                    .unwrap_or(crate::types::PolicyVersion(1));
+            for (key_range, _total_authorities) in &defs {
+                if self.compaction_engine.should_checkpoint(key_range, &now) {
+                    let policy_version = ns
+                        .get_placement_policy(&key_range.prefix)
+                        .map(|p| p.version)
+                        .unwrap_or(crate::types::PolicyVersion(1));
 
+                    let digest = format!("digest-{}-{}", key_range.prefix, now.physical);
+                    self.compaction_engine.create_checkpoint(
+                        key_range.clone(),
+                        now.clone(),
+                        digest,
+                        policy_version,
+                    );
+                }
+            }
+
+            let fs = api.frontier_set().clone();
+            (defs, fs)
+        };
+
+        // After checkpoint creation, run compaction to prune old timestamps.
+        // This wires run_compaction into the runtime so that timestamp pruning
+        // actually happens in production (Gap #253).
+        if let Some(ref eventual_api) = self.eventual_api {
+            let mut ev_api = eventual_api.lock().await;
+            let store = ev_api.store_mut();
+            for (key_range, total_authorities) in &defs {
+                let policy_version = {
+                    let certified_api = self.certified_api.lock().await;
+                    let ns = certified_api.namespace().read().unwrap();
+                    ns.get_placement_policy(&key_range.prefix)
+                        .map(|p| p.version)
+                        .unwrap_or(crate::types::PolicyVersion(1))
+                };
                 let digest = format!("digest-{}-{}", key_range.prefix, now.physical);
-                self.compaction_engine.create_checkpoint(
-                    key_range.clone(),
+                let pruned = self.compaction_engine.run_compaction(
+                    key_range,
                     now.clone(),
                     digest,
                     policy_version,
+                    &frontier_set,
+                    *total_authorities,
+                    store,
                 );
+                if pruned > 0 {
+                    tracing::info!(
+                        node_id = %self.node_id.0,
+                        key_range = %key_range.prefix,
+                        pruned,
+                        "compaction pruned old timestamps"
+                    );
+                }
             }
         }
     }
 
     /// Run tombstone GC on the eventual store (if available).
     ///
-    /// Acquires the store lock, runs `gc_tombstones()` on all CRDT values,
-    /// and logs the number of tombstones collected.
+    /// Before running GC, populates the version floor from the
+    /// `AckFrontierSet` so that tombstones are only reclaimed after all
+    /// authorities have acknowledged them. For each authority's frontier,
+    /// extracts the HLC physical timestamp as a proxy counter and uses it
+    /// to set the GC version floor.
     async fn run_gc(&mut self) {
         let now_ms = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
@@ -1711,6 +1749,29 @@ impl NodeRunner {
 
         if !self.tombstone_gc.should_run(now_ms) {
             return;
+        }
+
+        // Populate the global version floor from the ack frontier set.
+        // The global minimum HLC physical timestamp across all authority
+        // frontiers serves as the floor: any dot with a counter below this
+        // value has been acknowledged by every authority and is safe to GC.
+        {
+            let api = self.certified_api.lock().await;
+            let frontiers = api.all_frontiers();
+            if !frontiers.is_empty() {
+                let global_min = frontiers
+                    .iter()
+                    .map(|f| f.frontier_hlc.physical)
+                    .min()
+                    .unwrap();
+                self.tombstone_gc.set_global_floor(global_min);
+
+                // Also set per-authority floors for completeness.
+                for frontier in &frontiers {
+                    self.tombstone_gc
+                        .set_floor(&frontier.authority_id, frontier.frontier_hlc.physical);
+                }
+            }
         }
 
         if let Some(ref eventual_api) = self.eventual_api {


### PR DESCRIPTION
## Summary
- Wire `version_floor` from ack_frontier into `TombstoneGc::gc_tombstones()` via global floor
- Connect `CompactionEngine::run_compaction()` into NodeRunner's compaction check loop
- Add `compact_deferred_with_floor()` for OrSet and OrMap CRDT types with global_floor fallback
- Add `frontier_set()` accessor on CertifiedApi for runtime components

Closes #252
Closes #253

## Test plan
- [x] `cargo fmt --check` clean
- [x] `cargo clippy -- -D warnings` clean
- [x] All 878+ tests pass (0 failures)
- [x] New `gc_tick_collects_tombstones_through_runtime` integration test
- [x] New `compaction_prunes_timestamps_after_checkpoint` integration test

🤖 Generated with [Claude Code](https://claude.com/claude-code)