### PR TITLE
feat: add full sync fallback on high change rate (#262)

### DIFF
--- a/src/crdt/gc.rs
+++ b/src/crdt/gc.rs
@@ -156,10 +156,7 @@ impl TombstoneGc {
                     CrdtValue::Set(set) => {
                         let before = set.deferred_len();
                         if has_floor {
-                            set.compact_deferred_with_floor(
-                                &self.version_floor,
-                                self.global_floor,
-                            );
+                            set.compact_deferred_with_floor(&self.version_floor, self.global_floor);
                         } else {
                             set.compact_deferred();
                         }
@@ -169,10 +166,7 @@ impl TombstoneGc {
                     CrdtValue::Map(map) => {
                         let before = map.deferred_len();
                         if has_floor {
-                            map.compact_deferred_with_floor(
-                                &self.version_floor,
-                                self.global_floor,
-                            );
+                            map.compact_deferred_with_floor(&self.version_floor, self.global_floor);
                         } else {
                             map.compact_deferred();
                         }

--- a/src/network/sync.rs
+++ b/src/network/sync.rs
@@ -216,6 +216,30 @@ pub const DEFAULT_BATCH_SIZE: usize = 100;
 /// the bandwidth savings.
 pub const MAX_DELTA_PAYLOAD_BYTES: usize = 512 * 1024; // 512 KiB
 
+/// Default change rate threshold for triggering full sync fallback.
+///
+/// When the ratio `changed_keys / total_keys` exceeds this value during
+/// delta sync, the delta payload is nearly as large as a full dump, so
+/// the system falls back to pushing the full state instead.
+pub const DEFAULT_FULL_SYNC_THRESHOLD: f64 = 0.5;
+
+/// Check whether the change rate exceeds the threshold for full sync fallback.
+///
+/// Returns `true` when `changed_keys / total_keys > threshold`, indicating
+/// that delta sync loses its advantage and full sync should be used.
+/// Returns `false` when `total_keys` is zero (empty store, no fallback needed).
+pub fn should_fallback_to_full_sync(
+    changed_keys: usize,
+    total_keys: usize,
+    threshold: f64,
+) -> bool {
+    if total_keys == 0 {
+        return false;
+    }
+    let rate = changed_keys as f64 / total_keys as f64;
+    rate > threshold
+}
+
 /// Tracks per-peer delta frontiers for efficient delta sync.
 ///
 /// Maintains the last-acknowledged HLC frontier for each peer, enabling
@@ -1100,5 +1124,64 @@ mod tests {
     fn frontier_tracker_default() {
         let tracker = PeerFrontierTracker::default();
         assert_eq!(tracker.peer_count(), 0);
+    }
+
+    // ---------------------------------------------------------------
+    // Full sync fallback threshold tests
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn fallback_low_change_rate_returns_false() {
+        // 10 changed out of 100 total = 10% < 50% threshold
+        assert!(!super::should_fallback_to_full_sync(10, 100, 0.5));
+    }
+
+    #[test]
+    fn fallback_at_threshold_returns_false() {
+        // Exactly at 50% threshold should NOT trigger fallback (> not >=)
+        assert!(!super::should_fallback_to_full_sync(50, 100, 0.5));
+    }
+
+    #[test]
+    fn fallback_above_threshold_returns_true() {
+        // 51 changed out of 100 total = 51% > 50% threshold
+        assert!(super::should_fallback_to_full_sync(51, 100, 0.5));
+    }
+
+    #[test]
+    fn fallback_all_keys_changed_returns_true() {
+        // 100% change rate > any threshold < 1.0
+        assert!(super::should_fallback_to_full_sync(100, 100, 0.5));
+    }
+
+    #[test]
+    fn fallback_empty_store_returns_false() {
+        // Empty store should never trigger fallback
+        assert!(!super::should_fallback_to_full_sync(0, 0, 0.5));
+    }
+
+    #[test]
+    fn fallback_zero_changes_returns_false() {
+        // No changes should never trigger fallback
+        assert!(!super::should_fallback_to_full_sync(0, 100, 0.5));
+    }
+
+    #[test]
+    fn fallback_custom_threshold_low() {
+        // With a 20% threshold, 25 out of 100 should trigger
+        assert!(super::should_fallback_to_full_sync(25, 100, 0.2));
+        assert!(!super::should_fallback_to_full_sync(15, 100, 0.2));
+    }
+
+    #[test]
+    fn fallback_custom_threshold_high() {
+        // With a 90% threshold, only very high rates should trigger
+        assert!(!super::should_fallback_to_full_sync(89, 100, 0.9));
+        assert!(super::should_fallback_to_full_sync(91, 100, 0.9));
+    }
+
+    #[test]
+    fn fallback_default_threshold_constant() {
+        assert!((super::DEFAULT_FULL_SYNC_THRESHOLD - 0.5).abs() < f64::EPSILON);
     }
 }

--- a/src/ops/metrics.rs
+++ b/src/ops/metrics.rs
@@ -271,6 +271,15 @@ pub struct RuntimeMetrics {
     /// Cumulative count of delta-fail -> full-sync fallback events.
     pub sync_fallback_total: AtomicU64,
 
+    /// Cumulative number of delta syncs performed (push phase).
+    pub delta_sync_count: AtomicU64,
+
+    /// Cumulative number of full sync fallbacks triggered by high change rate.
+    ///
+    /// When the ratio of changed keys to total keys exceeds the configured
+    /// threshold, delta sync is skipped and full state is pushed instead.
+    pub full_sync_fallback_count: AtomicU64,
+
     /// Cumulative number of rebalance operations started.
     pub rebalance_start_total: AtomicU64,
 
@@ -322,6 +331,8 @@ impl Default for RuntimeMetrics {
             sync_failure_total: AtomicU64::default(),
             sync_attempt_total: AtomicU64::default(),
             sync_fallback_total: AtomicU64::default(),
+            delta_sync_count: AtomicU64::default(),
+            full_sync_fallback_count: AtomicU64::default(),
             rebalance_start_total: AtomicU64::default(),
             rebalance_keys_migrated: AtomicU64::default(),
             rebalance_keys_failed: AtomicU64::default(),
@@ -365,6 +376,19 @@ impl RuntimeMetrics {
         }
         let failures = self.sync_failure_total.load(Ordering::Relaxed);
         failures as f64 / attempts as f64
+    }
+
+    /// Get the ratio of full sync fallbacks to total delta syncs (0.0 to 1.0).
+    ///
+    /// Returns 0.0 when no syncs have been performed yet.
+    pub fn full_sync_fallback_ratio(&self) -> f64 {
+        let delta = self.delta_sync_count.load(Ordering::Relaxed);
+        let full = self.full_sync_fallback_count.load(Ordering::Relaxed);
+        let total = delta + full;
+        if total == 0 {
+            return 0.0;
+        }
+        full as f64 / total as f64
     }
 
     /// Record a successful sync operation for a specific peer.
@@ -499,6 +523,9 @@ impl RuntimeMetrics {
             key_rotation_last_version: self.key_rotation_last_version.load(Ordering::Relaxed),
             key_rotation_last_time_ms: self.key_rotation_last_time_ms.load(Ordering::Relaxed),
             write_ops_total: self.write_ops_total.load(Ordering::Relaxed),
+            delta_sync_count: self.delta_sync_count.load(Ordering::Relaxed),
+            full_sync_fallback_count: self.full_sync_fallback_count.load(Ordering::Relaxed),
+            full_sync_fallback_ratio: self.full_sync_fallback_ratio(),
         }
     }
 }
@@ -566,6 +593,12 @@ pub struct MetricsSnapshot {
     pub key_rotation_last_time_ms: u64,
     /// Cumulative write operations (eventual + certified) for compaction tracking.
     pub write_ops_total: u64,
+    /// Cumulative number of delta syncs performed (push phase).
+    pub delta_sync_count: u64,
+    /// Cumulative number of full sync fallbacks triggered by high change rate.
+    pub full_sync_fallback_count: u64,
+    /// Ratio of full sync fallbacks to total syncs (0.0 to 1.0).
+    pub full_sync_fallback_ratio: f64,
 }
 
 #[cfg(test)]
@@ -917,5 +950,63 @@ mod tests {
         assert!(json.contains("\"node-1\""));
         assert!(json.contains("\"certification_latency_window\""));
         assert!(json.contains("\"sample_count\":1"));
+    }
+
+    // ---------------------------------------------------------------
+    // Delta/full sync fallback metrics tests
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn full_sync_fallback_ratio_zero_when_no_syncs() {
+        let m = RuntimeMetrics::default();
+        assert_eq!(m.full_sync_fallback_ratio(), 0.0);
+    }
+
+    #[test]
+    fn full_sync_fallback_ratio_all_delta() {
+        let m = RuntimeMetrics::default();
+        m.delta_sync_count.store(10, Ordering::Relaxed);
+        m.full_sync_fallback_count.store(0, Ordering::Relaxed);
+        assert_eq!(m.full_sync_fallback_ratio(), 0.0);
+    }
+
+    #[test]
+    fn full_sync_fallback_ratio_all_full() {
+        let m = RuntimeMetrics::default();
+        m.delta_sync_count.store(0, Ordering::Relaxed);
+        m.full_sync_fallback_count.store(5, Ordering::Relaxed);
+        assert_eq!(m.full_sync_fallback_ratio(), 1.0);
+    }
+
+    #[test]
+    fn full_sync_fallback_ratio_mixed() {
+        let m = RuntimeMetrics::default();
+        m.delta_sync_count.store(7, Ordering::Relaxed);
+        m.full_sync_fallback_count.store(3, Ordering::Relaxed);
+        assert!((m.full_sync_fallback_ratio() - 0.3).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn snapshot_includes_delta_full_sync_counts() {
+        let m = RuntimeMetrics::default();
+        m.delta_sync_count.store(42, Ordering::Relaxed);
+        m.full_sync_fallback_count.store(8, Ordering::Relaxed);
+
+        let snap = m.snapshot();
+        assert_eq!(snap.delta_sync_count, 42);
+        assert_eq!(snap.full_sync_fallback_count, 8);
+        assert!((snap.full_sync_fallback_ratio - 0.16).abs() < 0.01);
+
+        let json = serde_json::to_string(&snap).unwrap();
+        assert!(json.contains("\"delta_sync_count\":42"));
+        assert!(json.contains("\"full_sync_fallback_count\":8"));
+        assert!(json.contains("\"full_sync_fallback_ratio\":"));
+    }
+
+    #[test]
+    fn delta_sync_count_defaults_to_zero() {
+        let m = RuntimeMetrics::default();
+        assert_eq!(m.delta_sync_count.load(Ordering::Relaxed), 0);
+        assert_eq!(m.full_sync_fallback_count.load(Ordering::Relaxed), 0);
     }
 }

--- a/src/runtime/node_runner.rs
+++ b/src/runtime/node_runner.rs
@@ -16,7 +16,9 @@ use crate::control_plane::system_namespace::SystemNamespace;
 use crate::crdt::gc::TombstoneGc;
 use crate::hlc::{Hlc, HlcTimestamp};
 use crate::network::membership::MembershipClient;
-use crate::network::sync::{DEFAULT_BATCH_SIZE, PeerBackoff, SyncClient};
+use crate::network::sync::{
+    DEFAULT_BATCH_SIZE, PeerBackoff, SyncClient, should_fallback_to_full_sync,
+};
 use crate::node::Node;
 use crate::ops::metrics::RuntimeMetrics;
 use crate::ops::slo::{SLO_AUTHORITY_AVAILABILITY, SLO_REPLICATION_CONVERGENCE, SloTracker};
@@ -81,6 +83,13 @@ pub struct NodeRunnerConfig {
     /// Grace period in seconds after fencing before entries become eligible
     /// for GC. Default: 300 seconds (5 minutes).
     pub frontier_gc_grace_period_secs: u64,
+    /// Change rate threshold for falling back to full sync.
+    ///
+    /// When the ratio `changed_keys / total_keys` exceeds this threshold
+    /// during the push phase, delta sync is skipped and the full state is
+    /// pushed to the peer instead, because the delta payload is nearly as
+    /// large as a full dump. Default: 0.5 (50%).
+    pub full_sync_threshold: f64,
 }
 
 impl Default for NodeRunnerConfig {
@@ -99,6 +108,7 @@ impl Default for NodeRunnerConfig {
             frontier_gc_interval: Duration::from_secs(60),
             frontier_gc_max_retained_versions: 2,
             frontier_gc_grace_period_secs: 300,
+            full_sync_threshold: 0.5,
         }
     }
 }
@@ -1329,8 +1339,12 @@ impl NodeRunner {
             }
 
             // --- Push phase: send only changed local keys to peer ---
+            // When the change rate is too high (changed_keys / total_keys > threshold),
+            // delta sync payload approaches full-state size and loses its advantage.
+            // In that case, skip delta and push the full state directly.
             if let Some(frontier) = self.peer_frontiers.get(&peer_key) {
                 let api = eventual_api.lock().await;
+                let total_keys = api.store().len();
                 // entries_since returns entries sorted by HLC; split into
                 // (key, value) pairs for push and a parallel HLC vec for
                 // frontier tracking, avoiding a second clone of every entry.
@@ -1339,80 +1353,141 @@ impl NodeRunner {
                     crate::store::kv::CrdtValue,
                     crate::hlc::HlcTimestamp,
                 )> = api.store().entries_since(frontier);
-                drop(api);
-
                 let changed_count = entries_with_hlc.len();
-                // Separate HLCs (cheap Copy-like fields) from owned key-value
-                // pairs so push_changed_keys can take ownership without an
-                // extra clone of every CrdtValue.
-                let hlc_vec: Vec<crate::hlc::HlcTimestamp> = entries_with_hlc
-                    .iter()
-                    .map(|(_, _, hlc)| hlc.clone())
-                    .collect();
-                let changed: Vec<(String, crate::store::kv::CrdtValue)> = entries_with_hlc
-                    .into_iter()
-                    .map(|(key, value, _hlc)| (key, value))
-                    .collect();
 
-                if !changed.is_empty() {
-                    let push_result = sync_client
-                        .push_changed_keys(&peer.addr, changed, &self.node_id.0, DEFAULT_BATCH_SIZE)
+                // Compute change rate and decide whether to use delta or full sync.
+                let change_rate = if total_keys > 0 {
+                    changed_count as f64 / total_keys as f64
+                } else {
+                    0.0
+                };
+
+                if should_fallback_to_full_sync(
+                    changed_count,
+                    total_keys,
+                    self.config.full_sync_threshold,
+                ) {
+                    // High change rate: fall back to full state push.
+                    let all_entries: HashMap<String, crate::store::kv::CrdtValue> = api
+                        .store()
+                        .all_entries()
+                        .map(|(k, v)| (k.clone(), v.clone()))
+                        .collect();
+                    drop(api);
+
+                    tracing::info!(
+                        peer = %peer.node_id.0,
+                        change_rate = %format!("{:.2}", change_rate),
+                        threshold = %format!("{:.2}", self.config.full_sync_threshold),
+                        changed_keys = changed_count,
+                        total_keys = total_keys,
+                        "change rate exceeds threshold, falling back to full sync push"
+                    );
+
+                    self.metrics
+                        .full_sync_fallback_count
+                        .fetch_add(1, Ordering::Relaxed);
+
+                    let push_count = sync_client
+                        .push_all_keys(all_entries, &self.node_id.0)
                         .await;
 
-                    match push_result {
-                        Ok(pushed) => {
-                            tracing::debug!(
-                                peer = %peer.node_id.0,
-                                pushed_keys = pushed,
-                                total_changed = changed_count,
-                                "delta push succeeded"
-                            );
-                            // Record replication convergence SLO: time from
-                            // entry write (HLC physical) to push completion.
-                            if let Some(slo) = &self.slo_tracker {
-                                let now_ms = self.clock.now().physical;
-                                for hlc in hlc_vec.iter().take(pushed) {
-                                    let convergence_ms = now_ms.saturating_sub(hlc.physical) as f64;
-                                    slo.record_observation(
-                                        SLO_REPLICATION_CONVERGENCE,
-                                        convergence_ms,
-                                    );
+                    if push_count > 0 {
+                        // After a successful full push, advance the frontier to
+                        // the local store's current frontier so the next delta
+                        // sync starts from the right point.
+                        let api = eventual_api.lock().await;
+                        if let Some(current) = api.store().current_frontier() {
+                            self.peer_frontiers.insert(peer_key.clone(), current);
+                        }
+                        drop(api);
+                    }
+                } else {
+                    drop(api);
+
+                    // Normal delta push path.
+                    // Separate HLCs (cheap Copy-like fields) from owned key-value
+                    // pairs so push_changed_keys can take ownership without an
+                    // extra clone of every CrdtValue.
+                    let hlc_vec: Vec<crate::hlc::HlcTimestamp> = entries_with_hlc
+                        .iter()
+                        .map(|(_, _, hlc)| hlc.clone())
+                        .collect();
+                    let changed: Vec<(String, crate::store::kv::CrdtValue)> = entries_with_hlc
+                        .into_iter()
+                        .map(|(key, value, _hlc)| (key, value))
+                        .collect();
+
+                    if !changed.is_empty() {
+                        self.metrics
+                            .delta_sync_count
+                            .fetch_add(1, Ordering::Relaxed);
+
+                        let push_result = sync_client
+                            .push_changed_keys(
+                                &peer.addr,
+                                changed,
+                                &self.node_id.0,
+                                DEFAULT_BATCH_SIZE,
+                            )
+                            .await;
+
+                        match push_result {
+                            Ok(pushed) => {
+                                tracing::debug!(
+                                    peer = %peer.node_id.0,
+                                    pushed_keys = pushed,
+                                    total_changed = changed_count,
+                                    "delta push succeeded"
+                                );
+                                // Record replication convergence SLO: time from
+                                // entry write (HLC physical) to push completion.
+                                if let Some(slo) = &self.slo_tracker {
+                                    let now_ms = self.clock.now().physical;
+                                    for hlc in hlc_vec.iter().take(pushed) {
+                                        let convergence_ms =
+                                            now_ms.saturating_sub(hlc.physical) as f64;
+                                        slo.record_observation(
+                                            SLO_REPLICATION_CONVERGENCE,
+                                            convergence_ms,
+                                        );
+                                    }
+                                }
+                                // Advance peer frontier to the max HLC of the
+                                // pushed batch — NOT current_frontier(), which may
+                                // have advanced past unpushed concurrent writes.
+                                if let Some(max_hlc) = hlc_vec.last() {
+                                    self.peer_frontiers
+                                        .insert(peer_key.clone(), max_hlc.clone());
                                 }
                             }
-                            // Advance peer frontier to the max HLC of the
-                            // pushed batch — NOT current_frontier(), which may
-                            // have advanced past unpushed concurrent writes.
-                            if let Some(max_hlc) = hlc_vec.last() {
-                                self.peer_frontiers
-                                    .insert(peer_key.clone(), max_hlc.clone());
+                            Err(e) => {
+                                tracing::warn!(
+                                    peer = %peer.node_id.0,
+                                    error = %e,
+                                    pushed = e.pushed,
+                                    "delta push failed"
+                                );
+                                // On partial failure, advance the frontier only to
+                                // the HLC of the last successfully pushed entry.
+                                // hlc_vec is sorted by HLC, so index
+                                // `pushed - 1` is the last entry that was sent.
+                                if e.pushed > 0
+                                    && let Some(last_pushed_hlc) = hlc_vec.get(e.pushed - 1)
+                                {
+                                    self.peer_frontiers
+                                        .insert(peer_key.clone(), last_pushed_hlc.clone());
+                                }
+                                // Record failure and move to next peer.
+                                self.peer_backoffs
+                                    .entry(peer_key.clone())
+                                    .or_default()
+                                    .record_failure();
+                                self.metrics
+                                    .sync_failure_total
+                                    .fetch_add(1, Ordering::Relaxed);
+                                continue;
                             }
-                        }
-                        Err(e) => {
-                            tracing::warn!(
-                                peer = %peer.node_id.0,
-                                error = %e,
-                                pushed = e.pushed,
-                                "delta push failed"
-                            );
-                            // On partial failure, advance the frontier only to
-                            // the HLC of the last successfully pushed entry.
-                            // hlc_vec is sorted by HLC, so index
-                            // `pushed - 1` is the last entry that was sent.
-                            if e.pushed > 0
-                                && let Some(last_pushed_hlc) = hlc_vec.get(e.pushed - 1)
-                            {
-                                self.peer_frontiers
-                                    .insert(peer_key.clone(), last_pushed_hlc.clone());
-                            }
-                            // Record failure and move to next peer.
-                            self.peer_backoffs
-                                .entry(peer_key.clone())
-                                .or_default()
-                                .record_failure();
-                            self.metrics
-                                .sync_failure_total
-                                .fetch_add(1, Ordering::Relaxed);
-                            continue;
                         }
                     }
                 }


### PR DESCRIPTION
## Summary
- Monitor per-peer change rate during delta sync (`changed_keys / total_keys`)
- Fall back to full sync when change ratio exceeds configurable threshold (default 50%)
- Record `delta_sync_count` and `full_sync_fallback_count` in RuntimeMetrics
- Add `full_sync_threshold` to `NodeRunnerConfig` for tunability

Closes #262

## Test plan
- [x] cargo fmt --check
- [x] cargo clippy -- -D warnings
- [x] All 964 unit tests pass
- [x] 9 new threshold tests in `sync::tests`
- [x] 6 new metrics tests in `ops::metrics::tests`

🤖 Generated with [Claude Code](https://claude.com/claude-code)