### PR TITLE
feat: migrate internal node communication to bincode (#266)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,6 +78,7 @@ name = "asteroidb-poc"
 version = "0.1.0"
 dependencies = [
  "axum",
+ "bincode",
  "blst",
  "clap",
  "criterion",
@@ -174,6 +175,26 @@ name = "base64ct"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
+name = "bincode"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36eaf5d7b090263e8150820482d5d93cd964a81e4019913c972f4edcc6edb740"
+dependencies = [
+ "bincode_derive",
+ "serde",
+ "unty",
+]
+
+[[package]]
+name = "bincode_derive"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf95709a440f45e986983918d0e8a1f30a9b1df04918fc828670606804ac3c09"
+dependencies = [
+ "virtue",
+]
 
 [[package]]
 name = "bit-set"
@@ -2248,6 +2269,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
+name = "unty"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2288,6 +2315,12 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "virtue"
+version = "0.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
 
 [[package]]
 name = "wait-timeout"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 subtle = "2"
 hex = "0.4"
 redb = "2"
+bincode = { version = "2", features = ["serde"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/src/crdt/gc.rs
+++ b/src/crdt/gc.rs
@@ -156,10 +156,7 @@ impl TombstoneGc {
                     CrdtValue::Set(set) => {
                         let before = set.deferred_len();
                         if has_floor {
-                            set.compact_deferred_with_floor(
-                                &self.version_floor,
-                                self.global_floor,
-                            );
+                            set.compact_deferred_with_floor(&self.version_floor, self.global_floor);
                         } else {
                             set.compact_deferred();
                         }
@@ -169,10 +166,7 @@ impl TombstoneGc {
                     CrdtValue::Map(map) => {
                         let before = map.deferred_len();
                         if has_floor {
-                            map.compact_deferred_with_floor(
-                                &self.version_floor,
-                                self.global_floor,
-                            );
+                            map.compact_deferred_with_floor(&self.version_floor, self.global_floor);
                         } else {
                             map.compact_deferred();
                         }

--- a/src/http/codec.rs
+++ b/src/http/codec.rs
@@ -1,0 +1,399 @@
+//! Content-Type based serialization/deserialization helpers for internal
+//! node-to-node communication.
+//!
+//! Supports two wire formats:
+//! - `application/octet-stream` — bincode (compact binary, default for internal traffic)
+//! - `application/json` — JSON (backward compatible fallback)
+//!
+//! External client-facing APIs are not affected and continue to use JSON exclusively.
+
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use serde::{Deserialize, Serialize};
+
+/// MIME type for bincode-encoded payloads.
+pub const CONTENT_TYPE_BINCODE: &str = "application/octet-stream";
+/// MIME type for JSON-encoded payloads.
+pub const CONTENT_TYPE_JSON: &str = "application/json";
+
+/// Serialize `data` using the format requested by the `Accept` header.
+///
+/// If `accept` contains `application/octet-stream`, serializes as bincode.
+/// Otherwise falls back to JSON for backward compatibility.
+///
+/// Returns the serialized bytes and the Content-Type to set on the response.
+pub fn serialize_internal<T: Serialize>(
+    data: &T,
+    accept: Option<&str>,
+) -> Result<(Vec<u8>, &'static str), SerializationError> {
+    if accepts_bincode(accept) {
+        let bytes = bincode::serde::encode_to_vec(data, bincode::config::standard())
+            .map_err(|e| SerializationError(format!("bincode encode: {e}")))?;
+        Ok((bytes, CONTENT_TYPE_BINCODE))
+    } else {
+        let bytes = serde_json::to_vec(data)
+            .map_err(|e| SerializationError(format!("json encode: {e}")))?;
+        Ok((bytes, CONTENT_TYPE_JSON))
+    }
+}
+
+/// Deserialize `bytes` using the format indicated by the `Content-Type` header.
+///
+/// If `content_type` contains `application/octet-stream`, deserializes as bincode.
+/// Otherwise falls back to JSON.
+pub fn deserialize_internal<T: for<'de> Deserialize<'de>>(
+    bytes: &[u8],
+    content_type: Option<&str>,
+) -> Result<T, SerializationError> {
+    if is_bincode_content_type(content_type) {
+        let (val, _len) = bincode::serde::decode_from_slice(bytes, bincode::config::standard())
+            .map_err(|e| SerializationError(format!("bincode decode: {e}")))?;
+        Ok(val)
+    } else {
+        serde_json::from_slice(bytes).map_err(|e| SerializationError(format!("json decode: {e}")))
+    }
+}
+
+/// Check whether the `Accept` header value indicates bincode preference.
+pub fn accepts_bincode(accept: Option<&str>) -> bool {
+    accept
+        .map(|a| a.contains(CONTENT_TYPE_BINCODE))
+        .unwrap_or(false)
+}
+
+/// Check whether the `Content-Type` header value indicates bincode.
+pub fn is_bincode_content_type(content_type: Option<&str>) -> bool {
+    content_type
+        .map(|ct| ct.contains(CONTENT_TYPE_BINCODE))
+        .unwrap_or(false)
+}
+
+/// Error type for serialization/deserialization failures.
+#[derive(Debug, Clone)]
+pub struct SerializationError(pub String);
+
+impl std::fmt::Display for SerializationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "serialization error: {}", self.0)
+    }
+}
+
+impl std::error::Error for SerializationError {}
+
+impl IntoResponse for SerializationError {
+    fn into_response(self) -> Response {
+        (StatusCode::BAD_REQUEST, self.0).into_response()
+    }
+}
+
+/// Build an axum `Response` with the correct Content-Type for internal endpoints.
+///
+/// Checks the `Accept` header and serializes accordingly.
+pub fn internal_response<T: Serialize>(
+    data: &T,
+    accept: Option<&str>,
+) -> Result<Response, SerializationError> {
+    let (bytes, content_type) = serialize_internal(data, accept)?;
+    Ok(Response::builder()
+        .status(StatusCode::OK)
+        .header("content-type", content_type)
+        .body(axum::body::Body::from(bytes))
+        .unwrap())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    use crate::crdt::pn_counter::PnCounter;
+    use crate::hlc::HlcTimestamp;
+    use crate::network::sync::{
+        DeltaEntry, DeltaSyncRequest, DeltaSyncResponse, KeyDumpResponse, SyncError, SyncRequest,
+        SyncResponse,
+    };
+    use crate::store::kv::CrdtValue;
+    use crate::types::NodeId;
+
+    fn nid(s: &str) -> NodeId {
+        NodeId(s.into())
+    }
+
+    fn hlc(physical: u64, logical: u32, node: &str) -> HlcTimestamp {
+        HlcTimestamp {
+            physical,
+            logical,
+            node_id: node.into(),
+        }
+    }
+
+    // ---------------------------------------------------------------
+    // Bincode round-trip tests for all sync message types
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn bincode_roundtrip_sync_request() {
+        let mut entries = HashMap::new();
+        let mut counter = PnCounter::new();
+        counter.increment(&nid("node-1"));
+        entries.insert("key1".to_string(), CrdtValue::Counter(counter));
+
+        let req = SyncRequest {
+            sender: "node-1".to_string(),
+            entries,
+        };
+
+        let (bytes, ct) = serialize_internal(&req, Some(CONTENT_TYPE_BINCODE)).unwrap();
+        assert_eq!(ct, CONTENT_TYPE_BINCODE);
+
+        let decoded: SyncRequest =
+            deserialize_internal(&bytes, Some(CONTENT_TYPE_BINCODE)).unwrap();
+        assert_eq!(decoded.sender, "node-1");
+        assert!(decoded.entries.contains_key("key1"));
+    }
+
+    #[test]
+    fn bincode_roundtrip_sync_response() {
+        let resp = SyncResponse {
+            merged: 5,
+            errors: vec![SyncError {
+                key: "bad".into(),
+                error: "type mismatch".into(),
+            }],
+        };
+
+        let (bytes, ct) = serialize_internal(&resp, Some(CONTENT_TYPE_BINCODE)).unwrap();
+        assert_eq!(ct, CONTENT_TYPE_BINCODE);
+
+        let decoded: SyncResponse =
+            deserialize_internal(&bytes, Some(CONTENT_TYPE_BINCODE)).unwrap();
+        assert_eq!(decoded.merged, 5);
+        assert_eq!(decoded.errors.len(), 1);
+        assert_eq!(decoded.errors[0].key, "bad");
+    }
+
+    #[test]
+    fn bincode_roundtrip_delta_sync_request() {
+        let req = DeltaSyncRequest {
+            sender: "node-2".to_string(),
+            frontier: hlc(300, 1, "node-2"),
+        };
+
+        let (bytes, _) = serialize_internal(&req, Some(CONTENT_TYPE_BINCODE)).unwrap();
+        let decoded: DeltaSyncRequest =
+            deserialize_internal(&bytes, Some(CONTENT_TYPE_BINCODE)).unwrap();
+        assert_eq!(decoded.sender, "node-2");
+        assert_eq!(decoded.frontier.physical, 300);
+        assert_eq!(decoded.frontier.logical, 1);
+    }
+
+    #[test]
+    fn bincode_roundtrip_delta_sync_response() {
+        let mut counter = PnCounter::new();
+        counter.increment(&nid("node-1"));
+
+        let resp = DeltaSyncResponse {
+            entries: vec![DeltaEntry {
+                key: "key1".into(),
+                value: CrdtValue::Counter(counter),
+                hlc: hlc(200, 0, "node-1"),
+            }],
+            sender_frontier: Some(hlc(200, 0, "node-1")),
+        };
+
+        let (bytes, _) = serialize_internal(&resp, Some(CONTENT_TYPE_BINCODE)).unwrap();
+        let decoded: DeltaSyncResponse =
+            deserialize_internal(&bytes, Some(CONTENT_TYPE_BINCODE)).unwrap();
+        assert_eq!(decoded.entries.len(), 1);
+        assert_eq!(decoded.entries[0].key, "key1");
+        assert_eq!(decoded.sender_frontier.unwrap().physical, 200);
+    }
+
+    #[test]
+    fn bincode_roundtrip_key_dump_response() {
+        let mut entries = HashMap::new();
+        let mut counter = PnCounter::new();
+        counter.increment(&nid("node-1"));
+        entries.insert("hits".to_string(), CrdtValue::Counter(counter));
+
+        let mut timestamps = HashMap::new();
+        timestamps.insert("hits".to_string(), hlc(500, 0, "node-1"));
+
+        let resp = KeyDumpResponse {
+            entries,
+            frontier: Some(hlc(500, 0, "node-1")),
+            timestamps,
+        };
+
+        let (bytes, _) = serialize_internal(&resp, Some(CONTENT_TYPE_BINCODE)).unwrap();
+        let decoded: KeyDumpResponse =
+            deserialize_internal(&bytes, Some(CONTENT_TYPE_BINCODE)).unwrap();
+        assert!(decoded.entries.contains_key("hits"));
+        assert_eq!(decoded.frontier.unwrap().physical, 500);
+        assert_eq!(decoded.timestamps.get("hits").unwrap().physical, 500);
+    }
+
+    #[test]
+    fn bincode_roundtrip_frontier_push_request() {
+        use crate::authority::ack_frontier::AckFrontier;
+        use crate::network::frontier_sync::{
+            FrontierPullResponse, FrontierPushRequest, FrontierPushResponse,
+        };
+        use crate::types::{KeyRange, PolicyVersion};
+
+        let req = FrontierPushRequest {
+            frontiers: vec![AckFrontier {
+                authority_id: nid("auth-1"),
+                frontier_hlc: hlc(100, 0, "auth-1"),
+                key_range: KeyRange {
+                    prefix: "user/".into(),
+                },
+                policy_version: PolicyVersion(1),
+                digest_hash: "hash-1".into(),
+            }],
+        };
+
+        let (bytes, _) = serialize_internal(&req, Some(CONTENT_TYPE_BINCODE)).unwrap();
+        let decoded: FrontierPushRequest =
+            deserialize_internal(&bytes, Some(CONTENT_TYPE_BINCODE)).unwrap();
+        assert_eq!(decoded.frontiers.len(), 1);
+        assert_eq!(decoded.frontiers[0].authority_id, nid("auth-1"));
+
+        // Also test FrontierPushResponse
+        let resp = FrontierPushResponse { accepted: 3 };
+        let (bytes, _) = serialize_internal(&resp, Some(CONTENT_TYPE_BINCODE)).unwrap();
+        let decoded: FrontierPushResponse =
+            deserialize_internal(&bytes, Some(CONTENT_TYPE_BINCODE)).unwrap();
+        assert_eq!(decoded.accepted, 3);
+
+        // Also test FrontierPullResponse
+        let pull_resp = FrontierPullResponse {
+            frontiers: vec![AckFrontier {
+                authority_id: nid("auth-2"),
+                frontier_hlc: hlc(200, 0, "auth-2"),
+                key_range: KeyRange {
+                    prefix: "order/".into(),
+                },
+                policy_version: PolicyVersion(2),
+                digest_hash: "hash-2".into(),
+            }],
+        };
+        let (bytes, _) = serialize_internal(&pull_resp, Some(CONTENT_TYPE_BINCODE)).unwrap();
+        let decoded: FrontierPullResponse =
+            deserialize_internal(&bytes, Some(CONTENT_TYPE_BINCODE)).unwrap();
+        assert_eq!(decoded.frontiers.len(), 1);
+        assert_eq!(decoded.frontiers[0].key_range.prefix, "order/");
+    }
+
+    // ---------------------------------------------------------------
+    // JSON backward compatibility
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn json_fallback_when_no_accept_header() {
+        let req = SyncRequest {
+            sender: "node-1".to_string(),
+            entries: HashMap::new(),
+        };
+
+        let (bytes, ct) = serialize_internal(&req, None).unwrap();
+        assert_eq!(ct, CONTENT_TYPE_JSON);
+
+        // Should be valid JSON
+        let decoded: SyncRequest = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(decoded.sender, "node-1");
+    }
+
+    #[test]
+    fn json_fallback_when_accept_is_json() {
+        let req = SyncRequest {
+            sender: "node-1".to_string(),
+            entries: HashMap::new(),
+        };
+
+        let (bytes, ct) = serialize_internal(&req, Some(CONTENT_TYPE_JSON)).unwrap();
+        assert_eq!(ct, CONTENT_TYPE_JSON);
+
+        let decoded: SyncRequest = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(decoded.sender, "node-1");
+    }
+
+    #[test]
+    fn json_deserialization_when_content_type_is_json() {
+        let req = SyncRequest {
+            sender: "node-1".to_string(),
+            entries: HashMap::new(),
+        };
+
+        let json_bytes = serde_json::to_vec(&req).unwrap();
+        let decoded: SyncRequest =
+            deserialize_internal(&json_bytes, Some(CONTENT_TYPE_JSON)).unwrap();
+        assert_eq!(decoded.sender, "node-1");
+    }
+
+    #[test]
+    fn json_deserialization_when_content_type_is_none() {
+        let req = SyncRequest {
+            sender: "node-1".to_string(),
+            entries: HashMap::new(),
+        };
+
+        let json_bytes = serde_json::to_vec(&req).unwrap();
+        let decoded: SyncRequest = deserialize_internal(&json_bytes, None).unwrap();
+        assert_eq!(decoded.sender, "node-1");
+    }
+
+    // ---------------------------------------------------------------
+    // Content-Type negotiation helpers
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn accepts_bincode_detects_octet_stream() {
+        assert!(accepts_bincode(Some("application/octet-stream")));
+        assert!(accepts_bincode(Some(
+            "application/octet-stream, application/json"
+        )));
+    }
+
+    #[test]
+    fn accepts_bincode_rejects_json() {
+        assert!(!accepts_bincode(Some("application/json")));
+        assert!(!accepts_bincode(None));
+    }
+
+    #[test]
+    fn is_bincode_content_type_detects_octet_stream() {
+        assert!(is_bincode_content_type(Some("application/octet-stream")));
+        assert!(!is_bincode_content_type(Some("application/json")));
+        assert!(!is_bincode_content_type(None));
+    }
+
+    // ---------------------------------------------------------------
+    // Payload size comparison (bincode vs JSON)
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn bincode_is_smaller_than_json() {
+        let mut entries = HashMap::new();
+        for i in 0..10 {
+            let mut counter = PnCounter::new();
+            counter.increment(&nid("node-1"));
+            entries.insert(format!("key-{i}"), CrdtValue::Counter(counter));
+        }
+
+        let req = SyncRequest {
+            sender: "node-1".to_string(),
+            entries,
+        };
+
+        let json_bytes = serde_json::to_vec(&req).unwrap();
+        let (bincode_bytes, _) = serialize_internal(&req, Some(CONTENT_TYPE_BINCODE)).unwrap();
+
+        assert!(
+            bincode_bytes.len() < json_bytes.len(),
+            "bincode ({} bytes) should be smaller than JSON ({} bytes)",
+            bincode_bytes.len(),
+            json_bytes.len()
+        );
+    }
+}

--- a/src/http/handlers.rs
+++ b/src/http/handlers.rs
@@ -3,8 +3,13 @@ use std::sync::{Arc, RwLock};
 use std::time::Instant;
 
 use axum::Json;
+use axum::body::Bytes;
 use axum::extract::{Path, State};
+use axum::http::HeaderMap;
+use axum::response::Response;
 use tokio::sync::Mutex;
+
+use super::codec::{deserialize_internal, internal_response};
 
 use crate::api::certified::{CertifiedApi, OnTimeout};
 use crate::api::eventual::EventualApi;
@@ -289,8 +294,15 @@ pub async fn get_certification_status(
 /// `AckFrontierSet`. Monotonicity is enforced by `AckFrontierSet::update()`.
 pub async fn post_internal_frontiers(
     State(state): State<Arc<AppState>>,
-    Json(req): Json<crate::network::frontier_sync::FrontierPushRequest>,
-) -> Json<crate::network::frontier_sync::FrontierPushResponse> {
+    headers: HeaderMap,
+    body: Bytes,
+) -> Result<Response, super::codec::SerializationError> {
+    let content_type = headers.get("content-type").and_then(|v| v.to_str().ok());
+    let accept = headers.get("accept").and_then(|v| v.to_str().ok());
+
+    let req: crate::network::frontier_sync::FrontierPushRequest =
+        deserialize_internal(&body, content_type)?;
+
     let mut api = state.certified.lock().await;
     let mut accepted = 0;
     for frontier in req.frontiers {
@@ -298,7 +310,8 @@ pub async fn post_internal_frontiers(
             accepted += 1;
         }
     }
-    Json(crate::network::frontier_sync::FrontierPushResponse { accepted })
+    let resp = crate::network::frontier_sync::FrontierPushResponse { accepted };
+    internal_response(&resp, accept)
 }
 
 /// `GET /api/internal/frontiers`
@@ -306,10 +319,14 @@ pub async fn post_internal_frontiers(
 /// Returns all frontiers currently tracked by this node.
 pub async fn get_internal_frontiers(
     State(state): State<Arc<AppState>>,
-) -> Json<crate::network::frontier_sync::FrontierPullResponse> {
+    headers: HeaderMap,
+) -> Result<Response, super::codec::SerializationError> {
+    let accept = headers.get("accept").and_then(|v| v.to_str().ok());
+
     let api = state.certified.lock().await;
     let frontiers = api.all_frontiers().into_iter().cloned().collect();
-    Json(crate::network::frontier_sync::FrontierPullResponse { frontiers })
+    let resp = crate::network::frontier_sync::FrontierPullResponse { frontiers };
+    internal_response(&resp, accept)
 }
 
 // ---------------------------------------------------------------
@@ -704,8 +721,14 @@ fn hex_to_bytes(hex: &str) -> Option<Vec<u8>> {
 /// local eventual store using `merge_remote`.
 pub async fn internal_sync(
     State(state): State<Arc<AppState>>,
-    Json(req): Json<SyncRequest>,
-) -> Json<SyncResponse> {
+    headers: HeaderMap,
+    body: Bytes,
+) -> Result<Response, super::codec::SerializationError> {
+    let content_type = headers.get("content-type").and_then(|v| v.to_str().ok());
+    let accept = headers.get("accept").and_then(|v| v.to_str().ok());
+
+    let req: SyncRequest = deserialize_internal(&body, content_type)?;
+
     let mut api = state.eventual.lock().await;
     let mut merged = 0;
     let mut errors = Vec::new();
@@ -722,7 +745,8 @@ pub async fn internal_sync(
         }
     }
 
-    Json(SyncResponse { merged, errors })
+    let resp = SyncResponse { merged, errors };
+    internal_response(&resp, accept)
 }
 
 /// `GET /api/internal/keys`
@@ -731,7 +755,12 @@ pub async fn internal_sync(
 /// store's current frontier HLC. Used by remote peers for pull-based
 /// anti-entropy sync. The frontier allows the requester to correctly
 /// initialise its peer frontier tracking after a full sync.
-pub async fn internal_keys(State(state): State<Arc<AppState>>) -> Json<KeyDumpResponse> {
+pub async fn internal_keys(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+) -> Result<Response, super::codec::SerializationError> {
+    let accept = headers.get("accept").and_then(|v| v.to_str().ok());
+
     let api = state.eventual.lock().await;
     let store = api.store();
     let mut entries = std::collections::HashMap::new();
@@ -750,11 +779,12 @@ pub async fn internal_keys(State(state): State<Arc<AppState>>) -> Json<KeyDumpRe
     }
     let frontier = store.current_frontier();
 
-    Json(KeyDumpResponse {
+    let resp = KeyDumpResponse {
         entries,
         frontier,
         timestamps,
-    })
+    };
+    internal_response(&resp, accept)
 }
 
 /// `POST /api/internal/sync/delta`
@@ -764,8 +794,14 @@ pub async fn internal_keys(State(state): State<Arc<AppState>>) -> Json<KeyDumpRe
 /// anti-entropy sync.
 pub async fn internal_delta_sync(
     State(state): State<Arc<AppState>>,
-    Json(req): Json<DeltaSyncRequest>,
-) -> Json<DeltaSyncResponse> {
+    headers: HeaderMap,
+    body: Bytes,
+) -> Result<Response, super::codec::SerializationError> {
+    let content_type = headers.get("content-type").and_then(|v| v.to_str().ok());
+    let accept = headers.get("accept").and_then(|v| v.to_str().ok());
+
+    let req: DeltaSyncRequest = deserialize_internal(&body, content_type)?;
+
     let api = state.eventual.lock().await;
     let store = api.store();
 
@@ -777,10 +813,11 @@ pub async fn internal_delta_sync(
 
     let sender_frontier = store.current_frontier();
 
-    Json(DeltaSyncResponse {
+    let resp = DeltaSyncResponse {
         entries,
         sender_frontier,
-    })
+    };
+    internal_response(&resp, accept)
 }
 
 // ---------------------------------------------------------------

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -1,4 +1,5 @@
 pub(crate) mod auth;
+pub mod codec;
 pub mod handlers;
 pub mod routes;
 pub mod types;

--- a/src/network/frontier_sync.rs
+++ b/src/network/frontier_sync.rs
@@ -3,6 +3,7 @@ use std::time::Duration;
 use serde::{Deserialize, Serialize};
 
 use crate::authority::ack_frontier::AckFrontier;
+use crate::http::codec::{self, CONTENT_TYPE_BINCODE, deserialize_internal, serialize_internal};
 
 /// Request body for pushing frontiers to a peer.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -80,47 +81,83 @@ impl FrontierSyncClient {
         builder
     }
 
+    /// Send a POST request with bincode-encoded body and Accept header.
+    ///
+    /// Falls back to JSON encoding if bincode serialization fails.
+    fn bincode_post<T: Serialize>(
+        &self,
+        url: &str,
+        data: &T,
+    ) -> Result<reqwest::RequestBuilder, codec::SerializationError> {
+        let (bytes, content_type) = serialize_internal(data, Some(CONTENT_TYPE_BINCODE))?;
+        Ok(self
+            .authorized_post(url)
+            .header("content-type", content_type)
+            .header("accept", CONTENT_TYPE_BINCODE)
+            .body(bytes))
+    }
+
+    /// Deserialize a response body based on the response's Content-Type header.
+    async fn decode_response<T: for<'de> Deserialize<'de>>(
+        resp: reqwest::Response,
+    ) -> Result<T, String> {
+        let content_type = resp
+            .headers()
+            .get("content-type")
+            .and_then(|v| v.to_str().ok())
+            .map(|s| s.to_string());
+        let bytes = resp.bytes().await.map_err(|e| e.to_string())?;
+        deserialize_internal(&bytes, content_type.as_deref()).map_err(|e| e.to_string())
+    }
+
     /// Push frontier updates to a remote peer.
     ///
     /// Sends a POST request to `http://{peer_addr}/api/internal/frontiers`
-    /// with the given frontiers serialised as JSON. The peer will apply
-    /// each frontier via `AckFrontierSet::update()`, which handles
-    /// monotonicity and deduplication.
+    /// with the given frontiers serialised as bincode (with JSON fallback).
+    /// The peer will apply each frontier via `AckFrontierSet::update()`,
+    /// which handles monotonicity and deduplication.
     ///
     /// Returns the number of frontiers accepted by the peer.
     pub async fn push_frontiers(
         &self,
         peer_addr: &str,
         frontiers: Vec<AckFrontier>,
-    ) -> Result<FrontierPushResponse, reqwest::Error> {
+    ) -> Result<FrontierPushResponse, Box<dyn std::error::Error + Send + Sync>> {
         let url = format!("http://{peer_addr}/api/internal/frontiers");
         let body = FrontierPushRequest { frontiers };
 
-        self.authorized_post(&url)
-            .json(&body)
-            .send()
-            .await?
-            .error_for_status()?
-            .json::<FrontierPushResponse>()
+        let req_builder = match self.bincode_post(&url, &body) {
+            Ok(b) => b,
+            Err(_) => self.authorized_post(&url).json(&body),
+        };
+
+        let resp = req_builder.send().await?.error_for_status()?;
+        Self::decode_response::<FrontierPushResponse>(resp)
             .await
+            .map_err(|e| -> Box<dyn std::error::Error + Send + Sync> { e.into() })
     }
 
     /// Pull all frontiers from a remote peer.
     ///
-    /// Sends a GET request to `http://{peer_addr}/api/internal/frontiers`.
-    /// The returned frontiers can be applied locally via `AckFrontierSet::update()`.
+    /// Sends a GET request to `http://{peer_addr}/api/internal/frontiers`
+    /// with Accept: application/octet-stream to request bincode responses.
+    /// Falls back to JSON if the peer responds with JSON.
     pub async fn pull_frontiers(
         &self,
         peer_addr: &str,
-    ) -> Result<FrontierPullResponse, reqwest::Error> {
+    ) -> Result<FrontierPullResponse, Box<dyn std::error::Error + Send + Sync>> {
         let url = format!("http://{peer_addr}/api/internal/frontiers");
 
-        self.authorized_get(&url)
+        let resp = self
+            .authorized_get(&url)
+            .header("accept", CONTENT_TYPE_BINCODE)
             .send()
             .await?
-            .error_for_status()?
-            .json::<FrontierPullResponse>()
+            .error_for_status()?;
+
+        Self::decode_response::<FrontierPullResponse>(resp)
             .await
+            .map_err(|e| -> Box<dyn std::error::Error + Send + Sync> { e.into() })
     }
 }
 

--- a/src/network/sync.rs
+++ b/src/network/sync.rs
@@ -6,6 +6,7 @@ use serde::{Deserialize, Serialize};
 use tokio::sync::Mutex;
 
 use crate::hlc::HlcTimestamp;
+use crate::http::codec::{self, CONTENT_TYPE_BINCODE, deserialize_internal, serialize_internal};
 use crate::network::peer::PeerRegistry;
 use crate::store::kv::CrdtValue;
 
@@ -365,6 +366,38 @@ impl SyncClient {
         builder
     }
 
+    /// Send a POST request with bincode-encoded body and Accept header.
+    ///
+    /// Falls back to JSON encoding if bincode serialization fails.
+    fn bincode_post<T: Serialize>(
+        &self,
+        url: &str,
+        data: &T,
+    ) -> Result<reqwest::RequestBuilder, codec::SerializationError> {
+        let (bytes, content_type) = serialize_internal(data, Some(CONTENT_TYPE_BINCODE))?;
+        Ok(self
+            .authorized_post(url)
+            .header("content-type", content_type)
+            .header("accept", CONTENT_TYPE_BINCODE)
+            .body(bytes))
+    }
+
+    /// Deserialize a response body based on the response's Content-Type header.
+    ///
+    /// Supports both bincode (`application/octet-stream`) and JSON responses
+    /// for backward compatibility with older peers.
+    async fn decode_response<T: for<'de> Deserialize<'de>>(
+        resp: reqwest::Response,
+    ) -> Result<T, String> {
+        let content_type = resp
+            .headers()
+            .get("content-type")
+            .and_then(|v| v.to_str().ok())
+            .map(|s| s.to_string());
+        let bytes = resp.bytes().await.map_err(|e| e.to_string())?;
+        deserialize_internal(&bytes, content_type.as_deref()).map_err(|e| e.to_string())
+    }
+
     /// Push all key-value pairs from the local store to every peer.
     ///
     /// For each peer, sends a `POST /api/internal/sync` request with
@@ -392,7 +425,15 @@ impl SyncClient {
         for peer in &peers {
             let url = format!("http://{}/api/internal/sync", peer.addr);
 
-            match self.authorized_post(&url).json(&request).send().await {
+            let req_builder = match self.bincode_post(&url, &request) {
+                Ok(b) => b,
+                Err(_) => {
+                    // Fallback to JSON if bincode encoding fails.
+                    self.authorized_post(&url).json(&request)
+                }
+            };
+
+            match req_builder.send().await {
                 Ok(resp) => {
                     if resp.status().is_success() {
                         success_count += 1;
@@ -457,13 +498,18 @@ impl SyncClient {
             };
             let url = format!("http://{peer_addr}/api/internal/sync");
 
-            match self.authorized_post(&url).json(&request).send().await {
+            let req_builder = match self.bincode_post(&url, &request) {
+                Ok(b) => b,
+                Err(_) => self.authorized_post(&url).json(&request),
+            };
+
+            match req_builder.send().await {
                 Ok(resp) => {
                     if resp.status().is_success() {
                         // Parse the response body to check for per-key merge
                         // errors. Only count entries that were actually merged.
                         let sync_resp: Option<SyncResponse> =
-                            resp.json::<SyncResponse>().await.ok();
+                            Self::decode_response(resp).await.ok();
                         let error_count = sync_resp.as_ref().map(|r| r.errors.len()).unwrap_or(0);
                         let actually_pushed = chunk.len().saturating_sub(error_count);
                         if error_count > 0 {
@@ -527,10 +573,15 @@ impl SyncClient {
     pub async fn pull_all_keys(&self, peer_addr: &str) -> Option<KeyDumpResponse> {
         let url = format!("http://{}/api/internal/keys", peer_addr);
 
-        match self.authorized_get(&url).send().await {
+        match self
+            .authorized_get(&url)
+            .header("accept", CONTENT_TYPE_BINCODE)
+            .send()
+            .await
+        {
             Ok(resp) => {
                 if resp.status().is_success() {
-                    match resp.json::<KeyDumpResponse>().await {
+                    match Self::decode_response::<KeyDumpResponse>(resp).await {
                         Ok(dump) => Some(dump),
                         Err(e) => {
                             tracing::warn!(
@@ -584,10 +635,15 @@ impl SyncClient {
             frontier: frontier.clone(),
         };
 
-        match self.authorized_post(&url).json(&req).send().await {
+        let req_builder = match self.bincode_post(&url, &req) {
+            Ok(b) => b,
+            Err(_) => self.authorized_post(&url).json(&req),
+        };
+
+        match req_builder.send().await {
             Ok(resp) => {
                 if resp.status().is_success() {
-                    match resp.json::<DeltaSyncResponse>().await {
+                    match Self::decode_response::<DeltaSyncResponse>(resp).await {
                         Ok(delta) => Some(delta),
                         Err(e) => {
                             tracing::warn!(error = %e, "failed to parse delta sync response");


### PR DESCRIPTION
## Summary
- Add bincode serialization for internal sync and frontier exchange endpoints
- Content-Type based format negotiation for gradual migration
- External client APIs remain JSON (backward compatible)
- Expected 2-5x payload size reduction, 2-10x serialization speedup

Closes #266

## Test plan
- [x] cargo fmt --check
- [x] cargo clippy -- -D warnings
- [x] All tests pass
- [x] Bincode round-trip verified
- [x] JSON backward compatibility verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)