### PR TITLE
fix: resolve delta sync convergence under network impairment

### DIFF
--- a/src/network/sync.rs
+++ b/src/network/sync.rs
@@ -486,6 +486,61 @@ impl SyncClient {
         success_count
     }
 
+    /// Push the full local state to a single peer by address.
+    ///
+    /// Sends a `POST /api/internal/sync` request with all provided entries.
+    /// Returns `true` if the push succeeded, `false` on failure.
+    /// Used for initial sync when no peer frontier is known.
+    pub async fn push_full_state_to_peer(
+        &self,
+        peer_addr: &str,
+        entries: HashMap<String, CrdtValue>,
+        sender_id: &str,
+    ) -> bool {
+        if entries.is_empty() {
+            return true;
+        }
+
+        let request = SyncRequest {
+            sender: sender_id.to_string(),
+            entries,
+        };
+
+        let url = format!("http://{peer_addr}/api/internal/sync");
+
+        let req_builder = match self.bincode_post(&url, &request) {
+            Ok(b) => b,
+            Err(_) => self.authorized_post(&url).json(&request),
+        };
+
+        match req_builder.send().await {
+            Ok(resp) => {
+                if resp.status().is_success() {
+                    tracing::debug!(
+                        peer_addr = %peer_addr,
+                        "initial full push to peer succeeded"
+                    );
+                    true
+                } else {
+                    tracing::warn!(
+                        peer_addr = %peer_addr,
+                        status = %resp.status(),
+                        "initial full push to peer received non-success status"
+                    );
+                    false
+                }
+            }
+            Err(e) => {
+                tracing::warn!(
+                    peer_addr = %peer_addr,
+                    error = %e,
+                    "initial full push to peer failed"
+                );
+                false
+            }
+        }
+    }
+
     /// Push only entries changed since the given frontier to a single peer.
     ///
     /// Extracts entries from `all_entries` that have a timestamp strictly

--- a/src/runtime/node_runner.rs
+++ b/src/runtime/node_runner.rs
@@ -1491,6 +1491,41 @@ impl NodeRunner {
                         }
                     }
                 }
+            } else {
+                // No frontier known for this peer — this is the initial sync.
+                // Push the full local state so the peer receives our data even
+                // if it has nothing to offer us in return. Without this push,
+                // data written locally would never reach a peer that starts
+                // empty, because both the delta push and delta pull paths
+                // require a known frontier.
+                let api = eventual_api.lock().await;
+                let all_entries: HashMap<String, crate::store::kv::CrdtValue> = api
+                    .store()
+                    .all_entries()
+                    .map(|(k, v)| (k.clone(), v.clone()))
+                    .collect();
+                let local_frontier = api.store().current_frontier();
+                drop(api);
+
+                if !all_entries.is_empty() {
+                    tracing::info!(
+                        peer = %peer.node_id.0,
+                        keys = all_entries.len(),
+                        "initial sync: pushing full state to peer (no frontier known)"
+                    );
+
+                    let success = sync_client
+                        .push_full_state_to_peer(&peer.addr, all_entries, &self.node_id.0)
+                        .await;
+
+                    if success {
+                        // Set the frontier to the local store's current
+                        // frontier so subsequent cycles use delta mode.
+                        if let Some(f) = local_frontier {
+                            self.peer_frontiers.insert(peer_key.clone(), f);
+                        }
+                    }
+                }
             }
 
             // --- Pull phase: pull delta (or full) from peer ---
@@ -1645,11 +1680,22 @@ impl NodeRunner {
                 if let Some(remote_frontier) = dump.frontier {
                     self.peer_frontiers
                         .insert(peer_key.clone(), remote_frontier);
+                } else {
+                    // Remote reported no frontier (empty store or older peer).
+                    // Set a zero-epoch frontier so that subsequent sync cycles
+                    // enter the delta push/pull paths instead of repeatedly
+                    // falling back to full sync. A zero frontier causes
+                    // `entries_since()` to return all entries, which is correct
+                    // because the peer has seen nothing so far.
+                    self.peer_frontiers.insert(
+                        peer_key.clone(),
+                        crate::hlc::HlcTimestamp {
+                            physical: 0,
+                            logical: 0,
+                            node_id: String::new(),
+                        },
+                    );
                 }
-                // If the remote did not report a frontier (e.g. empty store or
-                // older peer that doesn't support the field), we intentionally
-                // leave peer_frontiers without an entry. This means the next
-                // sync cycle will fall back to full sync again, which is safe.
 
                 any_success = true;
                 let elapsed = peer_start.elapsed();


### PR DESCRIPTION
## Summary
- **Add initial push path for peers with no known frontier**: When `peer_frontiers` has no entry for a peer, the delta push and pull paths were both skipped (guarded by `if let Some(frontier)`). The only remaining code path was a full sync pull, which retrieves data FROM the remote but never pushes local data TO it. Added `SyncClient::push_full_state_to_peer()` and an `else` branch in `run_sync()` that pushes the full local state to peers without a known frontier.
- **Set zero-epoch frontier after empty-store pull**: When a full sync pull succeeded but the remote store was empty (`frontier=None`), the peer frontier was left unset, causing every subsequent cycle to repeat the full sync pull and never enter the push path. Now sets a zero-epoch frontier (`HlcTimestamp{0, 0, ""}`) so subsequent cycles use delta push/pull, which correctly sends all local entries to the peer.

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy -- -D warnings`  
- [x] All unit tests pass (lib, bins, crdt_properties, compound_e2e)
- [x] Pre-existing `or_map_commutativity` failure in `property_crdt` confirmed as pre-existing on main
- [ ] Netem tests pass (verify in CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)