### PR TITLE
fix: wire delta_entries_since into sync push path (#265)

### DIFF
--- a/src/http/handlers.rs
+++ b/src/http/handlers.rs
@@ -806,7 +806,7 @@ pub async fn internal_delta_sync(
     let store = api.store();
 
     let entries: Vec<DeltaEntry> = store
-        .entries_since(&req.frontier)
+        .delta_entries_since(&req.frontier)
         .into_iter()
         .map(|(key, value, hlc)| DeltaEntry { key, value, hlc })
         .collect();

--- a/src/runtime/node_runner.rs
+++ b/src/runtime/node_runner.rs
@@ -1345,14 +1345,14 @@ impl NodeRunner {
             if let Some(frontier) = self.peer_frontiers.get(&peer_key) {
                 let api = eventual_api.lock().await;
                 let total_keys = api.store().len();
-                // entries_since returns entries sorted by HLC; split into
-                // (key, value) pairs for push and a parallel HLC vec for
-                // frontier tracking, avoiding a second clone of every entry.
+                // delta_entries_since returns delta-state entries sorted by
+                // HLC; each value contains only the portion changed since
+                // the frontier, reducing bandwidth compared to full state.
                 let entries_with_hlc: Vec<(
                     String,
                     crate::store::kv::CrdtValue,
                     crate::hlc::HlcTimestamp,
-                )> = api.store().entries_since(frontier);
+                )> = api.store().delta_entries_since(frontier);
                 let changed_count = entries_with_hlc.len();
 
                 // Compute change rate and decide whether to use delta or full sync.


### PR DESCRIPTION
## Summary
- Wire `delta_entries_since()` into the sync push path in `node_runner.rs` instead of `entries_since()`
- Fix `internal_delta_sync` HTTP handler in `handlers.rs` to also use `delta_entries_since()` for pull responses
- Enables actual bandwidth reduction from delta-state CRDTs (PnCounter, OrSet, OrMap)
- Falls back to full state when per-CRDT delta extraction returns `None`

## Test plan
- [x] cargo fmt --check
- [x] cargo clippy -- -D warnings
- [x] All 1,349 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)