### PR TITLE
fix: resolve OrMap commutativity property test failure

### DIFF
--- a/src/crdt/lww_register.rs
+++ b/src/crdt/lww_register.rs
@@ -48,22 +48,6 @@ impl<T: Clone> LwwRegister<T> {
         &self.timestamp
     }
 
-    /// Merge another register into this one, keeping the value with the higher timestamp.
-    pub fn merge(&mut self, other: &LwwRegister<T>) {
-        if other.timestamp > self.timestamp {
-            self.value = other.value.clone();
-            self.timestamp = other.timestamp.clone();
-        }
-    }
-
-    /// Merge a delta into this register.
-    ///
-    /// For LwwRegister, `merge_delta` is identical to `merge` because the
-    /// delta is a complete register snapshot (value + timestamp).
-    pub fn merge_delta(&mut self, delta: &LwwRegister<T>) {
-        self.merge(delta);
-    }
-
     /// Extract changes since the given frontier timestamp.
     ///
     /// If the register's timestamp is strictly greater than `frontier`, the
@@ -75,6 +59,44 @@ impl<T: Clone> LwwRegister<T> {
         } else {
             None
         }
+    }
+}
+
+impl<T: Clone + Ord> LwwRegister<T> {
+    /// Merge another register into this one, keeping the value with the higher timestamp.
+    ///
+    /// When timestamps are equal, the larger value (by `Ord`) wins to
+    /// guarantee commutativity: `merge(a, b)` always produces the same
+    /// result as `merge(b, a)`.
+    pub fn merge(&mut self, other: &LwwRegister<T>) {
+        match other.timestamp.cmp(&self.timestamp) {
+            std::cmp::Ordering::Greater => {
+                self.value = other.value.clone();
+                self.timestamp = other.timestamp.clone();
+            }
+            std::cmp::Ordering::Equal => {
+                // Deterministic tiebreaker: keep the larger value so that
+                // merge(a, b) == merge(b, a) even when timestamps collide.
+                match (&self.value, &other.value) {
+                    (Some(s), Some(o)) if o > s => {
+                        self.value = other.value.clone();
+                    }
+                    (None, Some(_)) => {
+                        self.value = other.value.clone();
+                    }
+                    _ => {}
+                }
+            }
+            std::cmp::Ordering::Less => {}
+        }
+    }
+
+    /// Merge a delta into this register.
+    ///
+    /// For LwwRegister, `merge_delta` is identical to `merge` because the
+    /// delta is a complete register snapshot (value + timestamp).
+    pub fn merge_delta(&mut self, delta: &LwwRegister<T>) {
+        self.merge(delta);
     }
 }
 

--- a/src/crdt/or_map.rs
+++ b/src/crdt/or_map.rs
@@ -25,7 +25,7 @@ struct Dot {
 pub struct OrMap<K, V>
 where
     K: Eq + Hash + Clone,
-    V: Clone,
+    V: Clone + Ord,
 {
     /// Active entries: key -> (dots that justify presence, LWW value).
     entries: HashMap<K, (HashSet<Dot>, LwwRegister<V>)>,
@@ -39,7 +39,7 @@ where
 impl<K, V> OrMap<K, V>
 where
     K: Eq + Hash + Clone + Serialize + DeserializeOwned,
-    V: Clone + Serialize + DeserializeOwned,
+    V: Clone + Ord + Serialize + DeserializeOwned,
 {
     /// Create an empty OR-Map.
     pub fn new() -> Self {
@@ -380,7 +380,7 @@ where
 impl<K, V> Default for OrMap<K, V>
 where
     K: Eq + Hash + Clone + Serialize + DeserializeOwned,
-    V: Clone + Serialize + DeserializeOwned,
+    V: Clone + Ord + Serialize + DeserializeOwned,
 {
     fn default() -> Self {
         Self::new()

--- a/tests/crdt_properties.rs
+++ b/tests/crdt_properties.rs
@@ -551,8 +551,14 @@ proptest! {
             prop_assert_eq!(merged.get(), b.get());
             prop_assert_eq!(merged.timestamp(), ts_b);
         } else {
-            // Equal timestamps: a retains its value (merge only updates on strictly greater).
-            prop_assert_eq!(merged.get(), a.get());
+            // Equal timestamps: the larger value wins (deterministic tiebreaker for commutativity).
+            let expected = match (a.get(), b.get()) {
+                (Some(va), Some(vb)) => Some(va.max(vb)),
+                (None, Some(vb)) => Some(vb),
+                (Some(va), None) => Some(va),
+                (None, None) => None,
+            };
+            prop_assert_eq!(merged.get(), expected);
         }
     }
 


### PR DESCRIPTION
## Summary
- Fix `LwwRegister::merge` non-commutativity when timestamps are equal but values differ
- Add `Ord` bound to `LwwRegister::merge` and propagate to `OrMap<K, V>` (all existing usages already satisfy `V: Ord`)
- When timestamps tie, the larger value (by `Ord`) wins deterministically, guaranteeing `merge(a, b) == merge(b, a)`
- Update `lww_register_timestamp_ordering` property test for new equal-timestamp semantics

## Root cause
`LwwRegister::merge` used strictly-greater comparison (`other.timestamp > self.timestamp`), so when two registers had identical timestamps but different values, the receiver always kept its own value. This meant `merge(a, b)` could produce a different result from `merge(b, a)`, violating the CRDT commutativity invariant.

The `or_map_commutativity` proptest caught this because its strategy can generate two independent OrMaps that share the same dot counter, timestamp, and node but have different LWW register values.

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy -- -D warnings`
- [x] All 22 `crdt_properties` tests pass (including `or_map_commutativity`, `or_map_convergence`)
- [x] All 12 `property_crdt` tests pass
- [x] Full test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)