### PR TITLE
fix: allocation spikes, size estimation, key matching, stable hash (P2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,6 +91,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "siphasher",
  "subtle",
  "tempfile",
  "thiserror",
@@ -1889,6 +1890,12 @@ checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "rand_core 0.6.4",
 ]
+
+[[package]]
+name = "siphasher"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
 name = "slab"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ subtle = "2"
 hex = "0.4"
 redb = "2"
 bincode = { version = "2", features = ["serde"] }
+siphasher = "1"
 
 [dev-dependencies]
 tempfile = "3"

--- a/src/runtime/node_runner.rs
+++ b/src/runtime/node_runner.rs
@@ -1463,12 +1463,20 @@ impl NodeRunner {
                                 .fetch_add(1, Ordering::Relaxed);
 
                             let api = eventual_api.lock().await;
-                            let all_entries: HashMap<String, crate::store::kv::CrdtValue> = api
+                            let snapshot: Vec<(String, crate::store::kv::CrdtValue)> = api
                                 .store()
                                 .all_entries()
                                 .map(|(k, v)| (k.clone(), v.clone()))
                                 .collect();
                             drop(api);
+
+                            let all_entries = tokio::task::spawn_blocking(move || {
+                                snapshot
+                                    .into_iter()
+                                    .collect::<HashMap<String, crate::store::kv::CrdtValue>>()
+                            })
+                            .await
+                            .expect("spawn_blocking panicked");
 
                             let push_ok = sync_client
                                 .push_full_state_to_peer(&peer.addr, all_entries, &self.node_id.0)
@@ -1562,12 +1570,20 @@ impl NodeRunner {
                 // empty, because both the delta push and delta pull paths
                 // require a known frontier.
                 let api = eventual_api.lock().await;
-                let all_entries: HashMap<String, crate::store::kv::CrdtValue> = api
+                let snapshot: Vec<(String, crate::store::kv::CrdtValue)> = api
                     .store()
                     .all_entries()
                     .map(|(k, v)| (k.clone(), v.clone()))
                     .collect();
                 drop(api);
+
+                let all_entries = tokio::task::spawn_blocking(move || {
+                    snapshot
+                        .into_iter()
+                        .collect::<HashMap<String, crate::store::kv::CrdtValue>>()
+                })
+                .await
+                .expect("spawn_blocking panicked");
 
                 if !all_entries.is_empty() {
                     tracing::info!(
@@ -1902,10 +1918,10 @@ impl NodeRunner {
     async fn check_compaction(&mut self) {
         let now = self.clock.now();
 
-        // Drain write ops recorded by HTTP handlers and feed them into the
-        // compaction engine so that the ops-based checkpoint threshold works
-        // in production.
-        let pending_ops = self.metrics.write_ops_total.swap(0, Ordering::Relaxed);
+        // Drain per-key write ops recorded by HTTP handlers and aggregate
+        // by key range prefix so that hot ranges trigger compaction
+        // independently of idle ones.
+        let ops_by_key = self.metrics.drain_write_ops_by_key();
 
         // Phase 1: Acquire certified_api lock, read all needed data, then drop
         // the lock before any subsequent .await points.
@@ -1937,13 +1953,26 @@ impl NodeRunner {
             (defs, fs, policy_versions)
         };
 
-        // Phase 2: Distribute drained write ops and create checkpoints using
-        // only the cloned data — no locks held.
-        if pending_ops > 0 && !defs.is_empty() {
-            let ops_per_range = pending_ops / defs.len() as u64;
-            let remainder = pending_ops % defs.len() as u64;
-            for (i, (key_range, _)) in defs.iter().enumerate() {
-                let ops = ops_per_range + if (i as u64) < remainder { 1 } else { 0 };
+        // Phase 2: Aggregate per-key write ops into per-range counts by
+        // matching each written key against key range prefixes. Keys that
+        // don't match any range are counted under the first range as a
+        // fallback (maintains the previous behaviour of counting all ops).
+        if !ops_by_key.is_empty() && !defs.is_empty() {
+            let mut range_ops: HashMap<&str, u64> = HashMap::new();
+            for (key, count) in &ops_by_key {
+                let matched = defs
+                    .iter()
+                    .find(|(kr, _)| key.starts_with(&kr.prefix))
+                    .map(|(kr, _)| kr.prefix.as_str());
+                let prefix = matched.unwrap_or(&defs[0].0.prefix);
+                *range_ops.entry(prefix).or_insert(0) += count;
+            }
+
+            for (key_range, _) in &defs {
+                let ops = range_ops
+                    .get(key_range.prefix.as_str())
+                    .copied()
+                    .unwrap_or(0);
                 for _ in 0..ops {
                     self.compaction_engine.record_op(key_range);
                 }


### PR DESCRIPTION
## Summary
- P2-5: Spawn blocking for full state clone to avoid Tokio runtime starvation
- P2-6: Use heuristic size estimation instead of per-entry bincode serialization
- P2-7: Use key-based HashMap matching for certification status comparison
- P2-8: Use deterministic hasher for cluster fingerprint stability

## Test plan
- [x] cargo fmt --check
- [x] cargo clippy -- -D warnings
- [x] All tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)