### PR TITLE
fix: log fallback errors, latency lookups, per-range write ops (P2)

### DIFF
--- a/src/http/handlers.rs
+++ b/src/http/handlers.rs
@@ -95,6 +95,8 @@ pub async fn eventual_write(
     State(state): State<Arc<AppState>>,
     Json(req): Json<EventualWriteRequest>,
 ) -> Result<Json<WriteResponse>, ApiError> {
+    let written_key = req.key().to_string();
+
     let mut api = state.eventual.lock().await;
 
     match req {
@@ -125,10 +127,7 @@ pub async fn eventual_write(
         }
     }
 
-    state
-        .metrics
-        .write_ops_total
-        .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    state.metrics.record_write_op(&written_key);
 
     Ok(Json(WriteResponse { ok: true }))
 }
@@ -176,14 +175,12 @@ pub async fn certified_write(
     };
 
     let crdt_value = json_to_crdt_value(&req.value)?;
+    let written_key = req.key.clone();
 
     let mut api = state.certified.lock().await;
     let status = api.certified_write(req.key, crdt_value, on_timeout)?;
 
-    state
-        .metrics
-        .write_ops_total
-        .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    state.metrics.record_write_op(&written_key);
 
     Ok(Json(CertifiedWriteResponse { status }))
 }

--- a/src/http/types.rs
+++ b/src/http/types.rs
@@ -76,6 +76,21 @@ pub enum EventualWriteRequest {
     RegisterSet { key: String, value: String },
 }
 
+impl EventualWriteRequest {
+    /// Return the key being written, regardless of operation type.
+    pub fn key(&self) -> &str {
+        match self {
+            Self::CounterInc { key }
+            | Self::CounterDec { key }
+            | Self::SetAdd { key, .. }
+            | Self::SetRemove { key, .. }
+            | Self::MapSet { key, .. }
+            | Self::MapDelete { key, .. }
+            | Self::RegisterSet { key, .. } => key,
+        }
+    }
+}
+
 /// Request body for `POST /api/certified/write`.
 #[derive(Debug, Deserialize)]
 pub struct CertifiedWriteRequest {

--- a/src/network/frontier_sync.rs
+++ b/src/network/frontier_sync.rs
@@ -121,9 +121,13 @@ impl FrontierSyncClient {
 
         match req_builder.send().await {
             Ok(resp) if !resp.status().is_success() => {
-                tracing::debug!(
+                let status = resp.status();
+                let body = resp.text().await.unwrap_or_else(|_| "<unreadable>".into());
+                let truncated: String = body.chars().take(500).collect();
+                tracing::warn!(
                     url = %url,
-                    status = %resp.status(),
+                    status = %status,
+                    body = %truncated,
                     "bincode request rejected, retrying with JSON"
                 );
                 self.json_post(url, data).send().await

--- a/src/network/sync.rs
+++ b/src/network/sync.rs
@@ -431,9 +431,13 @@ impl SyncClient {
 
         match req_builder.send().await {
             Ok(resp) if !resp.status().is_success() => {
-                tracing::debug!(
+                let status = resp.status();
+                let body = resp.text().await.unwrap_or_else(|_| "<unreadable>".into());
+                let truncated: String = body.chars().take(500).collect();
+                tracing::warn!(
                     url = %url,
-                    status = %resp.status(),
+                    status = %status,
+                    body = %truncated,
                     "bincode request rejected, retrying with JSON"
                 );
                 self.json_post(url, data).send().await

--- a/src/ops/metrics.rs
+++ b/src/ops/metrics.rs
@@ -310,6 +310,13 @@ pub struct RuntimeMetrics {
     /// during periodic checkpoint checks.
     pub write_ops_total: AtomicU64,
 
+    /// Per-key write operation counts for accurate per-range compaction tracking.
+    ///
+    /// Maps written keys to their cumulative op count since last drain.
+    /// The compaction engine drains this map and aggregates counts by key range
+    /// prefix so that hot ranges trigger compaction independently of idle ones.
+    write_ops_by_key: Mutex<HashMap<String, u64>>,
+
     /// Per-peer sync statistics (peer_id -> stats).
     peer_sync_stats: Mutex<HashMap<String, PeerSyncStats>>,
 
@@ -342,6 +349,7 @@ impl Default for RuntimeMetrics {
             key_rotation_last_version: AtomicU64::default(),
             key_rotation_last_time_ms: AtomicU64::default(),
             write_ops_total: AtomicU64::default(),
+            write_ops_by_key: Mutex::new(HashMap::new()),
             peer_sync_stats: Mutex::new(HashMap::new()),
             certification_latency_window: Mutex::new(CertificationLatencyWindow::default()),
             window_duration: Duration::from_secs(WINDOW_SECS),
@@ -355,6 +363,30 @@ impl RuntimeMetrics {
         Self {
             window_duration: window,
             ..Default::default()
+        }
+    }
+
+    /// Record a write operation for a specific key.
+    ///
+    /// The key is stored so that `drain_write_ops_by_key` can aggregate
+    /// counts by key-range prefix for accurate per-range compaction.
+    pub fn record_write_op(&self, key: &str) {
+        self.write_ops_total.fetch_add(1, Ordering::Relaxed);
+        if let Ok(mut map) = self.write_ops_by_key.lock() {
+            *map.entry(key.to_string()).or_insert(0) += 1;
+        }
+    }
+
+    /// Drain the per-key write ops map and return the accumulated counts.
+    ///
+    /// Also resets `write_ops_total` to 0.  The caller (compaction engine)
+    /// should aggregate these by key-range prefix.
+    pub fn drain_write_ops_by_key(&self) -> HashMap<String, u64> {
+        self.write_ops_total.swap(0, Ordering::Relaxed);
+        if let Ok(mut map) = self.write_ops_by_key.lock() {
+            std::mem::take(&mut *map)
+        } else {
+            HashMap::new()
         }
     }
 

--- a/src/placement/latency.rs
+++ b/src/placement/latency.rs
@@ -122,9 +122,17 @@ impl LatencyModel {
     }
 
     /// Get the current latency statistics for a node pair.
+    ///
+    /// NOTE: This clones both `NodeId` values to construct the lookup key.
+    /// `NodeId` contains a `String`, so this performs two heap allocations per
+    /// call.  In practice the strings are short node identifiers and this
+    /// method is called infrequently (once per placement decision), so the
+    /// cost is negligible.  Avoiding the clone would require `HashMap`
+    /// `raw_entry` (nightly) or a custom key type with `Borrow` impl.
     pub fn get_latency(&self, from: &NodeId, to: &NodeId) -> Option<LatencyStats> {
-        let key = (from.clone(), to.clone());
-        self.samples.get(&key).map(|s| s.stats())
+        self.samples
+            .get(&(from.clone(), to.clone()))
+            .map(|s| s.stats())
     }
 
     /// Return all nodes reachable from `from` within the given latency bound.

--- a/src/runtime/node_runner.rs
+++ b/src/runtime/node_runner.rs
@@ -1902,10 +1902,10 @@ impl NodeRunner {
     async fn check_compaction(&mut self) {
         let now = self.clock.now();
 
-        // Drain write ops recorded by HTTP handlers and feed them into the
-        // compaction engine so that the ops-based checkpoint threshold works
-        // in production.
-        let pending_ops = self.metrics.write_ops_total.swap(0, Ordering::Relaxed);
+        // Drain per-key write ops recorded by HTTP handlers and aggregate
+        // by key range prefix so that hot ranges trigger compaction
+        // independently of idle ones.
+        let ops_by_key = self.metrics.drain_write_ops_by_key();
 
         // Phase 1: Acquire certified_api lock, read all needed data, then drop
         // the lock before any subsequent .await points.
@@ -1937,13 +1937,26 @@ impl NodeRunner {
             (defs, fs, policy_versions)
         };
 
-        // Phase 2: Distribute drained write ops and create checkpoints using
-        // only the cloned data — no locks held.
-        if pending_ops > 0 && !defs.is_empty() {
-            let ops_per_range = pending_ops / defs.len() as u64;
-            let remainder = pending_ops % defs.len() as u64;
-            for (i, (key_range, _)) in defs.iter().enumerate() {
-                let ops = ops_per_range + if (i as u64) < remainder { 1 } else { 0 };
+        // Phase 2: Aggregate per-key write ops into per-range counts by
+        // matching each written key against key range prefixes. Keys that
+        // don't match any range are counted under the first range as a
+        // fallback (maintains the previous behaviour of counting all ops).
+        if !ops_by_key.is_empty() && !defs.is_empty() {
+            let mut range_ops: HashMap<&str, u64> = HashMap::new();
+            for (key, count) in &ops_by_key {
+                let matched = defs
+                    .iter()
+                    .find(|(kr, _)| key.starts_with(&kr.prefix))
+                    .map(|(kr, _)| kr.prefix.as_str());
+                let prefix = matched.unwrap_or(&defs[0].0.prefix);
+                *range_ops.entry(prefix).or_insert(0) += count;
+            }
+
+            for (key_range, _) in &defs {
+                let ops = range_ops
+                    .get(key_range.prefix.as_str())
+                    .copied()
+                    .unwrap_or(0);
                 for _ in 0..ops {
                     self.compaction_engine.record_op(key_range);
                 }


### PR DESCRIPTION
## Summary
- P2-9: Log error response body in `send_with_json_fallback` before JSON retry
- P2-10: Reduce/document NodeId cloning in LatencyModel lookups
- P2-11: Track write ops per key range for accurate compaction triggering

## Test plan
- [x] cargo fmt --check
- [x] cargo clippy -- -D warnings
- [x] All tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)