### PR TITLE
fix: resolve fault injection jitter-latency and rolling-partition convergence

### DIFF
--- a/scripts/fault-inject/scenario-jitter-latency.sh
+++ b/scripts/fault-inject/scenario-jitter-latency.sh
@@ -20,7 +20,7 @@ NODE3_URL="http://localhost:3003"
 NODE2_CONTAINER="asteroidb-node-2"
 KEY="fault-jitter-$$"
 
-CONVERGENCE_RETRIES=15
+CONVERGENCE_RETRIES=20
 CONVERGENCE_INTERVAL=2
 
 # Trap: remove netem on exit.

--- a/scripts/fault-inject/scenario-rolling-partition.sh
+++ b/scripts/fault-inject/scenario-rolling-partition.sh
@@ -22,7 +22,7 @@ NODE2_CONTAINER="asteroidb-node-2"
 NODE3_CONTAINER="asteroidb-node-3"
 KEY="fault-rolling-$$"
 
-CONVERGENCE_RETRIES=15
+CONVERGENCE_RETRIES=20
 CONVERGENCE_INTERVAL=2
 
 # Trap: remove all netem rules on exit.

--- a/src/network/sync.rs
+++ b/src/network/sync.rs
@@ -132,9 +132,14 @@ pub struct PeerBackoff {
 
 impl PeerBackoff {
     /// Initial backoff delay after the first failure.
-    pub const INITIAL_BACKOFF: Duration = Duration::from_secs(1);
+    pub const INITIAL_BACKOFF: Duration = Duration::from_millis(500);
     /// Maximum backoff delay.
-    pub const MAX_BACKOFF: Duration = Duration::from_secs(30);
+    ///
+    /// Capped at 8 seconds to ensure timely convergence under network
+    /// fault conditions (jitter, rolling partitions). A 2-second sync
+    /// interval combined with a 30-second max backoff previously caused
+    /// peers to miss too many sync cycles after transient failures.
+    pub const MAX_BACKOFF: Duration = Duration::from_secs(8);
 
     /// Create a new backoff state that is immediately ready.
     pub fn new() -> Self {
@@ -158,11 +163,12 @@ impl PeerBackoff {
     /// Record a failed sync, increasing the backoff delay.
     ///
     /// Uses exponential backoff: `min(INITIAL_BACKOFF * 2^failures, MAX_BACKOFF)`
-    /// with a random jitter of up to 25% of the computed delay.
+    /// with a random jitter of up to 25% of the computed delay. The exponent
+    /// is capped at 4 (i.e. max multiplier 16x) to keep backoff growth bounded.
     pub fn record_failure(&mut self) {
         self.consecutive_failures = self.consecutive_failures.saturating_add(1);
         let base = Self::INITIAL_BACKOFF
-            .saturating_mul(1u32 << self.consecutive_failures.saturating_sub(1).min(5));
+            .saturating_mul(1u32 << self.consecutive_failures.saturating_sub(1).min(4));
         let capped = base.min(Self::MAX_BACKOFF);
 
         // Add jitter: up to 25% of the capped delay.
@@ -194,7 +200,7 @@ impl PeerBackoff {
             return Duration::ZERO;
         }
         let base = Self::INITIAL_BACKOFF
-            .saturating_mul(1u32 << self.consecutive_failures.saturating_sub(1).min(5));
+            .saturating_mul(1u32 << self.consecutive_failures.saturating_sub(1).min(4));
         base.min(Self::MAX_BACKOFF)
     }
 }
@@ -337,7 +343,8 @@ impl SyncClient {
     /// Create a new `SyncClient` with a shared peer registry.
     pub fn new(peer_registry: Arc<Mutex<PeerRegistry>>) -> Self {
         let http_client = reqwest::Client::builder()
-            .timeout(Duration::from_secs(5))
+            .timeout(Duration::from_secs(10))
+            .connect_timeout(Duration::from_secs(5))
             .build()
             .expect("failed to build HTTP client");
         Self {
@@ -350,7 +357,8 @@ impl SyncClient {
     /// Create a `SyncClient` that attaches a Bearer token to all requests.
     pub fn with_token(peer_registry: Arc<Mutex<PeerRegistry>>, token: String) -> Self {
         let http_client = reqwest::Client::builder()
-            .timeout(Duration::from_secs(5))
+            .timeout(Duration::from_secs(10))
+            .connect_timeout(Duration::from_secs(5))
             .build()
             .expect("failed to build HTTP client");
         Self {


### PR DESCRIPTION
## Summary
- Reduce peer backoff aggressiveness (500ms initial / 8s max, down from 1s / 30s) to prevent sync starvation under transient network faults
- Increase HTTP client timeout from 5s to 10s with separate 5s connect timeout to handle jitter without premature timeouts
- Cap backoff exponent at 4 (16x max multiplier) instead of 5 (32x) for bounded growth
- Increase fault injection test convergence retries from 15 to 20 for adequate headroom

## Root cause
The exponential backoff (1s initial, 30s max, 2^5 cap) grew too aggressively relative to the 2-second sync interval. Under jitter conditions, 2-3 consecutive sync failures would push backoff to 4-8s, causing the node to skip multiple sync cycles. Under rolling partitions, each partition phase accumulated backoff across multiple peers, and after healing the convergence window was insufficient.

## Test plan
- [x] cargo fmt --check
- [x] cargo clippy -- -D warnings
- [x] All 1007 unit tests pass
- [ ] Fault injection tests pass (verify in CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)